### PR TITLE
Dontcheck construct and Inlined functions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -45,6 +45,7 @@ tmp
 .idea
 Leon.eml
 Leon.iml
+*.iml
 /.idea_modules
 
 #scripts

--- a/core/src/main/scala/stainless/ast/Expressions.scala
+++ b/core/src/main/scala/stainless/ast/Expressions.scala
@@ -41,6 +41,14 @@ trait Expressions extends inox.ast.Expressions with inox.ast.Types { self: Trees
     }
   }
 
+  /** Unchecked conditions *
+    *
+    * @param body
+    */
+  case class Dontcheck(body: Expr) extends Expr with CachingTyped {
+    protected def computeType(implicit s: Symbols): Type = body.getType
+  }
+
   /** Postcondition of an [[Expressions.Expr]]. Corresponds to the Stainless keyword *ensuring*
     *
     * @param body The body of the expression. It can contain at most one [[Expressions.Require]] sub-expression.

--- a/core/src/main/scala/stainless/ast/Extractors.scala
+++ b/core/src/main/scala/stainless/ast/Extractors.scala
@@ -45,6 +45,8 @@ trait TreeDeconstructor extends inox.ast.TreeDeconstructor {
       (Seq(), Seq(body, pred), Seq(), (_, es, _) => t.Ensuring(es(0), es(1).asInstanceOf[t.Lambda]))
     case s.Assert(pred, error, body) =>
       (Seq(), Seq(pred, body), Seq(), (_, es, _) => t.Assert(es(0), error, es(1)))
+    case s.Dontcheck(body) =>
+      (Seq(), Seq(body), Seq(), (_, es, _) => t.Dontcheck(es(0)))
     case s.Pre(f) =>
       (Seq(), Seq(f), Seq(), (_, es, _) => t.Pre(es.head))
 

--- a/core/src/main/scala/stainless/ast/Printers.scala
+++ b/core/src/main/scala/stainless/ast/Printers.scala
@@ -33,6 +33,11 @@ trait Printer extends inox.ast.Printer {
           |  $post
           |}"""
 
+    case Dontcheck(body) =>
+      p"""|@Dontcheck {
+          |  $body
+          |}"""
+
     case Pre(f) =>
       p"$f.pre"
 

--- a/core/src/main/scala/stainless/codegen/CodeGeneration.scala
+++ b/core/src/main/scala/stainless/codegen/CodeGeneration.scala
@@ -1223,6 +1223,9 @@ trait CodeGeneration { self: CompilationUnit =>
       mkBranch(b, al, fl, ch, canDelegateToMkExpr = false)
       ch << Label(fl) << POP << Ldc(0) << Label(al)
 
+    case Dontcheck(body) =>
+      mkExpr(body, ch)
+
     case _ => throw CompilationException("Unsupported expr " + e + " : " + e.getClass)
   }
 
@@ -1492,6 +1495,9 @@ trait CodeGeneration { self: CompilationUnit =>
     case other if canDelegateToMkExpr =>
       mkExpr(other, ch, canDelegateToMkBranch = false)
       ch << IfEq(elze) << Goto(thenn)
+
+    case Dontcheck(condition) =>
+      mkBranch(condition, thenn, elze, ch)
 
     case other => throw CompilationException("Unsupported branching expr. : " + other)
   }

--- a/core/src/main/scala/stainless/evaluators/RecursiveEvaluator.scala
+++ b/core/src/main/scala/stainless/evaluators/RecursiveEvaluator.scala
@@ -71,6 +71,9 @@ trait RecursiveEvaluator extends inox.evaluators.RecursiveEvaluator {
     case NoTree(tpe) =>
       throw RuntimeError("Reached empty tree in evaluation @" + expr.getPos)
 
+    case Dontcheck(body) =>
+      e(body)
+
     case _ => super.e(expr)
   }
 

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -125,6 +125,8 @@ trait InoxEncoder extends ProgramEncoder {
       case s.Assert(pred, error, body) =>
         t.Assume(transform(pred), transform(body)).copiedFrom(e)
 
+      case s.Dontcheck(body) => transform(body)
+
       case s.FiniteArray(elems, base) =>
         t.ADT(t.ADTType(arrayID, Seq(transform(base))).copiedFrom(e), Seq(
           t.FiniteMap(

--- a/core/src/main/scala/stainless/transformers/TransformerWithPC.scala
+++ b/core/src/main/scala/stainless/transformers/TransformerWithPC.scala
@@ -35,6 +35,8 @@ trait TransformerWithPC extends inox.transformers.TransformerWithPC {
       val sbody = rec(body, env withCond spred)
       Assert(spred, err, sbody).copiedFrom(e)
 
+    case Dontcheck(body) => body
+
     case MatchExpr(scrut, cases) =>
       val rs = rec(scrut, env)
 

--- a/core/src/main/scala/stainless/verification/DefaultTactic.scala
+++ b/core/src/main/scala/stainless/verification/DefaultTactic.scala
@@ -60,7 +60,7 @@ trait DefaultTactic extends Tactic {
         } else if (err.startsWith("Cast ")) {
           VCKind.CastError
         } else {
-          VCKind.Assert
+          VCKind.AssertErr(err)
         }
 
       case _: Choose =>

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -34,6 +34,7 @@ object VCKind {
   case object PostTactic      extends VCKind("postcondition tactic", "tact.")
   case object Choose          extends VCKind("choose satisfiability", "choose")
   case object AdtInvariant    extends VCKind("adt invariant", "adt inv.")
+  case class  AssertErr(err: String)  extends VCKind("body assertion: " + err, "assert.")
 }
 
 sealed abstract class VCStatus[+Model](val name: String) {


### PR DESCRIPTION
This commit adds a Dontcheck class. Expressions inside this class are ignored by the generation of verification conditions. When inlining a function, we add an assertion that the precondition holds, which will generate a verification condition. Then, we inline the code using the Dontcheck class, so that the code of the inlined function does not generate duplicate verification conditions.