### PR TITLE
cache for verification conditions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 # Stainless
 /bin/stainless-*
+.vccache.bin
 
 
 # Vim

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -7,11 +7,12 @@ import org.json4s.JsonAST.JArray
 import extraction.xlang.{trees => xt}
 import scala.language.existentials
 
-case class ReportStats(total: Int, time: Long, valid: Int, invalid: Int, unknown: Int) {
+case class ReportStats(total: Int, time: Long, valid: Int, validFromCache: Int, invalid: Int, unknown: Int) {
   def +(more: ReportStats) = ReportStats(
     total + more.total,
     time + more.time,
     valid + more.valid,
+    validFromCache + more.validFromCache,
     invalid + more.invalid,
     unknown + more.unknown
   )
@@ -57,7 +58,7 @@ trait AbstractReport { self =>
     t += Separator
     t += Row(Seq(
       Cell(
-        f"total: ${stats.total}%-4d   valid: ${stats.valid}%-4d   " +
+        f"total: ${stats.total}%-4d   valid: ${stats.valid}%-4d (${stats.validFromCache} from cache)   " +
         f"invalid: ${stats.invalid}%-4d   unknown: ${stats.unknown}%-4d  " +
         f"time: ${stats.time/1000d}%7.3f",
         spanning = width

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -63,7 +63,7 @@ trait MainHelpers extends inox.MainHelpers {
 
   override protected def getDebugSections: Set[inox.DebugSection] = super.getDebugSections ++ Set(
     verification.DebugSectionVerification,
-    verification.DebugSectionCache,
+    verification.DebugSectionCacheHit,
     verification.DebugSectionCacheMiss,
     termination.DebugSectionTermination,
     DebugSectionExtraction,

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -119,10 +119,11 @@ trait MainHelpers extends inox.MainHelpers {
     }
 
     // Shutdown the pool for a clean exit.
-    val unexecuted = MainHelpers.executor.shutdownNow()
-    if (!ctx.interruptManager.isInterrupted && unexecuted.size != 0) {
-      ctx.reporter.error("Some tasks were not run (" + unexecuted.size + ")")
-    }
+    MainHelpers.executor.shutdown()
+    // val unexecuted = MainHelpers.executor.shutdownNow()
+    // if (!ctx.interruptManager.isInterrupted && unexecuted.size != 0) {
+    //   ctx.reporter.error("Some tasks were not run (" + unexecuted.size + ")")
+    // }
   } catch {
     case _: inox.FatalError => System.exit(1)
   }

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -119,6 +119,7 @@ trait MainHelpers extends inox.MainHelpers {
     }
 
     // Shutdown the pool for a clean exit.
+    ctx.reporter.info("Shutting down executor service.")
     MainHelpers.executor.shutdown()
   } catch {
     case _: inox.FatalError => System.exit(1)

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -44,7 +44,8 @@ trait MainHelpers extends inox.MainHelpers {
     codegen.optInstrumentFields -> Description(Evaluators, "Instrument ADT field access during code generation"),
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),
     verification.optParallelVCs -> Description(Verification, "Check verification conditions in parallel"),
-    verification.optFailEarly -> Description(Verification, "Halt verification as soon as a check fails"),
+    verification.optFailEarly -> Description(Verification, "Halt verification as soon as a check fails (invalid or unknown)"),
+    verification.optVCCache -> Description(Verification, "Enable caching of verification conditions"),
     verification.VerificationComponent.optStrictArithmetic -> Description(Verification, "Check arithmetic operations for unintended behaviour and overflows"),
     inox.optTimeout -> Description(General, "Set a timeout n (in sec) such that\n" +
       "  - verification: each proof attempt takes at most n seconds\n" +
@@ -62,6 +63,8 @@ trait MainHelpers extends inox.MainHelpers {
 
   override protected def getDebugSections: Set[inox.DebugSection] = super.getDebugSections ++ Set(
     verification.DebugSectionVerification,
+    verification.DebugSectionCache,
+    verification.DebugSectionCacheMiss,
     termination.DebugSectionTermination,
     DebugSectionExtraction,
     frontend.DebugSectionFrontend

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -120,10 +120,6 @@ trait MainHelpers extends inox.MainHelpers {
 
     // Shutdown the pool for a clean exit.
     MainHelpers.executor.shutdown()
-    // val unexecuted = MainHelpers.executor.shutdownNow()
-    // if (!ctx.interruptManager.isInterrupted && unexecuted.size != 0) {
-    //   ctx.reporter.error("Some tasks were not run (" + unexecuted.size + ")")
-    // }
   } catch {
     case _: inox.FatalError => System.exit(1)
   }

--- a/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
+++ b/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
@@ -88,7 +88,7 @@ trait FunctionClosure extends inox.ast.SymbolTransformer { self =>
       val nestedFuns = nestedWithPaths.keys.toSeq
       val nestedFunsIds = nestedFuns.map(_.name.id).toSet
 
-      // Transitively called funcions from each function
+      // Transitively called functions from each function
       val callGraph: Map[Identifier, Set[Identifier]] = inox.utils.GraphOps.transitiveClosure(
         nestedFuns.map { f =>
           val calls = exprOps.innerFunctionCalls(f.body) intersect nestedFunsIds
@@ -120,7 +120,7 @@ trait FunctionClosure extends inox.ast.SymbolTransformer { self =>
 
       val transFree: Map[Identifier, Seq[Variable]] = 
         //transFreeWithBindings.map(p => (p._1, p._2 -- nestedWithPaths(p._1).bindings.map(_._1))).map(p => (p._1, p._2.toSeq))
-        transFreeWithBindings.map(p => (p._1, p._2.toSeq))
+        transFreeWithBindings.map(p => (p._1, p._2.toSeq.sortBy(_.id.name)))
 
       // Closed functions along with a map (old var -> new var).
       val closed = nestedWithPaths.map {

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -79,7 +79,7 @@ trait AdtSpecialization extends inox.ast.SymbolTransformer { self =>
         case s.IsInstanceOf(e, s.ClassType(id, tps)) if candidates(id) =>
           val te = transform(e)
           val ttps = tps map transform
-          t.orJoin(classToConstructors(id).toSeq.map {
+          t.orJoin(classToConstructors(id).toSeq.sortBy(_.name).map {
             id => t.IsInstanceOf(te, t.ADTType(id, ttps)).setPos(e)
           })
 
@@ -135,7 +135,7 @@ trait AdtSpecialization extends inox.ast.SymbolTransformer { self =>
         case (ovd, vd) => ovd.tpe match {
           case s.ClassType(id, tps) if candidates(id) && approximate(id) != id =>
             val ttps = tps map transformer.transform
-            Some(t.orJoin(classToConstructors(id).toSeq.map {
+            Some(t.orJoin(classToConstructors(id).toSeq.sortBy(_.name).map {
               id => t.IsInstanceOf(vd.toVariable, t.ADTType(id, ttps))
             }))
           case _ => None

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -164,7 +164,7 @@ trait AdtSpecialization extends inox.ast.SymbolTransformer { self =>
     val sorts: Seq[t.ADTSort] = sortClasses.map(cd => new t.ADTSort(
       cd.id,
       cd.tparams map transformer.transform,
-      classToConstructors(cd.id).toSeq,
+      classToConstructors(cd.id).toSeq.sortBy(_.name),
       (cd.flags - IsAbstract - IsSealed) map transformer.transform
     ).copiedFrom(cd)).toSeq
 

--- a/core/src/main/scala/stainless/extraction/oo/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/oo/MethodLifting.scala
@@ -151,8 +151,8 @@ trait MethodLifting extends inox.ast.SymbolTransformer { self =>
         }
       }
 
-      val subCalls = (for (co <- cos.toSeq) yield {
-        firstOverrides(co).toSeq.map { case (cid, either) =>
+      val subCalls = (for (co <- cos.toSeq.sortBy(_.cid.name)) yield {
+        firstOverrides(co).toSeq.sortBy(_._1.name).map { case (cid, either) =>
           val descType = default.transform(tcd.descendants.find(_.id == cid).get.toType).asInstanceOf[t.ClassType]
           val thiss = t.AsInstanceOf(arg.toVariable, descType).copiedFrom(arg)
           (t.IsInstanceOf(arg.toVariable, descType).copiedFrom(arg), either match {

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -74,10 +74,11 @@ object TerminationComponent extends SimpleComponent {
       ))
 
       val valid = results count { r => r._2.isGuaranteed }
+      val validFromCache = 0
       val invalid = 0
       val unknown = results.size - valid
 
-      val stats = ReportStats(results.size, time, valid, invalid, unknown)
+      val stats = ReportStats(results.size, time, valid, validFromCache, invalid, unknown)
 
       Some((rows, stats))
     }

--- a/core/src/main/scala/stainless/transformers/Canonization.scala
+++ b/core/src/main/scala/stainless/transformers/Canonization.scala
@@ -59,7 +59,7 @@ trait Canonization { self =>
 
 
 object Canonization {
-  def canonize(p: inox.Program { val trees: stainless.ast.Trees }, vc: verification.VC[p.trees.type]): 
+  def canonize(p: inox.Program { val trees: stainless.ast.Trees })(vc: verification.VC[p.trees.type]): 
                 (p.trees.Symbols, p.trees.Expr)  = {
     object Canonizer extends Canonization {
       override val trees: p.trees.type = p.trees

--- a/core/src/main/scala/stainless/transformers/Canonization.scala
+++ b/core/src/main/scala/stainless/transformers/Canonization.scala
@@ -17,12 +17,7 @@ trait Canonization { self =>
 
   type VC = verification.VC[trees.type]
 
-  // Sequence of transformed function definitions
-  var functions = Seq[FunDef]()
-  // Sequence of transformed ADT definitions
-  var adts = Seq[ADTDefinition]()
-
-  def transform(syms: s.Symbols, vc: VC): (t.Symbols, Expr) = {
+  def normalize(syms: s.Symbols, vc: VC): (t.Symbols, Expr) = {
 
     // Stores the transformed function and ADT definitions
     var functions = Seq[FunDef]()
@@ -64,14 +59,13 @@ trait Canonization { self =>
 
 
 object Canonization {
-  def canonize(trs: stainless.ast.Trees)
-              (p: inox.Program { val trees: trs.type }, vc: verification.VC[trs.type]): 
-                (p.trees.Symbols, trs.Expr)  = {
-    object canonizer extends Canonization {
+  def canonize(p: inox.Program { val trees: stainless.ast.Trees }, vc: verification.VC[p.trees.type]): 
+                (p.trees.Symbols, p.trees.Expr)  = {
+    object Canonizer extends Canonization {
       override val trees: p.trees.type = p.trees
     }
 
-    val (newSymbols, newVCBody) = canonizer.transform(p.symbols, vc)
+    val (newSymbols, newVCBody) = Canonizer.normalize(p.symbols, vc)
 
     (newSymbols, newVCBody)
   }

--- a/core/src/main/scala/stainless/transformers/Canonization.scala
+++ b/core/src/main/scala/stainless/transformers/Canonization.scala
@@ -49,16 +49,11 @@ trait Canonization { self =>
         }
       }
 
-      def transformADT(adt: ADTDefinition): ADTDefinition = {
-        val newInvariant = adt.invariant(syms) map transform
-        transform(adt).changeInvariant(newInvariant)
-      }
-
       def exploreADT(id: Identifier): Unit = {
         if (syms.adts.contains(id) && !traversed(id)) {
           traversed += id
           val adt = syms.adts(id)
-          val newADT = transformADT(adt)
+          val newADT = transform(adt)
           transformedADTs += ((id, newADT))
         }
       }

--- a/core/src/main/scala/stainless/transformers/Canonization.scala
+++ b/core/src/main/scala/stainless/transformers/Canonization.scala
@@ -1,0 +1,106 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package transformers
+
+import stainless.extraction.inlining.Trees
+
+trait Canonization { self =>
+
+  val trees: stainless.ast.Trees
+  lazy val s: self.trees.type = self.trees
+  lazy val t: self.trees.type = self.trees
+
+  import self.trees._
+
+  type VC = verification.VC[trees.type]
+
+  def transform(syms: s.Symbols, vc: VC): (t.Symbols, Expr) = {
+
+    var localCounter = 0
+    // Maps an original identifier to a normalized identifier
+    var renaming: Map[Identifier,Identifier] = Map()
+
+    def addRenaming(id: Identifier): Unit = {
+      if (!renaming.contains(id)) {
+        val newId = new Identifier("x",localCounter,localCounter)
+        localCounter = localCounter + 1
+        renaming += ((id, newId))
+      }
+    }
+
+    // Map from old identifiers to new fundefs
+    var transformedFunctions = Map[Identifier, FunDef]()
+    // Map from old identifiers to new ADTs
+    var transformedADTs = Map[Identifier, ADTDefinition]()
+
+    object idTransformer extends inox.ast.TreeTransformer {
+      val s: self.trees.type = self.trees
+      val t: self.trees.type = self.trees
+
+      var traversed = Set[Identifier]()
+
+      def exploreFunDef(id: Identifier): Unit = {
+        if (syms.functions.contains(id) && !traversed(id)) {
+          traversed += id
+          val fd = syms.functions(id)
+          val newFD = transform(fd)
+          transformedFunctions += ((id, newFD))
+        }
+      }
+
+      def transformADT(adt: ADTDefinition): ADTDefinition = {
+        val newInvariant = adt.invariant(syms) map transform
+        transform(adt).changeInvariant(newInvariant)
+      }
+
+      def exploreADT(id: Identifier): Unit = {
+        if (syms.adts.contains(id) && !traversed(id)) {
+          traversed += id
+          val adt = syms.adts(id)
+          val newADT = transformADT(adt)
+          transformedADTs += ((id, newADT))
+        }
+      }
+
+      override def transform(id: Identifier): Identifier = {
+        addRenaming(id)
+        exploreFunDef(id)
+        exploreADT(id)
+        renaming(id)
+      }
+    }
+
+    val newVCBody = idTransformer.transform(vc.condition)
+
+    val newFundefs = syms.functions.values.map { fd => 
+      // explore again in case this FunDef was not explored during the transformation of vc
+      idTransformer.exploreFunDef(fd.id)         
+      transformedFunctions(fd.id)
+    }
+
+    val newADTs = syms.adts.values.map { adt =>
+      // explore again in case this ADT was not explored during the transformation of vc
+      idTransformer.exploreADT(adt.id)
+      transformedADTs(adt.id)
+    }
+    val newSyms = NoSymbols.withFunctions(newFundefs.toSeq).withADTs(newADTs.toSeq)
+
+    (newSyms, newVCBody)
+  }
+}
+
+
+object Canonization {
+  def canonize(trs: stainless.ast.Trees)
+              (p: inox.Program { val trees: trs.type }, vc: verification.VC[trs.type]): 
+                (p.trees.Symbols, trs.Expr)  = {
+    object canonizer extends Canonization {
+      override val trees: p.trees.type = p.trees
+    }
+
+    val (newSymbols, newVCBody) = canonizer.transform(p.symbols, vc)
+
+    (newSymbols, newVCBody)
+  }
+}

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -11,7 +11,7 @@ import java.io.FileOutputStream
 
 import inox.solvers.SolverFactory
 
-object DebugSectionCache extends inox.DebugSection("vccache")
+object DebugSectionCacheHit extends inox.DebugSection("cachehit")
 object DebugSectionCacheMiss extends inox.DebugSection("cachemiss")
 
 class AppendingObjectOutputStream(os: java.io.OutputStream) extends ObjectOutputStream(os) {
@@ -31,17 +31,21 @@ trait VerificationCache extends VerificationChecker { self =>
   override def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }) = {
     import VerificationCache._
 
+    ctx.reporter.info(s" - Checking cache: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
+
     val canonic = transformers.Canonization.canonize(program)(vc)
 
     if (VerificationCache.contains(program.trees)(canonic)) {
       ctx.reporter.synchronized {
-        ctx.reporter.debug("The following VC has already been verified:")(DebugSectionCache)
-        ctx.reporter.debug(vc.condition)(DebugSectionCache)
-        ctx.reporter.debug("--------------")(DebugSectionCache)
+        ctx.reporter.info(s"Cache hit: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
+        ctx.reporter.debug("The following VC has already been verified:")(DebugSectionCacheHit)
+        ctx.reporter.debug(vc.condition)(DebugSectionCacheHit)
+        ctx.reporter.debug("--------------")(DebugSectionCacheHit)
       }
       VCResult(VCStatus.ValidFromCache, None, Some(0))
     } else {
       ctx.reporter.synchronized {
+        ctx.reporter.info(s"Cache miss: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
         ctx.reporter.debug("Cache miss for VC")(DebugSectionCacheMiss)
         ctx.reporter.debug(vc.condition)(DebugSectionCacheMiss)
         ctx.reporter.debug("Canonical form:")(DebugSectionCacheMiss)

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -37,9 +37,9 @@ trait VerificationCache extends VerificationChecker { self =>
       val symbols = program.symbols
       val ctx = program.ctx
     }
-    val canonic = transformers.Canonization.canonize(p.trees)(p, vc)
+    val canonic = transformers.Canonization.canonize(p, vc)
 
-    if (VerificationCache.contains(p.trees)(canonic)) {
+    if (VerificationCache.contains(program.trees)(canonic)) {
       ctx.reporter.synchronized {
         ctx.reporter.debug("The following VC has already been verified:")(DebugSectionCache)
         ctx.reporter.debug(vc.condition)(DebugSectionCache)
@@ -51,13 +51,13 @@ trait VerificationCache extends VerificationChecker { self =>
         ctx.reporter.debug("Cache miss for VC")(DebugSectionCacheMiss)
         ctx.reporter.debug(vc.condition)(DebugSectionCacheMiss)
         ctx.reporter.debug("Canonical form:")(DebugSectionCacheMiss)
-        ctx.reporter.debug(serialize(p.trees)(canonic))(DebugSectionCacheMiss)
+        ctx.reporter.debug(serialize(program.trees)(canonic))(DebugSectionCacheMiss)
         ctx.reporter.debug("--------------")(DebugSectionCacheMiss)
       }
       val result = super.checkVC(vc,sf)
       if (result.isValid) {
-        VerificationCache.add(p.trees)(canonic)
-        VerificationCache.persist(p.trees)(canonic, vc.toString, ctx)
+        VerificationCache.add(program.trees)(canonic)
+        VerificationCache.persist(program.trees)(canonic, vc.toString, ctx)
       }
       result
     }

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -86,8 +86,10 @@ trait VerificationCache extends VerificationChecker { self =>
         ctx.reporter.debug("--------------")(DebugSectionCacheMiss)
       }
       val result = super.checkVC(vc,sf)
-      VerificationCache.add(sp.trees)(canonic)
-      VerificationCache.persist(sp.trees)(canonic, vc.toString, ctx)
+      if (result.isValid) {
+        VerificationCache.add(sp.trees)(canonic)
+        VerificationCache.persist(sp.trees)(canonic, vc.toString, ctx)
+      }
       result
     }
   }

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -37,8 +37,8 @@ trait VerificationCache extends VerificationChecker { self =>
       val symbols = program.symbols
       val ctx = program.ctx
     }
-
     val canonic = transformers.Canonization.canonize(p.trees)(p, vc)
+
     if (VerificationCache.contains(p.trees)(canonic)) {
       ctx.reporter.synchronized {
         ctx.reporter.debug("The following VC has already been verified:")(DebugSectionCache)
@@ -48,7 +48,9 @@ trait VerificationCache extends VerificationChecker { self =>
       VCResult(VCStatus.Valid, None, Some(0))
     } else {
       ctx.reporter.synchronized {
-        ctx.reporter.debug("Cache miss:")(DebugSectionCacheMiss)
+        ctx.reporter.debug("Cache miss for VC")(DebugSectionCacheMiss)
+        ctx.reporter.debug(vc.condition)(DebugSectionCacheMiss)
+        ctx.reporter.debug("Canonical form:")(DebugSectionCacheMiss)
         ctx.reporter.debug(serialize(p.trees)(canonic))(DebugSectionCacheMiss)
         ctx.reporter.debug("--------------")(DebugSectionCacheMiss)
       }
@@ -88,7 +90,7 @@ object VerificationCache {
     * The functions and ADTs representations are sorted to avoid non-determinism
     */
   def serialize(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr)): String = {
-    val uniq = new tt.PrinterOptions(printUniqueIds = true)
+    val uniq = new tt.PrinterOptions(printUniqueIds = true, printTypes = true, symbols = Some(p._1))
     p._1.functions.values.map(fd => fd.asString(uniq)).toList.sorted.mkString("\n\n") + 
     "\n#\n" + 
     p._1.adts.values.map(adt => adt.asString(uniq)).toList.sorted.mkString("\n\n") + 

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -52,10 +52,10 @@ trait VerificationCache extends VerificationChecker { self =>
         ctx.reporter.debug(serialize(p.trees)(canonic))(DebugSectionCacheMiss)
         ctx.reporter.debug("--------------")(DebugSectionCacheMiss)
       }
-      val result = inox.Bench.time("checking VC from scratch", super.checkVC(vc,sf))
+      val result = super.checkVC(vc,sf)
       if (result.isValid) {
         VerificationCache.add(p.trees)(canonic)
-        VerificationCache.addVCToPersistentCache(p.trees)(canonic, vc.toString, ctx)
+        VerificationCache.persist(p.trees)(canonic, vc.toString, ctx)
       }
       result
     }

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -31,7 +31,9 @@ trait VerificationCache extends VerificationChecker { self =>
   override def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }) = {
     import VerificationCache._
 
-    ctx.reporter.info(s" - Checking cache: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
+    ctx.reporter.synchronized {
+      ctx.reporter.info(s" - Checking cache: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
+    }
 
     val canonic = transformers.Canonization.canonize(program)(vc)
 

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -31,13 +31,7 @@ trait VerificationCache extends VerificationChecker { self =>
   override def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }) = {
     import VerificationCache._
 
-    // FIXME: can we simplify this?
-    val p: inox.Program { val trees: program.trees.type } = new inox.Program {
-      val trees: program.trees.type = program.trees
-      val symbols = program.symbols
-      val ctx = program.ctx
-    }
-    val canonic = transformers.Canonization.canonize(p, vc)
+    val canonic = transformers.Canonization.canonize(program)(vc)
 
     if (VerificationCache.contains(program.trees)(canonic)) {
       ctx.reporter.synchronized {

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -102,13 +102,13 @@ object VerificationCache {
     * Creates a task that adds a VC (and its dependencies) to the cache file
     */
   def persist(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr), descr: String, ctx: inox.Context): Unit = {
-
     val task = new java.util.concurrent.Callable[String] {
       override def call(): String = {
+        val s = serialize(tt)(p)
         VerificationCache.synchronized {
-          oos.writeObject(serialize(tt)(p))
-          descr
+          oos.writeObject(s)
         }
+        descr
       }
     }
     MainHelpers.executor.submit(task)

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -39,7 +39,7 @@ trait VerificationCache extends VerificationChecker { self =>
         ctx.reporter.debug(vc.condition)(DebugSectionCache)
         ctx.reporter.debug("--------------")(DebugSectionCache)
       }
-      VCResult(VCStatus.Valid, None, Some(0))
+      VCResult(VCStatus.ValidFromCache, None, Some(0))
     } else {
       ctx.reporter.synchronized {
         ctx.reporter.debug("Cache miss for VC")(DebugSectionCacheMiss)

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -1,0 +1,158 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package verification
+
+
+import java.io.ObjectInputStream
+import java.io.FileInputStream
+import java.io.ObjectOutputStream
+import java.io.FileOutputStream
+
+import inox.solvers.SolverFactory
+
+object DebugSectionCache extends inox.DebugSection("vccache")
+object DebugSectionCacheMiss extends inox.DebugSection("cachemiss")
+
+class AppendingObjectOutputStream(os: java.io.OutputStream) extends ObjectOutputStream(os) {
+  override protected def writeStreamHeader() = {
+    reset()
+  }
+}
+
+trait VerificationCache extends VerificationChecker { self =>
+
+  import program._
+  import program.symbols._
+  import program.trees._
+
+  type SubProgram = inox.Program { val trees: program.trees.type }
+
+  val uniq = new PrinterOptions(printUniqueIds = true)
+
+  def buildDependencies(vc: VC): SubProgram = {
+
+    var adts = Set[ADTDefinition]()
+    var fundefs = Set[FunDef]()
+    var traversed = Set[Identifier]()
+
+    val traverser = new TreeTraverser {
+      override def traverse(id: Identifier): Unit = {
+        if (!traversed.contains(id)) {
+          traversed += id
+          if (program.symbols.functions.contains(id)) {
+            val fd = program.symbols.functions(id)
+            fundefs += fd
+            traverse(fd)
+          }
+          else if (program.symbols.adts.contains(id)) {
+            val adtdef = program.symbols.adts(id)
+            adts += adtdef
+            fundefs ++= adtdef.invariant
+            traverse(adtdef)
+            adtdef.invariant foreach traverse
+          }
+        }
+      }
+    }
+
+    traverser.traverse(vc.condition)
+
+    new inox.Program {
+      val trees: program.trees.type = program.trees
+      val symbols = NoSymbols.withFunctions(fundefs.toSeq).withADTs(adts.toSeq)
+      val ctx = program.ctx
+    }
+  }
+
+  override def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }) = {
+    import VerificationCache._
+
+    val sp: SubProgram = buildDependencies(vc)
+    val canonic = transformers.Canonization.canonize(sp.trees)(sp, vc)
+    if (VerificationCache.contains(sp.trees)(canonic)) {
+      ctx.reporter.synchronized {
+        ctx.reporter.debug("The following VC has already been verified:")(DebugSectionCache)
+        ctx.reporter.debug(vc.condition)(DebugSectionCache)
+        ctx.reporter.debug("--------------")(DebugSectionCache)
+      }
+      VCResult(VCStatus.Valid, None, Some(0))
+    }
+    else {
+      ctx.reporter.synchronized {
+        ctx.reporter.debug("Cache miss:")(DebugSectionCacheMiss)
+        ctx.reporter.debug(serialize(sp.trees)(canonic))(DebugSectionCacheMiss)
+        ctx.reporter.debug("--------------")(DebugSectionCacheMiss)
+      }
+      val result = super.checkVC(vc,sf)
+      VerificationCache.add(sp.trees)(canonic)
+      VerificationCache.addVCToPersistentCache(sp.trees)(canonic, vc.toString, ctx)
+      result
+    }
+  }
+
+}
+
+object VerificationCache {
+  val cacheFile = ".vccache.bin"
+  var vccache = scala.collection.concurrent.TrieMap[String,Unit]()
+  VerificationCache.loadPersistentCache()
+  
+  // output stream used to save verified VCs 
+  val oos = if (new java.io.File(cacheFile).exists) {
+    new AppendingObjectOutputStream(new FileOutputStream(cacheFile, true))
+  } else {
+    new ObjectOutputStream(new FileOutputStream(cacheFile))
+  }
+    
+  def contains(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr)) = {
+    vccache.contains(serialize(tt)(p))
+  }
+    
+  def add(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr)) = {
+    vccache += ((serialize(tt)(p), ()))
+  }
+
+  /**
+    * Transforms the dependencies of a VC and a VC to a String
+    * The functions and ADTs representations are sorted to avoid non-determinism
+    */
+  def serialize(tt: inox.ast.Trees)(p: (tt. Symbols, tt. Expr)): String = {
+    val uniq = new tt.PrinterOptions(printUniqueIds = true)
+    p._1.functions.values.map(fd => fd.asString(uniq)).toList.sorted.mkString("\n\n") + 
+    "\n#\n" + 
+    p._1.adts.values.map(adt => adt.asString(uniq)).toList.sorted.mkString("\n\n") + 
+    "\n#\n" + 
+    p._2.asString(uniq)
+  }
+
+  def addVCToPersistentCache(tt: inox.ast.Trees)(p: (tt. Symbols, tt. Expr), descr: String, ctx: inox.Context): Unit = {
+
+    val task = new java.util.concurrent.Callable[String] {
+      override def call(): String = {
+        MainHelpers.synchronized {
+          oos.writeObject(serialize(tt)(p))
+          descr
+        }
+      }
+    }
+    MainHelpers.executor.submit(task)
+  }
+  
+  def loadPersistentCache(): Unit = {
+    if (new java.io.File(cacheFile).exists) {
+      MainHelpers.synchronized {
+        val ois = new ObjectInputStream(new FileInputStream(cacheFile))
+        try {
+          while (true) {
+            val s = ois.readObject.asInstanceOf[String]
+            vccache += ((s, ()))
+          }
+        } catch {
+          case e: java.io.EOFException => ois.close()
+        }
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -167,17 +167,17 @@ object VerificationChecker {
 
     val vccache = opts.findOptionOrDefault(optVCCache)
 
-    trait checkerInterface extends VerificationChecker {
+    trait CheckerInterface extends VerificationChecker {
       val program: p.type = p
       val options = opts
 
       protected def getFactory = solvers.SolverFactory.apply(p, opts)
     }
-    object checker extends checkerInterface
-    object cacheChecker extends checkerInterface with VerificationCache
+    object Checker extends CheckerInterface
+    object CacheChecker extends CheckerInterface with VerificationCache
 
-    if (vccache) cacheChecker.verify(vcs)
-    else checker.verify(vcs)
+    if (vccache) CacheChecker.verify(vcs)
+    else Checker.verify(vcs)
   }
 
   def verify(p: StainlessProgram)(vcs: Seq[VC[p.trees.type]]): Map[VC[p.trees.type], VCResult[p.Model]] = {

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -95,7 +95,7 @@ trait VerificationChecker { self =>
     try {
       val cond = simplifyLets(vc.condition)
       ctx.reporter.synchronized {
-        ctx.reporter.info(s" - Now considering '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
+        ctx.reporter.info(s" - Now solving '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
         ctx.reporter.debug(cond.asString)
         ctx.reporter.debug("Solving with: " + s.name)
       }

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -8,6 +8,8 @@ import inox.solvers._
 // TODO this should probably be removed as it is superseded by the flexible pipeline...
 object optParallelVCs extends inox.FlagOptionDef("parallelvcs", false)
 object optFailEarly extends inox.FlagOptionDef("failearly", false)
+object optFailInvalid extends inox.FlagOptionDef("failinvalid", false)
+object optVCCache extends inox.FlagOptionDef("vccache", false)
 
 object DebugSectionVerification extends inox.DebugSection("verification")
 
@@ -17,11 +19,11 @@ trait VerificationChecker { self =>
 
   private lazy val parallelCheck = options.findOptionOrDefault(optParallelVCs)
   private lazy val failEarly = options.findOptionOrDefault(optFailEarly)
+  private lazy val failInvalid = options.findOptionOrDefault(optFailInvalid)
 
   import program._
   import program.trees._
   import program.symbols._
-  import CallGraphOrderings._
 
   implicit val debugSection = DebugSectionVerification
 
@@ -33,48 +35,29 @@ trait VerificationChecker { self =>
   type VCResult = verification.VCResult[program.Model]
   val VCResult = verification.VCResult
 
-  protected def getTactic(fd: FunDef): Tactic { val program: self.program.type }
   protected def getFactory: SolverFactory {
     val program: self.program.type
     type S <: inox.solvers.combinators.TimeoutSolver { val program: self.program.type }
   }
 
-  private def defaultStop(res: VCResult): Boolean = if (failEarly) res.status != VCStatus.Valid else false
+  protected def defaultStop(res: VCResult): Boolean = {
+    if (failEarly) !res.isValid
+    else if (failInvalid) res.isInvalid
+    else false
+  }
 
-  def verify(funs: Seq[Identifier], stopWhen: VCResult => Boolean = defaultStop): Map[VC, VCResult] = {
+  def verify(vcs: Seq[VC], stopWhen: VCResult => Boolean = defaultStop): Map[VC, VCResult] = {
     val sf = ctx.options.findOption(inox.optTimeout) match {
       case Some(to) => getFactory.withTimeout(to)
       case None => getFactory
     }
 
     try {
-      ctx.reporter.debug("Generating Verification Conditions...")
-      val vcs = generateVCs(funs)
-
       ctx.reporter.debug("Checking Verification Conditions...")
       checkVCs(vcs, sf, stopWhen)
     } finally {
       sf.shutdown()
     }
-  }
-
-  def generateVCs(funs: Seq[Identifier]): Seq[VC] = {
-    val vcs: Seq[VC] = (for (id <- funs) yield {
-      val fd = getFunction(id)
-      val tactic = getTactic(fd)
-
-      if (fd.body.isDefined) {
-        tactic.generateVCs(id)
-      } else {
-        Nil
-      }
-    }).flatten
-
-    vcs.sortBy(vc => (getFunction(vc.fd),
-      if (vc.kind.underlying == VCKind.Precondition) 0
-      else if (vc.kind.underlying == VCKind.Assert) 1
-      else 2
-    ))
   }
 
   private lazy val unknownResult: VCResult = VCResult(VCStatus.Unknown, None, None)
@@ -105,7 +88,7 @@ trait VerificationChecker { self =>
     initMap ++ results
   }
 
-  private def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }): VCResult = {
+  protected def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }): VCResult = {
     import SolverResponses._
     val s = sf.getNewSolver
 
@@ -178,29 +161,26 @@ trait VerificationChecker { self =>
 }
 
 object VerificationChecker {
+
   def verify(p: StainlessProgram, opts: inox.Options)
-            (funs: Seq[Identifier]): Map[VC[p.trees.type], VCResult[p.Model]] = {
-    object checker extends VerificationChecker {
+            (vcs: Seq[VC[p.trees.type]]): Map[VC[p.trees.type], VCResult[p.Model]] = {
+
+    val vccache = opts.findOptionOrDefault(optVCCache)
+
+    trait checkerInterface extends VerificationChecker {
       val program: p.type = p
       val options = opts
 
-      val defaultTactic = DefaultTactic(p)
-      val inductionTactic = InductionTactic(p)
-
-      protected def getTactic(fd: p.trees.FunDef) =
-        if (fd.flags contains "induct") {
-          inductionTactic
-        } else {
-          defaultTactic
-        }
-
       protected def getFactory = solvers.SolverFactory.apply(p, opts)
     }
+    object checker extends checkerInterface
+    object cacheChecker extends checkerInterface with VerificationCache
 
-    checker.verify(funs)
+    if (vccache) cacheChecker.verify(vcs)
+    else checker.verify(vcs)
   }
 
-  def verify(p: StainlessProgram)(funs: Seq[Identifier]): Map[VC[p.trees.type], VCResult[p.Model]] = {
-    verify(p, p.ctx.options)(funs)
+  def verify(p: StainlessProgram)(vcs: Seq[VC[p.trees.type]]): Map[VC[p.trees.type], VCResult[p.Model]] = {
+    verify(p, p.ctx.options)(vcs)
   }
 }

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -46,6 +46,7 @@ object VerificationComponent extends SimpleComponent {
     lazy val totalConditions: Int = vrs.size
     lazy val totalTime = vrs.map(_._2.time.getOrElse(0l)).sum
     lazy val totalValid = vrs.count(_._2.isValid)
+    lazy val totalValidFromCache = vrs.count(_._2.isValidFromCache)
     lazy val totalInvalid = vrs.count(_._2.isInvalid)
     lazy val totalUnknown = vrs.count(_._2.isInconclusive)
 
@@ -64,7 +65,7 @@ object VerificationComponent extends SimpleComponent {
           Cell(vr.time.map(t => f"${t / 1000d}%3.3f").getOrElse(""))
         ))
       },
-      ReportStats(totalConditions, totalTime, totalValid, totalInvalid, totalUnknown)
+      ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
     ))
 
     override def emitJson: JArray = {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -104,7 +104,9 @@ object VerificationComponent extends SimpleComponent {
       }
     }
 
-    VerificationChecker.verify(encoder.targetProgram)(funs).mapValues {
+    val vcs = VerificationGenerator.gen(encoder.targetProgram)(funs)
+
+    VerificationChecker.verify(encoder.targetProgram)(vcs).mapValues {
       case VCResult(VCStatus.Invalid(model), s, t) =>
         VCResult(VCStatus.Invalid(model.encode(encoder.reverse)), s, t)
       case res => res.asInstanceOf[VCResult[p.Model]]
@@ -113,7 +115,7 @@ object VerificationComponent extends SimpleComponent {
 
   def apply(funs: Seq[Identifier], p: StainlessProgram): VerificationReport = {
     val res = check(funs, p)
-
+    
     new VerificationReport {
       val program: p.type = p
       val results = res

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -43,6 +43,7 @@ sealed abstract class VCStatus[+Model](val name: String) {
 object VCStatus {
   case class Invalid[+Model](cex: Model) extends VCStatus[Model]("invalid")
   case object Valid extends VCStatus[Nothing]("valid")
+  case object ValidFromCache extends VCStatus[Nothing]("valid from cache")
   case object Unknown extends VCStatus[Nothing]("unknown")
   case object Timeout extends VCStatus[Nothing]("timeout")
   case object Cancelled extends VCStatus[Nothing]("cancelled")
@@ -55,8 +56,9 @@ case class VCResult[+Model](
   solver: Option[Solver],
   time: Option[Long]
 ) {
-  def isValid   = status == VCStatus.Valid
-  def isInvalid = status.isInstanceOf[VCStatus.Invalid[_]]
-  def isInconclusive = !isValid && !isInvalid
+  def isValid           = status == VCStatus.Valid || isValidFromCache
+  def isValidFromCache  = status == VCStatus.ValidFromCache
+  def isInvalid         = status.isInstanceOf[VCStatus.Invalid[_]]
+  def isInconclusive    = !isValid && !isInvalid
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationGenerator.scala
+++ b/core/src/main/scala/stainless/verification/VerificationGenerator.scala
@@ -1,0 +1,59 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package verification
+
+trait VerificationGenerator { self =>
+  val program: Program
+
+  import program._
+  import program.symbols._
+  import program.trees._
+  import CallGraphOrderings._
+
+  type VC = verification.VC[program.trees.type]
+
+  protected def getTactic(fd: FunDef): Tactic { val program: self.program.type }
+
+
+  def generateVCs(funs: Seq[Identifier]): Seq[VC] = {
+    val vcs: Seq[VC] = (for (id <- funs) yield {
+      val fd = getFunction(id)
+      val tactic = getTactic(fd)
+
+      if (fd.body.isDefined) {
+        tactic.generateVCs(id)
+      } else {
+        Nil
+      }
+    }).flatten
+
+    vcs.sortBy(vc => (getFunction(vc.fd),
+      if (vc.kind.underlying == VCKind.Precondition) 0
+      else if (vc.kind.underlying == VCKind.Assert) 1
+      else 2
+    ))
+  }
+
+}
+
+object VerificationGenerator {
+
+  def gen(p: StainlessProgram)(funs: Seq[Identifier]): Seq[VC[p.trees.type]] = {
+    object generator extends VerificationGenerator {
+      val program: p.type = p
+
+      val defaultTactic = DefaultTactic(p)
+      val inductionTactic = InductionTactic(p)
+
+      protected def getTactic(fd: p.trees.FunDef) =
+        if (fd.flags contains "induct") {
+          inductionTactic
+        } else {
+          defaultTactic
+        }
+    }
+    generator.generateVCs(funs)
+  }
+
+}


### PR DESCRIPTION
This commit adds a verification cache to store VCs which have already been verified.
The cache is implemented in VerificationCache.scala, and extends the VerificationChecker trait.

Each VC is stored with its dependencies (a Program) as a String in the global `vccache` map.
The cache is also saved on disk in the file `.vccache.bin`, which is loaded at startup.

The dependencies are built with `buildDependencies` using a tree traversal.
The program is then transformed in canonical form, in the file Canonization.scala, using a tree 
transformer. The transformation starts by transforming the VC (by renaming all identifiers to `x`
and changing the global id to a new identifier, local to this transformation). It then transforms the 
function and ADT definitions encountered along the way.

I still need to add some documentation, and investigate why there are still some cache misses.
This pull request depends on https://github.com/epfl-lara/inox/pull/35 and https://github.com/epfl-lara/inox/pull/36.
