### PR TITLE
Add --strictarithmetic

### DIFF
--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -45,7 +45,7 @@ trait SimpleComponent extends Component { self =>
       (l, r) => l.lowering andThen r
     }
 
-    program.transform(extraction.extractor andThen lowering)
+    extraction.extract(program).transform(lowering)
   }
 
   def apply(units: List[xt.UnitDef], program: Program { val trees: xt.type }): Report = {

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -38,6 +38,7 @@ trait MainHelpers extends inox.MainHelpers {
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),
     verification.optParallelVCs -> Description(Verification, "Check verification conditions in parallel"),
     verification.optFailEarly -> Description(Verification, "Halt verification as soon as a check fails"),
+    verification.AssertionInjector.optStrictkArithmetic -> Description(Verification, "Check arithmetic operations for unintended behaviour and overflows"),
     inox.optTimeout -> Description(General, "Set a timeout n (in sec) such that\n" +
       "  - verification: each proof attempt takes at most n seconds\n" +
       "  - termination: each solver call takes at most n / 100 seconds"),

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -38,7 +38,7 @@ trait MainHelpers extends inox.MainHelpers {
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),
     verification.optParallelVCs -> Description(Verification, "Check verification conditions in parallel"),
     verification.optFailEarly -> Description(Verification, "Halt verification as soon as a check fails"),
-    verification.AssertionInjector.optStrictkArithmetic -> Description(Verification, "Check arithmetic operations for unintended behaviour and overflows"),
+    verification.VerificationComponent.optStrictArithmetic -> Description(Verification, "Check arithmetic operations for unintended behaviour and overflows"),
     inox.optTimeout -> Description(General, "Set a timeout n (in sec) such that\n" +
       "  - verification: each proof attempt takes at most n seconds\n" +
       "  - termination: each solver call takes at most n / 100 seconds"),

--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -363,7 +363,7 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
     andJoin(conditions)
   }
 
-  def weakestPrecondition(e: Expr, ctx: inox.Context): Expr =
+  def weakestPrecondition(e: Expr)(implicit ctx: inox.Context): Expr =
     weakestPrecondition(e, ctx.options.findOptionOrDefault(verification.AssertionInjector.optStrictkArithmetic))
 
 }

--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -315,11 +315,16 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
    * Weakest precondition
    * ==================== */
 
-  def weakestPrecondition(e: Expr): Expr = {
+  /**
+   * [[strict]] enable the strict arithmetic mode. See [[AssertionInjector.optStrictkArithmetic]].
+   * Overload with context below.
+   */
+  def weakestPrecondition(e: Expr, strict: Boolean): Expr = {
     object injector extends verification.AssertionInjector {
       val s: trees.type = trees
       val t: trees.type = trees
       val symbols: self.symbols.type = self.symbols
+      val strictArithmetic: Boolean = strict
     }
 
     val withAssertions = injector.transform(e)
@@ -357,4 +362,8 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
     val conditions = collector.collect(withAssertions)
     andJoin(conditions)
   }
+
+  def weakestPrecondition(e: Expr, ctx: inox.Context): Expr =
+    weakestPrecondition(e, ctx.options.findOptionOrDefault(verification.AssertionInjector.optStrictkArithmetic))
+
 }

--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -364,6 +364,6 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
   }
 
   def weakestPrecondition(e: Expr)(implicit ctx: inox.Context): Expr =
-    weakestPrecondition(e, ctx.options.findOptionOrDefault(verification.AssertionInjector.optStrictkArithmetic))
+    weakestPrecondition(e, ctx.options.findOptionOrDefault(verification.VerificationComponent.optStrictArithmetic))
 
 }

