### PR TITLE
export reports to JSON

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -69,7 +69,8 @@ lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
   libraryDependencies ++= Seq(
     "ch.epfl.lara" %% "inox" % inoxVersion,
     "ch.epfl.lara" %% "inox" % inoxVersion % "test" classifier "tests",
-    "org.scalatest" %% "scalatest" % "3.0.1" % "test"
+    "org.scalatest" %% "scalatest" % "3.0.1" % "test",
+    "org.json4s" %% "json4s-native" % "3.5.2"
   ),
 
   concurrentRestrictions in Global += Tags.limit(Tags.Test, nParallel),

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -2,6 +2,7 @@
 
 package stainless
 
+import org.json4s.JsonAST.JValue
 import extraction.xlang.{trees => xt}
 
 trait Component {
@@ -17,7 +18,7 @@ trait Component {
 
   trait AbstractReport {
     def emit(): Unit
-    def emitJson(): Unit
+    def emitJson(): JValue
   }
 
   def apply(units: List[xt.UnitDef], program: Program { val trees: xt.type }): Report

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -17,6 +17,7 @@ trait Component {
 
   trait AbstractReport {
     def emit(): Unit
+    def emitJson(): Unit
   }
 
   def apply(units: List[xt.UnitDef], program: Program { val trees: xt.type }): Report

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -93,6 +93,10 @@ object TerminationComponent extends SimpleComponent {
 
       ctx.reporter.info(t.render)
     }
+
+    def emitJson(): Unit = {
+      ???
+    }
   }
 
   def apply(funs: Seq[Identifier], p: Program { val trees: termination.trees.type }): TerminationReport = {

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -4,6 +4,7 @@ package stainless
 package termination
 
 import inox.utils.ASCIIHelpers._
+import org.json4s.JsonAST.JValue
 
 object TerminationComponent extends SimpleComponent {
   val name = "termination"
@@ -94,7 +95,7 @@ object TerminationComponent extends SimpleComponent {
       ctx.reporter.info(t.render)
     }
 
-    def emitJson(): Unit = {
+    def emitJson(): JValue = {
       ???
     }
   }

--- a/core/src/main/scala/stainless/utils/JsonConvertions.scala
+++ b/core/src/main/scala/stainless/utils/JsonConvertions.scala
@@ -1,0 +1,36 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+package stainless
+package utils
+
+import inox.utils.{ NoPosition, OffsetPosition, Position, RangePosition }
+
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST.{ JObject, JValue }
+
+/**
+ * Provide basic tools to convert some stainless/inox data into
+ * JSON format.
+ */
+object JsonConvertions {
+
+  private def pos2JsonImpl(pos: OffsetPosition): JObject =
+    ("line" -> pos.line) ~ ("col" -> pos.col)
+
+  implicit class Position2Json(pos: Position) {
+    def toJson: JValue = pos match {
+      case NoPosition =>
+        "Unknown"
+
+      case pos @ OffsetPosition(_, _, _, file) =>
+        pos2JsonImpl(pos) ~ ("file" -> file.getPath)
+
+      case range: RangePosition =>
+        ("begin" -> pos2JsonImpl(range.focusBegin)) ~
+        ("end" -> pos2JsonImpl(range.focusEnd)) ~
+        ("file" -> range.file.getPath)
+    }
+  }
+
+}
+

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -8,7 +8,6 @@ import inox.utils.{NoPosition, OffsetPosition, Position, RangePosition}
 import stainless.verification.VCStatus.Invalid
 
 import org.json4s.JsonDSL._
-import org.json4s.native.JsonMethods._
 import org.json4s.JsonAST.{JObject, JValue}
 
 object VerificationComponent extends SimpleComponent {
@@ -68,7 +67,7 @@ object VerificationComponent extends SimpleComponent {
       }
     }
 
-    def emitJson(): Unit = {
+    def emitJson(): JValue = {
       def pos2Json(pos: Position): JValue = pos match {
         case NoPosition => "Unknown"
         case OffsetPosition(line, col, _, file) => ("line" -> line) ~ ("col" -> col) ~ ("file" -> file.getPath)
@@ -91,8 +90,7 @@ object VerificationComponent extends SimpleComponent {
         if (totalConditions > 0) vrs map { case (vc, vr) => vc2Json(vc, vr) }
         else "No VC"
 
-      val str = pretty(render(report))
-      println(str)
+      report
     }
   }
 

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -76,13 +76,12 @@ object VerificationComponent extends SimpleComponent {
         case status => ("status" -> status.name)
       }
 
-      def vc2Json(vc: VC[program.trees.type], vr: VCResult[program.Model]): JObject = {
-        ("fd" -> vc.fd.name) ~ ("pos" -> vc.getPos.toJson) ~ ("kind" -> vc.kind.name) ~ status2Json(vr.status)
+      val report: JArray = for { (vc, vr) <- vrs } yield {
+        ("fd" -> vc.fd.name) ~
+        ("pos" -> vc.getPos.toJson) ~
+        ("kind" -> vc.kind.name) ~
+        status2Json(vr.status)
       }
-
-      val report: JValue =
-        if (totalConditions > 0) vrs map { case (vc, vr) => vc2Json(vc, vr) }
-        else "No VC"
 
       report
     }

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -68,10 +68,11 @@ object VerificationComponent extends SimpleComponent {
     }
 
     def emitJson(): JValue = {
+      def pos2JsonImpl(pos: OffsetPosition): JObject = ("line" -> pos.line) ~ ("col" -> pos.col)
       def pos2Json(pos: Position): JValue = pos match {
         case NoPosition => "Unknown"
-        case OffsetPosition(line, col, _, file) => ("line" -> line) ~ ("col" -> col) ~ ("file" -> file.getPath)
-        case range: RangePosition => ("begin" -> pos2Json(range.focusBegin)) ~ ("end" -> pos2Json(range.focusEnd))
+        case pos @ OffsetPosition(_, _, _, file) => pos2JsonImpl(pos) ~ ("file" -> file.getPath)
+        case range: RangePosition => ("begin" -> pos2JsonImpl(range.focusBegin)) ~ ("end" -> pos2JsonImpl(range.focusEnd)) ~ ("file" -> range.file.getPath)
       }
 
       def status2Json(status: VCStatus[Model]): JObject = status match {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -4,11 +4,11 @@ package stainless
 package verification
 
 import inox.utils.ASCIIHelpers._
-import inox.utils.{NoPosition, OffsetPosition, Position, RangePosition}
+import stainless.utils.JsonConvertions._
 import stainless.verification.VCStatus.Invalid
 
 import org.json4s.JsonDSL._
-import org.json4s.JsonAST.{JObject, JValue}
+import org.json4s.JsonAST.{ JArray, JObject, JValue }
 
 object VerificationComponent extends SimpleComponent {
   val name = "verification"
@@ -68,13 +68,6 @@ object VerificationComponent extends SimpleComponent {
     }
 
     def emitJson(): JValue = {
-      def pos2JsonImpl(pos: OffsetPosition): JObject = ("line" -> pos.line) ~ ("col" -> pos.col)
-      def pos2Json(pos: Position): JValue = pos match {
-        case NoPosition => "Unknown"
-        case pos @ OffsetPosition(_, _, _, file) => pos2JsonImpl(pos) ~ ("file" -> file.getPath)
-        case range: RangePosition => ("begin" -> pos2JsonImpl(range.focusBegin)) ~ ("end" -> pos2JsonImpl(range.focusEnd)) ~ ("file" -> range.file.getPath)
-      }
-
       def status2Json(status: VCStatus[Model]): JObject = status match {
         case Invalid(cex) =>
           val info = cex.vars map { case (vd, e) => (vd.id.name -> e.toString) }
@@ -84,7 +77,7 @@ object VerificationComponent extends SimpleComponent {
       }
 
       def vc2Json(vc: VC[program.trees.type], vr: VCResult[program.Model]): JObject = {
-        ("fd" -> vc.fd.name) ~ ("pos" -> pos2Json(vc.getPos)) ~ ("kind" -> vc.kind.name) ~ status2Json(vr.status)
+        ("fd" -> vc.fd.name) ~ ("pos" -> vc.getPos.toJson) ~ ("kind" -> vc.kind.name) ~ status2Json(vr.status)
       }
 
       val report: JValue =


### PR DESCRIPTION
Add a `--json` option. This is useful to produce HTML rendering of the reports.