### PR TITLE
Fix annotation import in stainless library

### DIFF
--- a/.larabot.conf
+++ b/.larabot.conf
@@ -14,6 +14,7 @@ trusted = [
     "romac"
     "samarion"
     "vkuncak"
+    "gsps"
 ]
 
 notify {

--- a/frontends/library/stainless/io/package.scala
+++ b/frontends/library/stainless/io/package.scala
@@ -2,9 +2,9 @@
 
 package stainless
 
-package object io {
+import stainless.annotation._
 
-  import stainless.annotation._
+package object io {
 
   @library
   case class State(var seed: BigInt)

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -69,17 +69,17 @@ package object lang {
       forall((a: A, b: B, c: C, d: D) => f.pre(a,b,c,d) ==> p(a,b,c,d,f(a,b,c,d)))
   }
 
-  @ignore def decreases(rank: BigInt): Unit = ()
-  @ignore def decreases(rank: (BigInt, BigInt)): Unit = ()
-  @ignore def decreases(rank: (BigInt, BigInt, BigInt)): Unit = ()
-  @ignore def decreases(rank: (BigInt, BigInt, BigInt, BigInt)): Unit = ()
-  @ignore def decreases(rank: (BigInt, BigInt, BigInt, BigInt, BigInt)): Unit = ()
+  @ignore def decreases(r1: BigInt): Unit = ()
+  @ignore def decreases(r1: BigInt, r2: BigInt): Unit = ()
+  @ignore def decreases(r1: BigInt, r2: BigInt, r3: BigInt): Unit = ()
+  @ignore def decreases(r1: BigInt, r2: BigInt, r3: BigInt, r4: BigInt): Unit = ()
+  @ignore def decreases(r1: BigInt, r2: BigInt, r3: BigInt, r4: BigInt, r5: BigInt): Unit = ()
 
-  @ignore def decreases(rank: Int): Unit = ()
-  @ignore def decreases(rank: (Int, Int)): Unit = ()
-  @ignore def decreases(rank: (Int, Int, Int)): Unit = ()
-  @ignore def decreases(rank: (Int, Int, Int, Int)): Unit = ()
-  @ignore def decreases(rank: (Int, Int, Int, Int, Int)): Unit = ()
+  @ignore def decreases(r1: Int): Unit = ()
+  @ignore def decreases(r1: Int, r2: Int): Unit = ()
+  @ignore def decreases(r1: Int, r2: Int, r3: Int): Unit = ()
+  @ignore def decreases(r1: Int, r2: Int, r3: Int, r4: Int): Unit = ()
+  @ignore def decreases(r1: Int, r2: Int, r3: Int, r4: Int, r5: Int): Unit = ()
 
   @ignore
   implicit class WhileDecorations(u: Unit) {

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -269,9 +269,9 @@ trait ASTExtractors {
 
     /** Extracts the 'decreases' contract for an expression (should be right after 'require') */
     object ExDecreasesExpression {
-      def unapply(tree: Apply): Option[Tree] = tree match {
-        case Apply(ExSelected("stainless", "lang", "package", "decreases"), Seq(arg)) =>
-          Some(arg)
+      def unapply(tree: Apply): Option[Seq[Tree]] = tree match {
+        case Apply(ExSelected("stainless", "lang", "package", "decreases"), args) =>
+          Some(args)
         case _ => None
       }
     }

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -679,10 +679,10 @@ trait CodeExtraction extends ASTExtractors {
           val b   = rec(xs)
           xt.Require(pre, b).setPos(e.pos)
 
-        case (e @ ExDecreasesExpression(rank)) :: xs =>
-          val r = extractTree(rank)(vctx)
+        case (e @ ExDecreasesExpression(ranks)) :: xs =>
+          val rs = ranks.map(extractTree(_)(vctx))
           val b = rec(xs)
-          xt.Decreases(r, b).setPos(e.pos)
+          xt.Decreases(xt.tupleWrap(rs), b).setPos(e.pos)
 
         case (d @ ExFunctionDef(sym, tparams, vparams, tpt, rhs)) :: xs =>
           val (vd, tdefs) = vctx.localFuns(sym)


### PR DESCRIPTION
This moves the import of annotations in the stainless.io package object to the top-level. In this specific case, Dotty prohibits imports and usage of annotations from within the same scope.