### PR TITLE
Add Mac support for ScalaZ3 to build.sbt

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,11 @@
-val osName = if (Option(System.getProperty("os.name")).getOrElse("").toLowerCase contains "win") "win" else "unix"
+
+val osInf = Option(System.getProperty("os.name")).getOrElse("")
+
+val isUnix    = osInf.indexOf("nix") >= 0 || osInf.indexOf("nux") >= 0
+val isWindows = osInf.indexOf("Win") >= 0
+val isMac     = osInf.indexOf("Mac") >= 0
+
+val osName = if (isWindows) "win" else if (isMac) "mac" else "unix"
 val osArch = System.getProperty("sun.arch.data.model")
 
 val inoxVersion = "1.0.2-2-gb5fdc3d"


### PR DESCRIPTION
So that on Mac, `unmanaged/scalaz3-mac-$arch-$scalaBinaryVersion.jar` will be added to classpath found in the generated scripts.