### PR TITLE
Fixes to compile (but not extract) the stainless standard library using stainless-dotty

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -2,6 +2,7 @@ val osName = if (Option(System.getProperty("os.name")).getOrElse("").toLowerCase
 val osArch = System.getProperty("sun.arch.data.model")
 
 val inoxVersion = "1.0.2-2-gb5fdc3d"
+val dottyVersion = "0.1.1-20170312-b319440-NIGHTLY"
 
 lazy val nParallel = {
   val p = System.getProperty("parallel")
@@ -155,7 +156,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 //lazy val inox = RootProject(file("../inox"))
-lazy val dotty = ghProject("git://github.com/lampepfl/dotty.git", "fb1dbba5e35d1fc7c00250f597b8c796d8c96eda")
+//lazy val dotty = ghProject("git://github.com/lampepfl/dotty.git", "b3194406d8e1a28690faee12257b53f9dcf49506")
 lazy val cafebabe = ghProject("git://github.com/psuter/cafebabe.git", "49dce3c83450f5fa0b5e6151a537cc4b9f6a79a6")
 
 
@@ -177,7 +178,8 @@ lazy val `stainless-scalac` = (project in file("frontends/scalac"))
 
 lazy val `stainless-dotty-frontend` = (project in file("frontends/dotty"))
   .settings(name := "stainless-dotty-frontend")
-  .dependsOn(`stainless-core`, dotty % "provided")
+  .dependsOn(`stainless-core`)
+  .settings(libraryDependencies += "ch.epfl.lamp" % "dotty_2.11" % dottyVersion % "provided")
   .settings(commonSettings)
 
 lazy val `stainless-dotty` = (project in file("frontends/stainless-dotty"))
@@ -189,7 +191,9 @@ lazy val `stainless-dotty` = (project in file("frontends/stainless-dotty"))
       *   sbt project. You can temporarily disable the following two lines when importing the project.
       */
     unmanagedResourceDirectories in IntegrationTest += file(".") / "frontends" / "scalac" / "it" / "resources")
-  .dependsOn(`stainless-dotty-frontend`, dotty)  // Should truly depend on dotty, overriding the "provided" modifier above
+  .dependsOn(`stainless-dotty-frontend`)
+  // Should truly depend on dotty, overriding the "provided" modifier above:
+  .settings(libraryDependencies += "ch.epfl.lamp" % "dotty_2.11" % dottyVersion)
   .aggregate(`stainless-dotty-frontend`)
   .configs(IntegrationTest)
   .settings(commonSettings, commonFrontendSettings, artifactSettings, scriptSettings)

--- a/build.sbt
+++ b/build.sbt
@@ -21,10 +21,12 @@ lazy val frontendClass = settingKey[String]("The name of the compiler wrapper us
 
 lazy val script = taskKey[Unit]("Generate the stainless Bash script")
 
+lazy val scalaVersionSetting: Setting[_] = scalaVersion := "2.11.8"
+
 lazy val artifactSettings: Seq[Setting[_]] = Seq(
   version := "0.1",
   organization := "ch.epfl.lara",
-  scalaVersion := "2.11.8"
+  scalaVersionSetting
 )
 
 lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
@@ -199,6 +201,6 @@ lazy val `stainless-dotty` = (project in file("frontends/stainless-dotty"))
   .settings(commonSettings, commonFrontendSettings, artifactSettings, scriptSettings)
 
 lazy val root = (project in file("."))
-  .settings(sourcesInBase in Compile := false)
+  .settings(scalaVersionSetting, sourcesInBase in Compile := false)
   .dependsOn(`stainless-scalac`, `stainless-dotty`)
   .aggregate(`stainless-core`, `stainless-scalac`, `stainless-dotty`)

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -48,7 +48,7 @@ class CodeExtraction(inoxCtx: inox.Context, symbols: SymbolsContext)(implicit va
     val actualSymbol = sym // .accessedOrSelf
     (for {
       a <- actualSymbol.annotations ++ actualSymbol.owner.annotations
-      name = a.symbol.fullName.toString.replaceAll("\\.package$\\.", ".")
+      name = a.symbol.fullName.toString.replaceAll("\\.package\\$\\.", ".")
       if name startsWith "stainless.annotation."
       shortName = name drop "stainless.annotation.".length
     } yield {
@@ -456,7 +456,7 @@ class CodeExtraction(inoxCtx: inox.Context, symbols: SymbolsContext)(implicit va
 
     val nctx = dctx.copy(tparams = dctx.tparams ++ tparams.toMap)
 
-    val (newParams, fctx) = vdefs.foldLeft((Seq.empty[xt.ValDef], nctx)) { case ((params, dctx), param) =>
+    val (newParams, fctx0) = vdefs.foldLeft((Seq.empty[xt.ValDef], nctx)) { case ((params, dctx), param) =>
       val vd = xt.ValDef(
         FreshIdentifier(param.symbol.name.toString).setPos(param.pos),
         stainlessType(param.tpe)(dctx, param.pos),
@@ -483,6 +483,8 @@ class CodeExtraction(inoxCtx: inox.Context, symbols: SymbolsContext)(implicit va
         case Block(List(Assign(_, realBody)), _) => realBody
         case _ => outOfSubsetError(rhs, "Wrong form of lazy accessor")
       }
+
+    val fctx = fctx0.copy(isExtern = fctx0.isExtern || (flags contains xt.Extern))
 
     val finalBody = if (rhs == tpd.EmptyTree) {
       flags += xt.IsAbstract

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1220,7 +1220,7 @@ class CodeExtraction(inoxCtx: inox.Context, symbols: SymbolsContext)(implicit va
       xt.ArrayType(extractType(btt))
     */
 
-    case defn.FunctionOf(from, to) =>
+    case defn.FunctionOf(from, to, _) =>
       xt.FunctionType(from map extractType, extractType(to))
 
     case tt @ ThisType(tr) =>
@@ -1253,7 +1253,7 @@ class CodeExtraction(inoxCtx: inox.Context, symbols: SymbolsContext)(implicit va
 
     case AndType(tp, prod) if prod.typeSymbol == defn.ProductClass => extractType(tp)
     case AndType(prod, tp) if prod.typeSymbol == defn.ProductClass => extractType(tp)
-    case ot: OrType => extractType(ot.approximateUnion)
+    case ot: OrType => extractType(ot.join)
 
     case pp @ PolyParam(binder, num) =>
       dctx.tparams.collectFirst { case (k, v) if k.name == pp.paramName => v }.getOrElse {

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/DottyCompiler.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/DottyCompiler.scala
@@ -33,7 +33,11 @@ object DottyCompiler {
     val driver = new Driver {
       def newCompiler(implicit ctx: Context) = compiler
     }
-    driver.process(compilerOpts.toArray)
+
+    // FIXME (gsps): Adapt sbt run task and stainless script to provide proper scala-library and dotty-library
+    //  classpaths via process args and add them here instead of -usejavacp (which imports unnecessary classpaths).
+    val compilerOpts1 = if (compilerOpts.contains("-usejavacp")) compilerOpts else "-usejavacp" +: compilerOpts
+    driver.process(compilerOpts1.toArray)
 
     timer.stop()
 


### PR DESCRIPTION
This commit introduces Dotty as a proper maven dependency, rather than a source dependency, and bumps the version to one that has some concrete issues with the stainless standard library fixed. We also introduce a workaround to provide Dotty with a classpath that includes dotty-library and scala-library, which it requires to run.