### PR TITLE
Fix the termination metrics of the 91 function

### DIFF
--- a/core/src/sphinx/intro.rst
+++ b/core/src/sphinx/intro.rst
@@ -126,6 +126,6 @@ can be shown terminating as follows:
 .. code-block:: scala
 
   def M(n: BigInt): BigInt = {
-    decreases(max(101 - n, 0))
+    decreases(stainless.math.max(101 - n, 0))
     if (n > 100) n - 10 else M(M(n + 11))
   } ensuring (_ == (if (n > 100) n - 10 else BigInt(91)))

--- a/core/src/sphinx/intro.rst
+++ b/core/src/sphinx/intro.rst
@@ -125,7 +125,7 @@ can be shown terminating as follows:
 
 .. code-block:: scala
 
-  def def M(n: BigInt): BigInt = {
-    decreases(101 - n)
+  def M(n: BigInt): BigInt = {
+    decreases(max(101 - n, 0))
     if (n > 100) n - 10 else M(M(n + 11))
   } ensuring (_ == (if (n > 100) n - 10 else BigInt(91)))


### PR DESCRIPTION
Stainless rejects the `decreases` contract because `101 - n` can be negative, like:
```
...
[  Info  ]  - Now considering 'body assertion' VC for M @14:30...
[Warning ]  => INVALID
[Warning ] Found counter-example:
[Warning ]   n: BigInt -> 102
...
```
or, with `--termination`,
```
...
[Warning ]  ==> INVALID: measure is not well-founded in M
[  Info  ] Result for M
[  Info  ]  => BROKEN (Decreases Processor) -> DecreasesFailed
...
```
So I'm afraid that we need to ensure the metrics non-negative, with `stainless.math.max`.

(stainless revision: f9aff1428512669ccd431b827a501094a45a62aa)