--- a/core/src/main/scala/stainless/codegen/CodeGeneration.scala
+++ b/core/src/main/scala/stainless/codegen/CodeGeneration.scala
@@ -443,7 +443,7 @@ trait CodeGeneration { self: CompilationUnit =>
           val preLambda = if (pre) {
             lambda.copy(body = BooleanLiteral(true))
           } else {
-            lambda.copy(body = weakestPrecondition(lambda.body, false)) // FIXME
+            lambda.copy(body = weakestPrecondition(lambda.body))
           }
 
           mkLambda(preLambda, pch, pre = true)(preLocals)

--- a/core/src/main/scala/stainless/codegen/CodeGeneration.scala
+++ b/core/src/main/scala/stainless/codegen/CodeGeneration.scala
@@ -443,7 +443,7 @@ trait CodeGeneration { self: CompilationUnit =>
           val preLambda = if (pre) {
             lambda.copy(body = BooleanLiteral(true))
           } else {
-            lambda.copy(body = weakestPrecondition(lambda.body))
+            lambda.copy(body = weakestPrecondition(lambda.body, false)) // FIXME
           }
 
           mkLambda(preLambda, pch, pre = true)(preLocals)

--- a/core/src/main/scala/stainless/evaluators/RecursiveEvaluator.scala
+++ b/core/src/main/scala/stainless/evaluators/RecursiveEvaluator.scala
@@ -25,7 +25,7 @@ trait RecursiveEvaluator extends inox.evaluators.RecursiveEvaluator {
 
     case Pre(f) =>
       e(f) match {
-        case Lambda(args, body) => e(Lambda(args, weakestPrecondition(body, false))) // FIXME
+        case Lambda(args, body) => e(Lambda(args, weakestPrecondition(body)))
         case e => throw EvalError("Cannot get pre of non-lambda function " + e.asString)
       }
 

--- a/core/src/main/scala/stainless/evaluators/RecursiveEvaluator.scala
+++ b/core/src/main/scala/stainless/evaluators/RecursiveEvaluator.scala
@@ -25,7 +25,7 @@ trait RecursiveEvaluator extends inox.evaluators.RecursiveEvaluator {
 
     case Pre(f) =>
       e(f) match {
-        case Lambda(args, body) => e(Lambda(args, weakestPrecondition(body)))
+        case Lambda(args, body) => e(Lambda(args, weakestPrecondition(body, false))) // FIXME
         case e => throw EvalError("Cannot get pre of non-lambda function " + e.asString)
       }
 

--- a/core/src/main/scala/stainless/extraction/PreconditionInference.scala
+++ b/core/src/main/scala/stainless/extraction/PreconditionInference.scala
@@ -447,7 +447,7 @@ trait PreconditionInference extends inox.ast.SymbolTransformer { self =>
         // @nv: can't use postMap because of Lambda in Ensuring predicate
         def injectRequires(e: Expr): Expr = (e match {
           case Lambda(args, r @ Require(pred, body)) => Lambda(args, Require(injectRequires(pred), injectRequires(body)).copiedFrom(r))
-          case Lambda(args, body) => Lambda(args, Require(preSyms.weakestPrecondition(body), injectRequires(body)))
+          case Lambda(args, body) => Lambda(args, Require(preSyms.weakestPrecondition(body, false), injectRequires(body))) // FIXME
           case Ensuring(body, l @ Lambda(args, pred)) => Ensuring(injectRequires(body), Lambda(args, injectRequires(pred)).copiedFrom(l))
           case Operator(es, recons) => recons(es.map(injectRequires))
         }).copiedFrom(e)

--- a/core/src/main/scala/stainless/extraction/oo/package.scala
+++ b/core/src/main/scala/stainless/extraction/oo/package.scala
@@ -31,4 +31,5 @@ package object oo {
   }
 
   val extractor = methods andThen adts andThen encoding
+
 }

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -59,18 +59,19 @@ package object extraction {
   case class MissformedStainlessCode(val tree: inox.ast.Trees#Tree, msg: String)
     extends Exception(msg)
 
-  object preconditionInference extends {
-    val trees: extraction.trees.type = extraction.trees
-  } with PreconditionInference
-
-  val extractor: inox.ast.SymbolTransformer {
-    val s: xlang.trees.type
-    val t: trees.type
-  } = xlang.extractor      andThen
+  def extract(program: Program { val trees: xlang.trees.type }): Program { val trees: extraction.trees.type } = {
+    val pipeline =
+      xlang.extractor      andThen
       oo.extractor         andThen
       holes.extractor      andThen
       imperative.extractor andThen
       innerfuns.extractor  andThen
-      inlining.extractor   andThen
-      preconditionInference
+      inlining.extractor
+
+    val extracted: Program { val trees: extraction.trees.type } =
+      program.transform(pipeline)
+
+    new PreconditionInference(extracted).targetProgram
+  }
+
 }

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -184,7 +184,7 @@ trait InoxEncoder extends ProgramEncoder {
           },
           t.Lambda(preArgs, t.exprOps.replaceFromSymbols(
             (fArgs.map(_.toVariable) zip preArgs.map(_.toVariable)).toMap,
-            transform(weakestPrecondition(body, false)) // FIXME
+            transform(weakestPrecondition(body))
           )).copiedFrom(e)
         ))
 

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -184,7 +184,7 @@ trait InoxEncoder extends ProgramEncoder {
           },
           t.Lambda(preArgs, t.exprOps.replaceFromSymbols(
             (fArgs.map(_.toVariable) zip preArgs.map(_.toVariable)).toMap,
-            transform(weakestPrecondition(body))
+            transform(weakestPrecondition(body, false)) // FIXME
           )).copiedFrom(e)
         ))
 

--- a/core/src/main/scala/stainless/verification/AssertionInjector.scala
+++ b/core/src/main/scala/stainless/verification/AssertionInjector.scala
@@ -3,11 +3,18 @@
 package stainless
 package verification
 
+/**
+ * Transform trees by inserting assertions. Those verify that all array access are valid,
+ * casts are legal, no division by zero occur and, when using the [[strictArithmetic]] mode,
+ * that the program is exempt of integer overflow and unexpected behaviour.
+ */
 trait AssertionInjector extends ast.TreeTransformer {
   val s: ast.Trees
   val t: ast.Trees
 
   implicit val symbols: s.Symbols
+
+  val strictArithmetic: Boolean
 
   private def indexUpTo(i: t.Expr, e: t.Expr) = t.And(
     t.GreaterEquals(i, t.Int32Literal(0).copiedFrom(i)).copiedFrom(i),
@@ -74,6 +81,14 @@ trait AssertionInjector extends ast.TreeTransformer {
 }
 
 object AssertionInjector {
+
+  /**
+   * Strict Arithmetmetic Mode:
+   *
+   * Add assertion for integer overflow checking and other unexpected behaviour (e.g. x << 65).
+   */
+  val optStrictkArithmetic = inox.FlagOptionDef("strictarithmetic", false)
+
   def apply(p: Program): inox.ast.SymbolTransformer {
     val s: p.trees.type
     val t: p.trees.type
@@ -86,6 +101,7 @@ object AssertionInjector {
         val s: p.trees.type = p.trees
         val t: p.trees.type = p.trees
         val symbols: p.symbols.type = p.symbols
+        val strictArithmetic: Boolean = p.ctx.options.findOptionOrDefault(optStrictkArithmetic)
       }
 
       t.NoSymbols

--- a/core/src/main/scala/stainless/verification/AssertionInjector.scala
+++ b/core/src/main/scala/stainless/verification/AssertionInjector.scala
@@ -192,14 +192,6 @@ trait AssertionInjector extends ast.TreeTransformer {
 }
 
 object AssertionInjector {
-
-  /**
-   * Strict Arithmetmetic Mode:
-   *
-   * Add assertion for integer overflow checking and other unexpected behaviour (e.g. x << 65).
-   */
-  val optStrictkArithmetic = inox.FlagOptionDef("strictarithmetic", false)
-
   def apply(p: Program): inox.ast.SymbolTransformer {
     val s: p.trees.type
     val t: p.trees.type
@@ -212,7 +204,8 @@ object AssertionInjector {
         val s: p.trees.type = p.trees
         val t: p.trees.type = p.trees
         val symbols: p.symbols.type = p.symbols
-        val strictArithmetic: Boolean = p.ctx.options.findOptionOrDefault(optStrictkArithmetic)
+        val strictArithmetic: Boolean =
+          p.ctx.options.findOptionOrDefault(VerificationComponent.optStrictArithmetic)
       }
 
       t.NoSymbols

--- a/core/src/main/scala/stainless/verification/DefaultTactic.scala
+++ b/core/src/main/scala/stainless/verification/DefaultTactic.scala
@@ -47,6 +47,10 @@ trait DefaultTactic extends Tactic {
           VCKind.ArrayUsage
         } else if (err.startsWith("Map ")) {
           VCKind.MapUsage
+        } else if (err.endsWith("Overflow")) {
+          VCKind.Overflow
+        } else if (err.startsWith("Shift")) {
+          VCKind.Shift
         } else if (err.startsWith("Division ")) {
           VCKind.DivisionByZero
         } else if (err.startsWith("Modulo ")) {

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -152,8 +152,6 @@ trait VerificationChecker { self =>
           VCResult(VCStatus.Unsupported, Some(s), Some(time))
       }
 
-      val time = timer.stop()
-
       ctx.reporter.synchronized {
         if (parallelCheck)
           ctx.reporter.info(s" - Result for '${vc.kind}' VC for ${vc.fd} @${vc.getPos}:")

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -14,6 +14,13 @@ object VerificationComponent extends SimpleComponent {
   val name = "verification"
   val description = "Verification of function contracts"
 
+  /**
+   * Strict Arithmetic Mode:
+   *
+   * Add assertions for integer overflow checking and other unexpected behaviour (e.g. x << 65).
+   */
+  val optStrictArithmetic = inox.FlagOptionDef("strictarithmetic", false)
+
   val trees: stainless.trees.type = stainless.trees
 
   type Report = VerificationReport

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -25,6 +25,8 @@ object VCKind {
   case object ExhaustiveMatch extends VCKind("match exhaustiveness", "match.")
   case object ArrayUsage      extends VCKind("array usage", "arr. use")
   case object MapUsage        extends VCKind("map usage", "map use")
+  case object Overflow        extends VCKind("integer overflow", "overflow")
+  case object Shift           extends VCKind("strict arithmetic on shift", "shift")
   case object DivisionByZero  extends VCKind("division by zero", "div 0")
   case object ModuloByZero    extends VCKind("modulo by zero", "mod 0")
   case object RemainderByZero extends VCKind("remainder by zero", "rem 0")

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow1.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow1.scala
@@ -1,0 +1,8 @@
+
+object Overflow1 {
+
+  def foo1(x: Int): Int = {
+    x + 1
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow10.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow10.scala
@@ -1,0 +1,8 @@
+
+object Overflow10 {
+
+  def foo10(x: Int, y: Int): Int = {
+    x * y
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow11.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow11.scala
@@ -1,0 +1,10 @@
+
+object Overflow11 {
+
+  def foo11(): Int = {
+    val x = 500000
+    val y = 500000
+    x * y
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow12.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow12.scala
@@ -1,0 +1,8 @@
+
+object Overflow12 {
+
+  def foo12(x: Int): Int = {
+    -x
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow13.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow13.scala
@@ -1,0 +1,9 @@
+
+object Overflow13 {
+
+  def foo13(x: Int, y: Int) = {
+    require(y != 0)
+    x / y
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow2.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow2.scala
@@ -1,0 +1,8 @@
+
+object Overflow2 {
+
+  def foo2(x: Int): Int = {
+    x + (-1)
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow3.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow3.scala
@@ -1,0 +1,8 @@
+
+object Overflow3 {
+
+  def foo3(x: Int): Int = {
+    x - 1
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow4.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow4.scala
@@ -1,0 +1,8 @@
+
+object Overflow4 {
+
+  def foo4(x: Int): Int = {
+    x - (-1)
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow5.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow5.scala
@@ -1,0 +1,8 @@
+
+object Overflow5 {
+
+  def foo5(x: Int, y: Int): Int = {
+    x + y
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow6.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow6.scala
@@ -1,0 +1,8 @@
+
+object Overflow6 {
+
+  def foo6(x: Int, y: Int): Int = {
+    x - y
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow7.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow7.scala
@@ -1,0 +1,8 @@
+
+object Overflow7 {
+
+  def foo7(x: Int): Int = {
+    x * 2
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow8.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow8.scala
@@ -1,0 +1,8 @@
+
+object Overflow8 {
+
+  def foo8(x: Int): Int = {
+    x * 3
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/Overflow9.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/Overflow9.scala
@@ -1,0 +1,8 @@
+
+object Overflow9 {
+
+  def foo9(x: Int): Int = {
+    x * 4
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic1.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic1.scala
@@ -1,0 +1,9 @@
+
+object StrictArithmetic1 {
+
+  def foo1(x: Int, y: Int) = {
+    x << y
+  }
+
+}
+

--- a/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic2.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic2.scala
@@ -1,0 +1,9 @@
+
+object StrictArithmetic2 {
+
+  def foo2(x: Int, y: Int) = {
+    x >> y
+  }
+
+}
+

--- a/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic3.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic3.scala
@@ -1,0 +1,9 @@
+
+object StrictArithmetic3 {
+
+  def foo3(x: Int, y: Int) = {
+    x >>> y
+  }
+
+}
+

--- a/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic4.scala
+++ b/frontends/benchmarks/strictarithmetic/invalid/StrictArithmetic4.scala
@@ -1,0 +1,10 @@
+
+object StrictArithmetic4 {
+
+  // Test: should find at least x % 0 as a counter example
+  def foo4(x: Int, y: Int) = {
+    x % y
+  }
+
+}
+

--- a/frontends/benchmarks/strictarithmetic/valid/Overflow1.scala
+++ b/frontends/benchmarks/strictarithmetic/valid/Overflow1.scala
@@ -1,0 +1,110 @@
+
+object Overflow1 {
+
+  def foo1(x: Int): Int = {
+    require(x < 100)
+    x + 1
+  }
+
+  def bab1(x: Byte): Int  = x + 1
+  def bas1(x: Short): Int = x + 1
+  def bal1(x: Int): Long  = x + 1L
+
+  def foo2(x: Int): Int = {
+    require(x > -100)
+    x + (-1)
+  }
+
+  def bab2(x: Byte): Int  = x + (-1)
+  def bas2(x: Short): Int = x + (-1)
+  def bal2(x: Int): Long  = x + (-1L)
+
+  def foo3(x: Int): Int = {
+    require(x > -100)
+    x - 1
+  }
+
+  def bab3(x: Byte): Int  = x - 1
+  def bas3(x: Short): Int = x - 1
+  def bal3(x: Int): Long  = x - 1L
+
+  def foo4(x: Int): Int = {
+    require(x < 100)
+    x - (-1)
+  }
+
+  def bab4(x: Byte): Int  = x - (-1)
+  def bas4(x: Short): Int = x - (-1)
+  def bal4(x: Int): Long  = x - (-1L)
+
+  def foo5(x: Int, y: Int): Int = {
+    require(x < 0 && y > 0)
+    x + y
+  }
+
+  def bab5(x: Byte, y: Byte): Int = x + y
+  def bas5(x: Short, y: Short): Int = x + y
+  def bal5(x: Int, y: Int): Long = x.toLong + y
+
+  def foo6(x: Int, y: Int): Int = {
+    require(x > 0 && y > 0)
+    x - y
+  }
+
+  def foo7(x: Int): Int = {
+    require(x > -100 && x < 100)
+    x * 2
+  }
+
+  def bab7(x: Byte): Int = x * 2
+  def bas7(x: Short): Int = x * 2
+  def bal7(x: Int): Long = x.toLong * 2
+
+  def fun7(x: Long): Long = {
+    require(x > -100 && x < 100)
+    x * 2
+  }
+
+  def foo8(x: Int): Int = {
+    require(x > -100 && x < 100)
+    x * 3
+  }
+
+  def foo10(x: Int, y: Int): Int = {
+    require(x >= -10 && x <= 10 && y >= -10 && y <= 10)
+    x * y
+  }
+
+  def foo11(): Int = {
+    val x = 40000
+    val y = 40000
+    x * y
+  }
+
+  def fun11(): Long = {
+    val x = 500000L
+    val y = 500000L
+    x * y
+  }
+
+  def foo12(x: Int): Int = {
+    require(x != -2147483648) // -2^31
+    -x
+  }
+
+  def fun12(x: Long): Long = {
+    require(x != -9223372036854775808L) // -2^63
+    -x
+  }
+
+  def foo13(x: Int, y: Int) = {
+    require(y != 0 && (x != -2147483648 || y != -1))
+    x / y
+  }
+
+  def fun13(x: Long, y: Long) = {
+    require(y != 0 && (x != -9223372036854775808L || y != -1L))
+    x / y
+  }
+
+}

--- a/frontends/benchmarks/strictarithmetic/valid/StrictArithmetic1.scala
+++ b/frontends/benchmarks/strictarithmetic/valid/StrictArithmetic1.scala
@@ -1,0 +1,35 @@
+
+object StrictArithmetic1 {
+
+  def foo1(x: Int, y: Int) = {
+    require(0 <= y && y <= 31)
+    x << y
+  }
+
+  def fun1(x: Long, y: Int) = {
+    require(0 <= y && y <= 63)
+    x << y
+  }
+
+  def foo2(x: Int, y: Int) = {
+    require(0 <= y && y <= 31)
+    x >> y
+  }
+
+  def fun2(x: Long, y: Int) = {
+    require(0 <= y && y <= 63)
+    x >> y
+  }
+
+  def foo3(x: Int, y: Int) = {
+    require(0 <= y && y <= 31)
+    x >>> y
+  }
+
+  def fun3(x: Long, y: Int) = {
+    require(0 <= y && y <= 63)
+    x >>> y
+  }
+
+}
+

--- a/frontends/scalac/src/it/scala/stainless/ExtractionSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/ExtractionSuite.scala
@@ -27,7 +27,7 @@ class ExtractionSuite extends FunSpec with inox.ResourceUtils {
           }
         }
 
-        val tryExProgram = scala.util.Try(program.transform(extraction.extractor))
+        val tryExProgram = scala.util.Try(extraction.extract(program))
         describe("and transformation") {
           it("should be successful") { assert(tryExProgram.isSuccess) }
 

--- a/frontends/scalac/src/it/scala/stainless/verification/StrictArithmeticSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/StrictArithmeticSuite.scala
@@ -8,7 +8,7 @@ import org.scalatest._
 class StrictArithmeticSuite extends ComponentTestSuite {
 
   override def configurations = super.configurations.map {
-    seq => Seq(AssertionInjector.optStrictkArithmetic(true), optFailEarly(true)) ++ seq
+    seq => Seq(VerificationComponent.optStrictArithmetic(true), optFailEarly(true)) ++ seq
   }
 
   override protected def optionsString(options: inox.Options): String = ""

--- a/frontends/scalac/src/it/scala/stainless/verification/StrictArithmeticSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/StrictArithmeticSuite.scala
@@ -1,0 +1,29 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+package stainless
+package verification
+
+import org.scalatest._
+
+class StrictArithmeticSuite extends ComponentTestSuite {
+
+  override def configurations = super.configurations.map {
+    seq => Seq(AssertionInjector.optStrictkArithmetic(true), optFailEarly(true)) ++ seq
+  }
+
+  override protected def optionsString(options: inox.Options): String = ""
+
+  val component = VerificationComponent
+
+  testAll("strictarithmetic/valid") { (report, reporter) =>
+    for ((vc, vr) <- report.vrs) {
+      if (vr.isInvalid) fail(s"The following verification condition was invalid: $vc @${vc.getPos}")
+      if (vr.isInconclusive) fail(s"The following verification condition was inconclusive: $vc @${vc.getPos}")
+    }
+    reporter.terminateIfError()
+  }
+
+  testAll("strictarithmetic/invalid") { (report, _) =>
+    assert(report.totalInvalid > 0, "There should be at least one invalid verification condition.")
+  }
+}

--- a/frontends/stainless-dotty/src/it/scala/stainless/ExtractionSuite.scala
+++ b/frontends/stainless-dotty/src/it/scala/stainless/ExtractionSuite.scala
@@ -27,7 +27,7 @@ class ExtractionSuite extends FunSpec with inox.ResourceUtils {
           }
         }
 
-        val tryExProgram = scala.util.Try(program.transform(extraction.extractor))
+        val tryExProgram = scala.util.Try(extraction.extract(program))
         describe("and transformation") {
           it("should be successful") { assert(tryExProgram.isSuccess) }
 


### PR DESCRIPTION
Import epfl-lara/leon#273, except for C-specific check (i.e. `MinValue % -1`).

Changes to have a `Context` available for calling `weakestPrecondition` should be minimal I think. This best as is, if we want to change things more fundamentally later.