### PR TITLE
Persistent cache

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -71,7 +71,9 @@ lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
     "ch.epfl.lara" %% "inox" % inoxVersion % "test" classifier "tests",
     "ch.epfl.lara" %% "cafebabe" % "1.2",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-    "org.json4s" %% "json4s-native" % "3.5.2"
+    "io.circe" %% "circe-core" % "0.8.0",
+    "io.circe" %% "circe-generic" % "0.8.0",
+    "io.circe" %% "circe-parser" % "0.8.0"
   ),
 
   concurrentRestrictions in Global += Tags.limit(Tags.Test, nParallel),

--- a/core/src/main/scala/stainless/Analysis.scala
+++ b/core/src/main/scala/stainless/Analysis.scala
@@ -1,0 +1,19 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+
+/**
+ * Analyses hold all the information about a [[SimpleComponent]] results.
+ *
+ * They can be converted to basic, text-only report, which can be easily serialized or displayed to the user,
+ * or they can be used, when their concrete type is known, to explore in detail the results of components,
+ * such as the source program itself.
+ */
+trait AbstractAnalysis {
+  val name: String
+
+  type Report <: AbstractReport[Report]
+
+  def toReport: Report
+}
+

--- a/core/src/main/scala/stainless/Analysis.scala
+++ b/core/src/main/scala/stainless/Analysis.scala
@@ -3,7 +3,7 @@
 package stainless
 
 /**
- * Analyses hold all the information about a [[SimpleComponent]] results.
+ * Analyses hold all the information about a [[Component]] results.
  *
  * They can be converted to basic, text-only report, which can be easily serialized or displayed to the user,
  * or they can be used, when their concrete type is known, to explore in detail the results of components,

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -9,7 +9,7 @@ trait Component {
   val name: String
   val description: String
 
-  type Report <: AbstractReport
+  type Report <: AbstractReport[Report]
 
   val lowering: inox.ast.SymbolTransformer {
     val s: extraction.trees.type

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -9,7 +9,7 @@ trait Component {
   val name: String
   val description: String
 
-  type Report <: AbstractReport[Report]
+  type Analysis <: AbstractAnalysis
 
   val lowering: inox.ast.SymbolTransformer {
     val s: extraction.trees.type
@@ -26,7 +26,6 @@ object optFunctions extends inox.OptionDef[Seq[String]] {
 
 trait SimpleComponent extends Component { self =>
   val trees: ast.Trees
-  import trees._
 
   def extract(program: Program { val trees: xt.type }, ctx: inox.Context): Program { val trees: self.trees.type } = {
     val checker = inox.ast.SymbolTransformer(new extraction.CheckingTransformer {
@@ -44,7 +43,7 @@ trait SimpleComponent extends Component { self =>
   private val marks = new utils.AtomicMarks[Identifier]
   def onCycleBegin(): Unit = marks.clear()
 
-  def apply(program: Program { val trees: xt.type }, ctx: inox.Context): Report = {
+  def apply(program: Program { val trees: xt.type }, ctx: inox.Context): Analysis = {
     val extracted = extract(program, ctx)
     import extracted._
 
@@ -56,6 +55,6 @@ trait SimpleComponent extends Component { self =>
     apply(relevant, extracted, ctx)
   }
 
-  def apply(functions: Seq[Identifier], program: Program { val trees: self.trees.type }, ctx: inox.Context): Report
+  def apply(functions: Seq[Identifier], program: Program { val trees: self.trees.type }, ctx: inox.Context): Analysis
 }
 

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -54,7 +54,8 @@ trait MainHelpers extends inox.MainHelpers {
     extraction.inlining.optInlinePosts -> Description(General, "Inline postconditions at call-sites"),
     termination.optIgnorePosts -> Description(Termination, "Ignore existing postconditions during strengthening"),
     optJson -> Description(General, "Output verification and termination reports to a JSON file"),
-    optWatch -> Description(General, "Re-run stainless upon file changes")
+    optWatch -> Description(General, "Re-run stainless upon file changes"),
+    frontend.optPersistentRegistryCache -> Description(General, "Load/save program verification status on disk")
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)
     option -> Description(Pipelines, component.description)

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -55,7 +55,7 @@ trait MainHelpers extends inox.MainHelpers {
     termination.optIgnorePosts -> Description(Termination, "Ignore existing postconditions during strengthening"),
     optJson -> Description(General, "Output verification and termination reports to a JSON file"),
     optWatch -> Description(General, "Re-run stainless upon file changes"),
-    frontend.optPersistentRegistryCache -> Description(General, "Enable caching of program extraction"),
+    frontend.optPersistentCache -> Description(General, "Enable caching of program extraction & analysis"),
     utils.Caches.optCacheDir -> Description(General, "Specify the directory in which cache files should be stored")
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -55,7 +55,8 @@ trait MainHelpers extends inox.MainHelpers {
     termination.optIgnorePosts -> Description(Termination, "Ignore existing postconditions during strengthening"),
     optJson -> Description(General, "Output verification and termination reports to a JSON file"),
     optWatch -> Description(General, "Re-run stainless upon file changes"),
-    frontend.optPersistentRegistryCache -> Description(General, "Load/save program verification status on disk")
+    frontend.optPersistentRegistryCache -> Description(General, "Enable caching of program extraction"),
+    utils.Caches.optCacheDir -> Description(General, "Specify the directory in which cache files should be stored")
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)
     option -> Description(Pipelines, component.description)

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -69,7 +69,8 @@ trait MainHelpers extends inox.MainHelpers {
     verification.DebugSectionCacheMiss,
     termination.DebugSectionTermination,
     DebugSectionExtraction,
-    frontend.DebugSectionFrontend
+    frontend.DebugSectionFrontend,
+    utils.DebugSectionRegistry
   )
 
   override protected def displayVersion(reporter: inox.Reporter): Unit = {

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -7,8 +7,7 @@ import utils.JsonUtils
 import java.io.File
 import java.util.concurrent.{ ExecutorService, Executors }
 
-import org.json4s.JsonAST.JObject
-import org.json4s.JsonDSL._
+import io.circe.Json
 
 object MainHelpers {
 
@@ -133,8 +132,7 @@ trait MainHelpers extends inox.MainHelpers {
 
   /** Exports the reports to the given file in JSON format. */
   private def exportJson(reports: Seq[AbstractReport[_]], file: String): Unit = {
-    val subs = reports map { r => JObject(r.name -> r.emitJson) }
-    val json = if (subs.isEmpty) JObject() else subs reduce { _ ~ _ }
+    val json = Json.fromFields(reports map { r => (r.name -> r.emitJson) })
     JsonUtils.writeFile(new File(file), json)
   }
 

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -2,12 +2,13 @@
 
 package stainless
 
-import java.io.{ File, PrintWriter }
+import utils.JsonUtils
+
+import java.io.File
 import java.util.concurrent.{ ExecutorService, Executors }
 
 import org.json4s.JsonAST.JObject
 import org.json4s.JsonDSL._
-import org.json4s.native.JsonMethods._
 
 object MainHelpers {
 
@@ -134,9 +135,7 @@ trait MainHelpers extends inox.MainHelpers {
   private def exportJson(reports: Seq[AbstractReport[_]], file: String): Unit = {
     val subs = reports map { r => JObject(r.name -> r.emitJson) }
     val json = if (subs.isEmpty) JObject() else subs reduce { _ ~ _ }
-    val string = pretty(render(json))
-    val pw = new PrintWriter(new File(file))
-    try pw.write(string) finally pw.close()
+    JsonUtils.writeFile(new File(file), json)
   }
 
 }

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -63,23 +63,22 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
 }
 
 object AbstractReportHelper {
-  type Record = { val fid: Identifier }
-  import scala.language.reflectiveCalls
+  trait Record { val id: Identifier }
 
   /**
-   * Keep records which `fid` is present in [[ids]], and returns the next generation counter.
+   * Keep records which `id` are present in [[ids]], and returns the next generation counter.
    */
   def filter[R <: Record](records: Seq[R], ids: Set[Identifier], lastGen: Long): (Seq[R], Long) =
-    (records filter { ids contains _.fid }, lastGen + 1)
+    (records filter { ids contains _.id }, lastGen + 1)
 
   /**
    * Merge two sets of records [[R]] into one, and returns the next generation counter.
    *
-   * Records in [[prevs]] which have the same `fid` as the ones in [[news]] are removed.
+   * Records in [[prevs]] which have the same `id` as the ones in [[news]] are removed.
    * The [[updater0]] function takes as first parameter the next generation counter.
    */
   def merge[R <: Record](prevs: Seq[R], news: Seq[R], lastGen: Long, updater0: Long => R => R): (Seq[R], Long) = {
-    def buildMapping(subs: Seq[R]): Map[Identifier, Seq[R]] = subs groupBy { _.fid }
+    def buildMapping(subs: Seq[R]): Map[Identifier, Seq[R]] = subs groupBy { _.id }
 
     val prev = buildMapping(prevs)
     val next0 = buildMapping(news)

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -31,8 +31,8 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
 
   def emitJson: Json
 
-  /** Create a new report without information about the given functions/classes/.... */
-  def invalidate(ids: Seq[Identifier]): SelfType
+  /** Create a new report with *only* the information about the given functions/classes/... */
+  def filter(ids: Set[Identifier]): SelfType
 
   /** Merge two reports, considering [[other]] to contain the last information in case of update. */
   def ~(other: SelfType): SelfType
@@ -66,7 +66,7 @@ class NoReport extends AbstractReport[NoReport] { // can't do this CRTP with obj
   override val name = "no-report"
   override def emitJson = Json.arr()
   override def emitRowsAndStats = None
-  override def invalidate(ids: Seq[Identifier]) = this
+  override def filter(ids: Set[Identifier]) = this
   override def ~(other: NoReport) = this
 }
 

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -3,7 +3,7 @@
 package stainless
 
 import inox.utils.ASCIIHelpers._
-import org.json4s.JsonAST.JArray
+import io.circe.Json
 
 case class ReportStats(total: Int, time: Long, valid: Int, validFromCache: Int, invalid: Int, unknown: Int) {
   def +(more: ReportStats) = ReportStats(
@@ -29,7 +29,7 @@ case class ReportStats(total: Int, time: Long, valid: Int, validFromCache: Int, 
 trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
   val name: String // The same name as the [[AbstractAnalysis]] this report was derived from.
 
-  def emitJson: JArray
+  def emitJson: Json
 
   /** Create a new report without information about the given functions/classes/.... */
   def invalidate(ids: Seq[Identifier]): SelfType
@@ -64,7 +64,7 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
 
 class NoReport extends AbstractReport[NoReport] { // can't do this CRTP with object...
   override val name = "no-report"
-  override def emitJson = JArray(Nil)
+  override def emitJson = Json.arr()
   override def emitRowsAndStats = None
   override def invalidate(ids: Seq[Identifier]) = this
   override def ~(other: NoReport) = this

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -26,7 +26,7 @@ case class ReportStats(total: Int, time: Long, valid: Int, validFromCache: Int, 
  * [[SelfType]] is used for typechecking purposed: it should denote the subclass itself. E.g.:
  * class SpecificReport extends AbstractReport[SpecificReport] { /* ... */ }
  */
-trait AbstractReport[SelfType <: AbstractReport[_]] { self =>
+trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
   val name: String // The same name as the [[AbstractAnalysis]] this report was derived from.
 
   def emitJson: JArray

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -34,9 +34,8 @@ trait AbstractReport[SelfType <: AbstractReport[_]] { self =>
     case Some(t) => ctx.reporter.info(t.render)
   }
 
-  protected val width: Int
-
   private def emitTable: Option[Table] = emitRowsAndStats map { case (rows, stats) =>
+    val width = if (rows.isEmpty) 1 else rows.head.cellsSize // all rows must have the same size
     var t = Table(s"$name summary")
     t ++= rows
     t += Separator
@@ -57,7 +56,6 @@ class NoReport extends AbstractReport[NoReport] { // can't do this CRTP with obj
   override val name = "no-report"
   override def emitJson = JArray(Nil)
   override def emitRowsAndStats = None
-  override val width = 0
   override def removeSubreports(ids: Seq[Identifier]) = this
   override def ~(other: NoReport) = this
 }

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -23,7 +23,7 @@ case class ReportStats(total: Int, time: Long, valid: Int, validFromCache: Int, 
  * of the results (through an ASCCI table) and the ability to maintain an up-to-date view of the results
  * by means of concatenation of reports and invalidation of some part of the report itself.
  *
- * [[SelfType]] is used for typechecking purposed: it should denote the subclass itself. E.g.:
+ * [[SelfType]] is used for typechecking purposes: it should denote the subclass itself. E.g.:
  * class SpecificReport extends AbstractReport[SpecificReport] { /* ... */ }
  */
 trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
@@ -34,7 +34,7 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
   /** Create a new report with *only* the information about the given functions/classes/... */
   def filter(ids: Set[Identifier]): SelfType
 
-  /** Merge two reports, considering [[other]] to contain the last information in case of update. */
+  /** Merge two reports, considering [[other]] to contain the latest information in case of update. */
   def ~(other: SelfType): SelfType
 
   protected def emitRowsAndStats: Option[(Seq[Row], ReportStats)]

--- a/core/src/main/scala/stainless/frontend/CallBack.scala
+++ b/core/src/main/scala/stainless/frontend/CallBack.scala
@@ -20,7 +20,7 @@ import extraction.xlang.{ trees => xt }
  * A [[Frontend]] has to [[stop]] or [[join]] its callback at some point between two cycles.
  * A callback cannot be reused after calling [[stop]].
  *
- * Calling [[getReports]] is valid exclusively after [[join]]ing and before the next cycle starts.
+ * Calling [[getReport]] is valid exclusively after [[join]]ing and before the next cycle starts.
  *
  * A callback is expected to be used by only one frontend at a time.
  */
@@ -33,25 +33,5 @@ trait CallBack {
 
   def join(): Unit // Wait until all tasks have finished.
 
-  def getReports: Seq[AbstractReport[_]]
-}
-
-
-/** MasterCallBack: combine several callbacks together. */
-final class MasterCallBack(val callbacks: Seq[CallBack]) extends CallBack {
-  override def beginExtractions(): Unit = callbacks foreach { _.beginExtractions() }
-
-  override def apply(file: String, unit: xt.UnitDef,
-                     classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Unit = {
-    callbacks foreach { c => c(file, unit, classes, functions) }
-  }
-
-  override def endExtractions(): Unit = callbacks foreach { _.endExtractions() }
-
-  override def stop(): Unit = callbacks foreach { _.stop() }
-
-  override def join(): Unit = callbacks foreach { _.join() }
-
-  // Group together reports from the same callback
-  override def getReports: Seq[AbstractReport[_]] = callbacks flatMap { _.getReports }
+  def getReport: Option[AbstractReport[_]]
 }

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -15,7 +15,7 @@ trait CallBackWithRegistry extends CallBack { self =>
 
   /******************* Public Interface: Override CallBack ***************************************/
 
-  final override def beginExtractions(): Unit = { /* nothing */ }
+  override def beginExtractions(): Unit = { /* nothing */ }
 
   final override def apply(file: String, unit: xt.UnitDef,
                            classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Unit = {
@@ -63,8 +63,6 @@ trait CallBackWithRegistry extends CallBack { self =>
   protected def shouldBeChecked(fd: xt.FunDef): Boolean
   protected def shouldBeChecked(cd: xt.ClassDef): Boolean
 
-  /** Mark the end of a callback cycle. */
-  protected def onCycleEnd(): Unit = () // Nothing by default.
 
   /******************* Internal State *************************************************************/
 

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -48,7 +48,7 @@ trait CallBackWithRegistry extends CallBack { self =>
       reporter.debug(s"\tclasses   -> [${removedClassesIds.sorted mkString ", "}]")
 
       registry.remove(removedClasses, removedFuns)
-      if (report != null) report = report.removeSubreports(removedClassesIds ++ removedFunsIds)
+      if (report != null) report = report.invalidate(removedClassesIds ++ removedFunsIds)
     }
 
     // Update our state with the new data, producing new symbols through the registry.

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -78,7 +78,7 @@ trait CallBackWithRegistry extends CallBack { self =>
   }
 
   // See assumption/requirements in [[CallBack]]
-  final override def getReport: Option[Report] = Some(report) filter { _ != null }
+  final override def getReport: Option[Report] = Option(report)
 
 
   /******************* Customisation Points *******************************************************/

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -74,7 +74,7 @@ trait CallBackWithRegistry extends CallBack { self =>
   }
 
   // See assumption/requirements in [[CallBack]]
-  final override def getReports: Seq[Report] = Seq(report) filter { _ != null }
+  final override def getReport: Option[Report] = Some(report) filter { _ != null }
 
 
   /******************* Customisation Points *******************************************************/

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -46,6 +46,7 @@ trait CallBackWithRegistry extends CallBack { self =>
     val symss = registry.checkpoint()
     processSymbols(symss)
 
+    if (report != null) report = report.filter(recentIdentifiers.toSet)
     recentIdentifiers.clear()
   }
 

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -103,26 +103,20 @@ trait CallBackWithRegistry extends CallBack { self =>
 
   /******************* Internal Helpers ***********************************************************/
 
-  private def getCacheDirectory: Option[File] = options findOption optPersistentRegistryCache map { d =>
-    val dir = if (d.isEmpty) optPersistentRegistryCache.default else d
-    new File(dir).getAbsoluteFile
-  }
+  private def getCacheFile: Option[File] =
+    utils.Caches.getCacheFile(context, optPersistentRegistryCache, cacheFilename)
 
   /** Load the registry cache, if specified by the user and available. */
-  private def loadRegistryCache(): Unit = getCacheDirectory foreach { dir =>
-    reporter.debug(s"Loading registry cache from $dir/$cacheFilename")
-    dir.mkdirs()
-    assert(dir.isDirectory)
-    val file = new File(dir, cacheFilename)
+  private def loadRegistryCache(): Unit = getCacheFile foreach { file =>
+    reporter.debug(s"Loading registry cache from $file")
     if (file.isFile()) {
       registry.loadCache(file)
     }
   }
 
   /** Save the registry cache, if specified by the user. */
-  private def saveRegistryCache(): Unit = getCacheDirectory foreach { dir =>
-    reporter.debug(s"Saving registry cache to $dir/$cacheFilename")
-    val file = new File(dir, cacheFilename)
+  private def saveRegistryCache(): Unit = getCacheFile foreach { file =>
+    reporter.debug(s"Saving registry cache to $file")
     registry.saveCache(file)
   }
 

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -114,7 +114,7 @@ trait CallBackWithRegistry extends CallBack { self =>
   /******************* Internal Helpers ***********************************************************/
 
   private def getCacheFile(filename: String): Option[File] =
-    utils.Caches.getCacheFile(context, optPersistentRegistryCache, cacheSubDirectory, filename)
+    utils.Caches.getCacheFile(context, optPersistentCache, cacheSubDirectory, filename)
 
   private def getRegistryCacheFile: Option[File] = getCacheFile("registry.bin")
   private def getReportCacheFile: Option[File] = getCacheFile("report.json")

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -15,8 +15,6 @@ trait CallBackWithRegistry extends CallBack { self =>
 
   /******************* Public Interface: Override CallBack ***************************************/
 
-  override def beginExtractions(): Unit = { /* nothing */ }
-
   final override def apply(file: String, unit: xt.UnitDef,
                            classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Unit = {
     context.reporter.debug(s"Got a unit for $file: ${unit.id} with:")

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -63,6 +63,8 @@ trait CallBackWithRegistry extends CallBack { self =>
   protected def shouldBeChecked(fd: xt.FunDef): Boolean
   protected def shouldBeChecked(cd: xt.ClassDef): Boolean
 
+  /** Mark the end of a callback cycle. */
+  protected def onCycleEnd(): Unit = () // Nothing by default.
 
   /******************* Internal State *************************************************************/
 

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -94,8 +94,8 @@ trait CallBackWithRegistry extends CallBack { self =>
   protected def shouldBeChecked(fd: xt.FunDef): Boolean
   protected def shouldBeChecked(cd: xt.ClassDef): Boolean
 
-  /** Filename of the registry cache under the directory denoted by [[optPersistentCache]]. */
-  protected val cacheFilename: String
+  /** Name of the sub-directory of [[optPersistentCache]] in which the registry cache files are saved. */
+  protected val cacheSubDirectory: String
 
 
   /******************* Internal State *************************************************************/
@@ -121,7 +121,7 @@ trait CallBackWithRegistry extends CallBack { self =>
   /******************* Internal Helpers ***********************************************************/
 
   private def getCacheFile: Option[File] =
-    utils.Caches.getCacheFile(context, optPersistentRegistryCache, cacheFilename)
+    utils.Caches.getCacheFile(context, optPersistentRegistryCache, cacheSubDirectory, "registry.bin")
 
   /** Load the registry cache, if specified by the user and available. */
   private def loadRegistryCache(): Unit = getCacheFile foreach { file =>

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -68,7 +68,7 @@ trait CallBackWithRegistry extends CallBack { self =>
     val newReports = tasks map { _.get } // blocking! TODO is there a more efficient "get all" version?
     val reports = (report +: newReports) filter { _ != null }
     if (reports.nonEmpty) {
-      report = reports reduce reduceReports
+      report = reports reduce { _ ~ _ }
     }
     tasks.clear()
   }
@@ -82,7 +82,6 @@ trait CallBackWithRegistry extends CallBack { self =>
   protected val context: inox.Context
 
   protected type Report <: AbstractReport[Report]
-  final protected def reduceReports(r1: Report, r2: Report): Report = r1 ~ r2
 
   /** Reset state for a new cycle. */
   protected def onCycleBegin(): Unit

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -4,15 +4,13 @@ package stainless
 package frontend
 
 import extraction.xlang.{ trees => xt }
-import utils.{ DependenciesFinder, Registry }
+import utils.{ DependenciesFinder, JsonUtils, Registry }
 
 import scala.collection.mutable.{ ListBuffer, Map => MutableMap }
 
-import java.io.{ File, PrintWriter }
-import java.util.Scanner
+import org.json4s.JValue
 
-import org.json4s._
-import org.json4s.native.JsonMethods._
+import java.io.File
 
 trait CallBackWithRegistry extends CallBack { self =>
   import context.{ options, reporter }
@@ -152,10 +150,7 @@ trait CallBackWithRegistry extends CallBack { self =>
       registry.loadCache(caches.registry)
 
       // Load report cache
-      val sc = new Scanner(caches.report)
-      val sb = new StringBuilder
-      while (sc.hasNextLine) { sb ++= sc.nextLine + "\n" }
-      val json = parse(sb.toString)
+      val json = JsonUtils.parseFile(caches.report)
       report = parseReportCache(json)
     }
   }
@@ -167,9 +162,7 @@ trait CallBackWithRegistry extends CallBack { self =>
     registry.saveCache(caches.registry)
 
     val json = report.emitJson
-    val string = compact(render(json))
-    val pw = new PrintWriter(caches.report)
-    try pw.write(string) finally pw.close()
+    JsonUtils.writeFile(caches.report, json)
   }
 
 

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -8,7 +8,7 @@ import utils.{ DependenciesFinder, JsonUtils, Registry }
 
 import scala.collection.mutable.{ ListBuffer, Map => MutableMap }
 
-import org.json4s.JValue
+import io.circe.Json
 
 import java.io.File
 
@@ -101,7 +101,7 @@ trait CallBackWithRegistry extends CallBack { self =>
   protected val cacheSubDirectory: String
 
   /** Parse a JSON value into a proper Report. We assume this doesn't fail. */
-  protected def parseReportCache(json: JValue): Report
+  protected def parseReportCache(json: Json): Report
 
 
   /******************* Internal State *************************************************************/

--- a/core/src/main/scala/stainless/frontend/Frontend.scala
+++ b/core/src/main/scala/stainless/frontend/Frontend.scala
@@ -41,7 +41,7 @@ abstract class Frontend(val callback: CallBack) {
   }
 
   // See assumption/requirements in [[CallBack]]
-  final def getReports: Seq[AbstractReport] = {
+  final def getReports: Seq[AbstractReport[_]] = {
     assert(!isRunning)
     callback.getReports
   }

--- a/core/src/main/scala/stainless/frontend/Frontend.scala
+++ b/core/src/main/scala/stainless/frontend/Frontend.scala
@@ -10,12 +10,13 @@ sealed class UnsupportedCodeException(val pos: inox.utils.Position, msg: String)
 /**
  * Abstract compiler, provides all the tools to extract compilation units
  * into a sequence of small, self-contained programs and send them to a
- * [[CallBack]] whenever they are ready.
+ * [[MasterCallBack]] whenever they are ready (the master callback forwards
+ * data to each active component's callback).
  *
  * Implementations of [[Frontend]] are required to rethrow exception emitted
  * in background thread (if any) when [[join]] or [[stop]] are invoked.
  */
-abstract class Frontend(val callback: CallBack) {
+abstract class Frontend(val callback: MasterCallBack) {
   /** Proceed to extract the trees in a non-blocking way. */
   def run(): Unit
 

--- a/core/src/main/scala/stainless/frontend/FrontendFactory.scala
+++ b/core/src/main/scala/stainless/frontend/FrontendFactory.scala
@@ -8,7 +8,7 @@ import java.nio.file.{ Files, StandardCopyOption }
 
 /** A Frontend factory which takes as input: context + compiler arguments + callback */
 trait FrontendFactory {
-  def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: CallBack): Frontend
+  def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: MasterCallBack): Frontend
 
   protected val extraCompilerArguments: Seq[String] = Nil
   protected val libraryPaths: Seq[String]

--- a/core/src/main/scala/stainless/frontend/MasterCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/MasterCallBack.scala
@@ -1,0 +1,32 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package frontend
+
+import extraction.xlang.{ trees => xt }
+
+/**
+ * MasterCallBack: combine several callbacks together.
+ *
+ * The interface is similar to [[CallBack]], except for the [[getReports]]
+ * method which returns one [[AbstractReport]] per active component.
+ *
+ * Otherwise, the same consideration applies to its API.
+ */
+final class MasterCallBack(val callbacks: Seq[CallBack]) {
+  def beginExtractions(): Unit = callbacks foreach { _.beginExtractions() }
+
+  def apply(file: String, unit: xt.UnitDef, classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Unit = {
+    callbacks foreach { c => c(file, unit, classes, functions) }
+  }
+
+  def endExtractions(): Unit = callbacks foreach { _.endExtractions() }
+
+  def stop(): Unit = callbacks foreach { _.stop() }
+
+  def join(): Unit = callbacks foreach { _.join() }
+
+  // Group together reports from the same callback
+  def getReports: Seq[AbstractReport[_]] = callbacks flatMap { _.getReport }
+}
+

--- a/core/src/main/scala/stainless/frontend/ThreadedFrontend.scala
+++ b/core/src/main/scala/stainless/frontend/ThreadedFrontend.scala
@@ -10,7 +10,7 @@ package frontend
  * If an exception is thrown from within the compiler, it is re-thrown upon
  * stopping or joining.
  */
-abstract class ThreadedFrontend(callback: CallBack, ctx: inox.Context) extends Frontend(callback) {
+abstract class ThreadedFrontend(callback: MasterCallBack, ctx: inox.Context) extends Frontend(callback) {
   private var thread: Thread = _
   private var exception: Throwable = _
 

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -9,10 +9,10 @@ package object frontend {
   /**
    * The persistent caches are stored in the same directory, denoted by this option.
    *
-   * Each [[CallBackWithRegistry]] store its cache in a different file to avoid
+   * Each [[CallBackWithRegistry]] store its cache in different files to avoid
    * confusion with custom filters.
    */
-  object optPersistentRegistryCache extends inox.FlagOptionDef("registry-cache", false)
+  object optPersistentCache extends inox.FlagOptionDef("cache", false)
 
   /**
    * Given a context (with its reporter) and a frontend factory, proceed to compile,

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -24,8 +24,7 @@ package object frontend {
    * is required to [[stop]] or [[join]] the returned compiler to free resources.
    */
   def build(ctx: inox.Context, compilerArgs: Seq[String], factory: FrontendFactory): Frontend = {
-    val callback = getCallBackForActiveComponents(ctx)
-    factory(ctx, compilerArgs, callback)
+    factory(ctx, compilerArgs, getMasterCallBack(ctx))
   }
 
   /**
@@ -65,7 +64,7 @@ package object frontend {
   }
 
   /** Get one callback for all active components. */
-  private def getCallBackForActiveComponents(ctx: inox.Context): CallBack = {
+  private def getMasterCallBack(ctx: inox.Context): MasterCallBack = {
     val activeComponents = getActiveComponents(ctx)
     val activeCallbacks = activeComponents map { c => getCallBack(c.name, ctx) }
 

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -12,12 +12,7 @@ package object frontend {
    * Each [[CallBackWithRegistry]] store its cache in a different file to avoid
    * confusion with custom filters.
    */
-  object optPersistentRegistryCache extends inox.OptionDef[String] {
-    val name = "registry-cache"
-    val default = "registry_cache/"
-    val parser = inox.OptionParsers.stringParser
-    val usageRhs = "directory"
-  }
+  object optPersistentRegistryCache extends inox.FlagOptionDef("registry-cache", false)
 
   /**
    * Given a context (with its reporter) and a compiler factory, proceed to compile,

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -15,21 +15,17 @@ package object frontend {
   object optPersistentRegistryCache extends inox.FlagOptionDef("registry-cache", false)
 
   /**
-   * Given a context (with its reporter) and a compiler factory, proceed to compile,
-   * extract, transform and verify the input programs based on the active components.
+   * Given a context (with its reporter) and a frontend factory, proceed to compile,
+   * extract, transform and verify the input programs based on the active components
+   * when [[run]] is invoked on the returned frontend.
    *
-   * The returned compiler is allowed to run forever in the background, e.g. when
+   * The returned frontend is allowed to run forever in the background, e.g. when
    * watching for file changes. This function is therefore non-blocking. The callee
    * is required to [[stop]] or [[join]] the returned compiler to free resources.
    */
-  def run(ctx: inox.Context, compilerArgs: Seq[String], factory: FrontendFactory): Frontend = {
+  def build(ctx: inox.Context, compilerArgs: Seq[String], factory: FrontendFactory): Frontend = {
     val callback = getCallBackForActiveComponents(ctx)
-
-    // Initiate & run the compiler for our needs.
-    val compiler = factory(ctx, compilerArgs, callback)
-    compiler.run()
-
-    compiler
+    factory(ctx, compilerArgs, callback)
   }
 
   /**

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -7,6 +7,19 @@ package object frontend {
   object DebugSectionFrontend extends inox.DebugSection("frontend")
 
   /**
+   * The persistent caches are stored in the same directory, denoted by this option.
+   *
+   * Each [[CallBackWithRegistry]] store its cache in a different file to avoid
+   * confusion with custom filters.
+   */
+  object optPersistentRegistryCache extends inox.OptionDef[String] {
+    val name = "registry-cache"
+    val default = "registry_cache/"
+    val parser = inox.OptionParsers.stringParser
+    val usageRhs = "directory"
+  }
+
+  /**
    * Given a context (with its reporter) and a compiler factory, proceed to compile,
    * extract, transform and verify the input programs based on the active components.
    *

--- a/core/src/main/scala/stainless/termination/TerminationAnalysis.scala
+++ b/core/src/main/scala/stainless/termination/TerminationAnalysis.scala
@@ -1,0 +1,59 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package termination
+
+trait TerminationAnalysis extends AbstractAnalysis {
+  val checker: TerminationChecker {
+    val program: TerminationProgram
+  }
+
+  import checker._
+  import context._
+  import program._
+  import program.trees._
+
+  type Duration = Long
+  type Record = (TerminationGuarantee, Duration)
+  val results: Map[FunDef, Record]
+
+  override val name: String = TerminationComponent.name
+
+  override type Report = TerminationReport
+
+  override def toReport = new TerminationReport(results.toSeq map { case (fd, (g, time)) =>
+    TerminationReport.Record(fd.id, fd.getPos, time, status(g), verdict(g, fd), kind(g))
+  })
+
+  private def kind(g: TerminationGuarantee): String = g match {
+    case checker.LoopsGivenInputs(_, _) => "non-terminating loop"
+    case checker.MaybeLoopsGivenInputs(_, _) => "possibly non-terminating loop"
+    case checker.CallsNonTerminating(_) => "non-terminating call"
+    case checker.DecreasesFailed => "failed decreases check"
+    case checker.Terminates(_) => "terminates"
+    case checker.NoGuarantee => "no guarantee"
+  }
+
+  private def verdict(g: TerminationGuarantee, fd: FunDef): String = g match {
+    case checker.LoopsGivenInputs(reason, args) =>
+      s"Non-terminating for call: ${fd.id.asString}(${args.map(_.asString).mkString(",")})"
+    case checker.MaybeLoopsGivenInputs(reason, args) =>
+      s"Possibly non-terminating for call: ${fd.id.asString}(${args.map(_.asString).mkString(",")})"
+    case checker.CallsNonTerminating(fds) =>
+      s"Calls non-terminating functions: ${fds.map(_.id.asString).mkString(",")}"
+    case checker.DecreasesFailed =>
+      s"Failed decreases check"
+    case checker.Terminates(reason) =>
+      s"Terminates ($reason)"
+    case checker.NoGuarantee =>
+      "No guarantee"
+  }
+
+  private def status(g: TerminationGuarantee): TerminationReport.Status = g match {
+    case checker.NoGuarantee => TerminationReport.Unknown
+    case checker.Terminates(_) => TerminationReport.Terminating
+    case _ => TerminationReport.NonTerminating
+  }
+
+}
+

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -11,7 +11,7 @@ import utils.CheckFilter
 final class TerminationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
   private implicit val debugSection = DebugSectionTermination
 
-  override type Report = TerminationComponent.Report
+  override type Report = TerminationComponent.TextReport
 
   override def onCycleBegin(): Unit = TerminationComponent.onCycleBegin()
 
@@ -22,7 +22,7 @@ final class TerminationCallBack(override val context: inox.Context) extends Call
       "\n\tclasses   = [" + (program.symbols.classes.keySet mkString ", ") + "]"
     )
 
-    TerminationComponent(program, context)
+    TerminationComponent(program, context).toTextReport
   }
 
   override val cacheFilename = TerminationComponent.name + ".bin"

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -11,9 +11,9 @@ import utils.CheckFilter
 final class TerminationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
   private implicit val debugSection = DebugSectionTermination
 
-  override type Report = TerminationComponent.TerminationReport // And not .Report!
+  override type Report = TerminationComponent.TerminationReport
   override val cacheSubDirectory = TerminationComponent.name
-  override def parseReportCache(json: org.json4s.JValue) = TerminationComponent.TerminationReport.parse(json)
+  override def parseReportCache(json: org.json4s.JValue): Report = TerminationComponent.TerminationReport.parse(json)
 
   override def onCycleBegin(): Unit = TerminationComponent.onCycleBegin()
 
@@ -24,7 +24,7 @@ final class TerminationCallBack(override val context: inox.Context) extends Call
       "\n\tclasses   = [" + (program.symbols.classes.keySet mkString ", ") + "]"
     )
 
-    TerminationComponent(program, context).toTextReport
+    TerminationComponent(program, context).toReport
   }
 
 }

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -8,12 +8,12 @@ import frontend.CallBackWithRegistry
 import utils.CheckFilter
 
 /** Callback for termination */
-class TerminationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
+final class TerminationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
   private implicit val debugSection = DebugSectionTermination
 
   override type Report = TerminationComponent.Report
 
-  final override def beginExtractions(): Unit = TerminationComponent.onCycleBegin()
+  override def onCycleBegin(): Unit = TerminationComponent.onCycleBegin()
 
   override def solve(program: Program { val trees: extraction.xlang.trees.type }): Report = {
     context.reporter.debug(
@@ -24,5 +24,8 @@ class TerminationCallBack(override val context: inox.Context) extends CallBackWi
 
     TerminationComponent(program, context)
   }
+
+  override val cacheFilename = TerminationComponent.name + ".bin"
+
 }
 

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -3,9 +3,10 @@
 package stainless
 package termination
 
-import extraction.xlang.{ trees => xt }
 import frontend.CallBackWithRegistry
 import utils.CheckFilter
+
+import io.circe.Json
 
 /** Callback for termination */
 final class TerminationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
@@ -13,7 +14,7 @@ final class TerminationCallBack(override val context: inox.Context) extends Call
 
   override type Report = TerminationReport
   override val cacheSubDirectory = TerminationComponent.name
-  override def parseReportCache(json: org.json4s.JValue): Report = TerminationReport.parse(json)
+  override def parseReportCache(json: Json): Report = TerminationReport.parse(json)
 
   override def onCycleBegin(): Unit = TerminationComponent.onCycleBegin()
 

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -11,7 +11,9 @@ import utils.CheckFilter
 final class TerminationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
   private implicit val debugSection = DebugSectionTermination
 
-  override type Report = TerminationComponent.TextReport
+  override type Report = TerminationComponent.TerminationReport // And not .Report!
+  override val cacheSubDirectory = TerminationComponent.name
+  override def parseReportCache(json: org.json4s.JValue) = TerminationComponent.TerminationReport.parse(json)
 
   override def onCycleBegin(): Unit = TerminationComponent.onCycleBegin()
 
@@ -24,8 +26,6 @@ final class TerminationCallBack(override val context: inox.Context) extends Call
 
     TerminationComponent(program, context).toTextReport
   }
-
-  override val cacheSubDirectory = TerminationComponent.name
 
 }
 

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -11,9 +11,9 @@ import utils.CheckFilter
 final class TerminationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
   private implicit val debugSection = DebugSectionTermination
 
-  override type Report = TerminationComponent.TerminationReport
+  override type Report = TerminationReport
   override val cacheSubDirectory = TerminationComponent.name
-  override def parseReportCache(json: org.json4s.JValue): Report = TerminationComponent.TerminationReport.parse(json)
+  override def parseReportCache(json: org.json4s.JValue): Report = TerminationReport.parse(json)
 
   override def onCycleBegin(): Unit = TerminationComponent.onCycleBegin()
 

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -13,6 +13,8 @@ class TerminationCallBack(override val context: inox.Context) extends CallBackWi
 
   override type Report = TerminationComponent.Report
 
+  final override def beginExtractions(): Unit = TerminationComponent.onCycleBegin()
+
   override def solve(program: Program { val trees: extraction.xlang.trees.type }): Report = {
     context.reporter.debug(
       s"Checking termination fo the following program: " +

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -25,7 +25,7 @@ final class TerminationCallBack(override val context: inox.Context) extends Call
     TerminationComponent(program, context).toTextReport
   }
 
-  override val cacheFilename = TerminationComponent.name + ".bin"
+  override val cacheSubDirectory = TerminationComponent.name
 
 }
 

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -66,8 +66,6 @@ object TerminationComponent extends SimpleComponent {
 
     override val name: String = TerminationComponent.this.name
 
-    override val width = 2
-
     override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (results.isEmpty) None else {
       val rows = for ((fd, g) <- results.toSeq.sortBy(_._1.getPos)) yield Row(Seq(
         Cell(fd.id.asString),

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -44,62 +44,6 @@ object TerminationComponent extends SimpleComponent {
     }
   }
 
-  type TerminationProgram = Program { val trees: termination.trees.type }
-
-  trait TerminationAnalysis extends AbstractAnalysis {
-    val checker: TerminationChecker {
-      val program: TerminationProgram
-    }
-
-    import checker._
-    import context._
-    import program._
-    import program.trees._
-
-    type Duration = Long
-    type Record = (TerminationGuarantee, Duration)
-    val results: Map[FunDef, Record]
-
-    override val name: String = TerminationComponent.name
-
-    override type Report = TerminationReport
-
-    override def toReport = new TerminationReport(results.toSeq map { case (fd, (g, time)) =>
-      TerminationReport.Record(fd.id, fd.getPos, time, status(g), verdict(g, fd), kind(g))
-    })
-
-    private def kind(g: TerminationGuarantee): String = g match {
-      case checker.LoopsGivenInputs(_, _) => "non-terminating loop"
-      case checker.MaybeLoopsGivenInputs(_, _) => "possibly non-terminating loop"
-      case checker.CallsNonTerminating(_) => "non-terminating call"
-      case checker.DecreasesFailed => "failed decreases check"
-      case checker.Terminates(_) => "terminates"
-      case checker.NoGuarantee => "no guarantee"
-    }
-
-    private def verdict(g: TerminationGuarantee, fd: FunDef): String = g match {
-      case checker.LoopsGivenInputs(reason, args) =>
-        s"Non-terminating for call: ${fd.id.asString}(${args.map(_.asString).mkString(",")})"
-      case checker.MaybeLoopsGivenInputs(reason, args) =>
-        s"Possibly non-terminating for call: ${fd.id.asString}(${args.map(_.asString).mkString(",")})"
-      case checker.CallsNonTerminating(fds) =>
-        s"Calls non-terminating functions: ${fds.map(_.id.asString).mkString(",")}"
-      case checker.DecreasesFailed =>
-        s"Failed decreases check"
-      case checker.Terminates(reason) =>
-        s"Terminates ($reason)"
-      case checker.NoGuarantee =>
-        "No guarantee"
-    }
-
-    private def status(g: TerminationGuarantee): TerminationReport.Status = g match {
-      case checker.NoGuarantee => TerminationReport.Unknown
-      case checker.Terminates(_) => TerminationReport.Terminating
-      case _ => TerminationReport.NonTerminating
-    }
-
-  }
-
   override def apply(funs: Seq[Identifier], p: TerminationProgram, ctx: inox.Context): TerminationAnalysis = {
     import p._
     import p.trees._

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -10,14 +10,14 @@ import org.json4s.JsonDSL._
 import org.json4s.JsonAST.JArray
 
 object TerminationComponent extends SimpleComponent {
-  val name = "termination"
-  val description = "Check program termination."
+  override val name = "termination"
+  override val description = "Check program termination."
 
-  val trees: termination.trees.type = termination.trees
+  override val trees: termination.trees.type = termination.trees
 
-  type Report = TerminationReport
+  override type Report = TerminationReport
 
-  object lowering extends inox.ast.SymbolTransformer {
+  override object lowering extends inox.ast.SymbolTransformer {
     val s: extraction.trees.type = extraction.trees
     val t: extraction.trees.type = extraction.trees
 
@@ -50,7 +50,7 @@ object TerminationComponent extends SimpleComponent {
     }
   }
 
-  trait TerminationReport extends AbstractReport {
+  trait TerminationReport extends AbstractReport[TerminationReport] {
     val checker: TerminationChecker {
       val program: Program { val trees: termination.trees.type }
     }
@@ -83,6 +83,9 @@ object TerminationComponent extends SimpleComponent {
 
       Some((rows, stats))
     }
+
+    override def ~(report: TerminationReport): TerminationReport = ???
+    override def removeSubreports(ids: Seq[Identifier]) = ???
 
     override def emitJson: JArray = {
       def kind(g: TerminationGuarantee): String = g match {
@@ -121,7 +124,7 @@ object TerminationComponent extends SimpleComponent {
     }
   }
 
-  def apply(funs: Seq[Identifier], p: Program { val trees: termination.trees.type }, ctx: inox.Context): TerminationReport = {
+  override def apply(funs: Seq[Identifier], p: Program { val trees: termination.trees.type }, ctx: inox.Context): TerminationReport = {
     import p._
     import p.trees._
     import p.symbols._

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -3,12 +3,6 @@
 package stainless
 package termination
 
-import inox.utils.ASCIIHelpers._
-import stainless.utils.JsonConvertions._
-
-import org.json4s.JsonDSL._
-import org.json4s.JsonAST._
-
 object TerminationComponent extends SimpleComponent {
   override val name = "termination"
   override val description = "Check program termination."
@@ -50,9 +44,11 @@ object TerminationComponent extends SimpleComponent {
     }
   }
 
+  type TerminationProgram = Program { val trees: termination.trees.type }
+
   trait TerminationAnalysis extends AbstractAnalysis {
     val checker: TerminationChecker {
-      val program: Program { val trees: termination.trees.type }
+      val program: TerminationProgram
     }
 
     import checker._
@@ -64,12 +60,12 @@ object TerminationComponent extends SimpleComponent {
     type Record = (TerminationGuarantee, Duration)
     val results: Map[FunDef, Record]
 
-    override val name: String = TerminationComponent.this.name
+    override val name: String = TerminationComponent.name
 
     override type Report = TerminationReport
 
     override def toReport = new TerminationReport(results.toSeq map { case (fd, (g, time)) =>
-      TextRecord(fd.id, fd.getPos, time, status(g), verdict(g, fd), kind(g))
+      TerminationReport.Record(fd.id, fd.getPos, time, status(g), verdict(g, fd), kind(g))
     })
 
     private def kind(g: TerminationGuarantee): String = g match {
@@ -96,114 +92,15 @@ object TerminationComponent extends SimpleComponent {
         "No guarantee"
     }
 
-    private def status(g: TerminationGuarantee): TerminationStatus = g match {
-      case checker.NoGuarantee => Unknown
-      case checker.Terminates(_) => Terminating
-      case _ => NonTerminating
+    private def status(g: TerminationGuarantee): TerminationReport.Status = g match {
+      case checker.NoGuarantee => TerminationReport.Unknown
+      case checker.Terminates(_) => TerminationReport.Terminating
+      case _ => TerminationReport.NonTerminating
     }
 
   }
 
-  sealed abstract class TerminationStatus {
-    def isUnknown = this == Unknown
-    def isTerminating = this == Terminating
-    def isNonTerminating = this == NonTerminating
-
-    def toText = this match {
-      case Unknown => "unknown"
-      case Terminating => "terminating"
-      case NonTerminating => "non-terminating"
-    }
-  }
-
-  object TerminationStatus {
-    def parse(json: JValue) = json match {
-      case JString("unknown") => Unknown
-      case JString("terminating") => Terminating
-      case JString("non-terminating") => NonTerminating
-      case _ => ???
-    }
-  }
-
-  case object Unknown extends TerminationStatus
-  case object Terminating extends TerminationStatus
-  case object NonTerminating extends TerminationStatus
-
-  case class TextRecord(
-    fid: Identifier, pos: inox.utils.Position, time: Long,
-    status: TerminationStatus, verdict: String, kind: String
-  )
-
-  // Variant of the report without the checker, where all the data is mapped to text
-  class TerminationReport(val results: Seq[TextRecord]) extends AbstractReport[TerminationReport] {
-    override val name: String = TerminationComponent.this.name
-
-    override def ~(other: TerminationReport): TerminationReport = {
-      def buildMapping(subs: Seq[TextRecord]): Map[Identifier, Seq[TextRecord]] = subs groupBy { _.fid }
-
-      val prev = buildMapping(this.results)
-      val next = buildMapping(other.results)
-
-      val fused = (prev ++ next).values.fold(Seq.empty)(_ ++ _)
-
-      new TerminationReport(results = fused)
-    }
-
-    override def invalidate(ids: Seq[Identifier]) =
-      new TerminationReport(results filterNot { ids contains _.fid })
-
-    override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (results.isEmpty) None else {
-      val rows = for { TextRecord(fid, pos, time, status, verdict, kind) <- results } yield Row(Seq(
-        Cell(fid.name),
-        Cell((if (status.isTerminating) "\u2713" else "\u2717") + " " + verdict),
-        Cell(f"${time / 1000d}%3.3f")
-      ))
-
-      val valid = results count { _.status.isTerminating }
-      val validFromCache = 0
-      val invalid = results count { _.status.isNonTerminating }
-      val unknown = results count { _.status.isUnknown }
-      val time = (results map { _.time }).sum
-
-      val stats = ReportStats(results.size, time, valid, validFromCache, invalid, unknown)
-
-      Some((rows, stats))
-    }
-
-    override def emitJson: JArray = for { TextRecord(fid, pos, time, status, verdict, kind) <- results } yield {
-      ("fd" -> fid.name) ~
-      ("_fid" -> fid.toJson) ~
-      ("pos" -> pos.toJson) ~
-      ("kind" -> kind) ~ // brief
-      ("verdict" -> verdict) ~ // detailed
-      ("status" -> status.toText) ~
-      ("time" -> time)
-    }
-
-  }
-
-  object TerminationReport {
-    def parse(json: JValue): TerminationReport = {
-      val records = for {
-        JArray(records) <- json
-        record <- records
-      } yield {
-        val fid = parseIdentifier(record \ "_fid")
-        val pos = parsePosition(record \ "pos")
-        val JInt(time) = record \ "time"
-        val JString(kind) = record \ "kind"
-        val JString(verdict) = record \ "verdict"
-        val status = TerminationStatus.parse(record \ "status")
-
-        TextRecord(fid, pos, time.longValue, status, verdict, kind)
-      }
-
-      new TerminationReport(records)
-    }
-  }
-
-
-  override def apply(funs: Seq[Identifier], p: Program { val trees: termination.trees.type }, ctx: inox.Context): TerminationAnalysis = {
+  override def apply(funs: Seq[Identifier], p: TerminationProgram, ctx: inox.Context): TerminationAnalysis = {
     import p._
     import p.trees._
     import p.symbols._
@@ -213,12 +110,11 @@ object TerminationComponent extends SimpleComponent {
 
     val toVerify = funs.map(getFunction(_)).sortBy(_.getPos)
 
-    for (fd <- toVerify)  {
-      if (fd.flags contains "library") {
-        val fullName = fd.id.fullName
-        reporter.warning(s"Forcing termination checking of $fullName which was assumed terminating")
-      }
-    }
+    for {
+      fd <- toVerify
+      if fd.flags contains "library"
+      fullName <- fd.id.fullName
+    } reporter.warning(s"Forcing termination checking of $fullName which was assumed terminating")
 
     val res = toVerify map { fd =>
       val timer = ctx.timers.termination.start()
@@ -238,3 +134,4 @@ object TerminationComponent extends SimpleComponent {
     }
   }
 }
+

--- a/core/src/main/scala/stainless/termination/TerminationReport.scala
+++ b/core/src/main/scala/stainless/termination/TerminationReport.scala
@@ -1,0 +1,112 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package termination
+
+import inox.utils.ASCIIHelpers._
+import stainless.utils.JsonConvertions._
+
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST._
+
+object TerminationReport {
+
+  sealed abstract class Status {
+    def isUnknown = this == Unknown
+    def isTerminating = this == Terminating
+    def isNonTerminating = this == NonTerminating
+
+    def toText = this match {
+      case Unknown => "unknown"
+      case Terminating => "terminating"
+      case NonTerminating => "non-terminating"
+    }
+  }
+
+  object Status {
+    def parse(json: JValue) = json match {
+      case JString("unknown") => Unknown
+      case JString("terminating") => Terminating
+      case JString("non-terminating") => NonTerminating
+      case _ => ???
+    }
+  }
+
+  case object Unknown extends Status
+  case object Terminating extends Status
+  case object NonTerminating extends Status
+
+  case class Record(
+    fid: Identifier, pos: inox.utils.Position, time: Long,
+    status: Status, verdict: String, kind: String
+  )
+
+  def parse(json: JValue): TerminationReport = {
+    val records = for {
+      JArray(records) <- json
+      record <- records
+    } yield {
+      val fid = parseIdentifier(record \ "_fid")
+      val pos = parsePosition(record \ "pos")
+      val JInt(time) = record \ "time"
+      val JString(kind) = record \ "kind"
+      val JString(verdict) = record \ "verdict"
+      val status = Status.parse(record \ "status")
+
+      Record(fid, pos, time.longValue, status, verdict, kind)
+    }
+
+    new TerminationReport(records)
+  }
+}
+
+// Variant of the report without the checker, where all the data is mapped to text
+class TerminationReport(val results: Seq[TerminationReport.Record]) extends AbstractReport[TerminationReport] {
+  import TerminationReport._
+
+  override val name: String = TerminationComponent.name
+
+  override def ~(other: TerminationReport): TerminationReport = {
+    def buildMapping(subs: Seq[Record]): Map[Identifier, Seq[Record]] = subs groupBy { _.fid }
+
+    val prev = buildMapping(this.results)
+    val next = buildMapping(other.results)
+
+    val fused = (prev ++ next).values.fold(Seq.empty)(_ ++ _)
+
+    new TerminationReport(results = fused)
+  }
+
+  override def invalidate(ids: Seq[Identifier]) =
+    new TerminationReport(results filterNot { ids contains _.fid })
+
+  override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (results.isEmpty) None else {
+    val rows = for { Record(fid, pos, time, status, verdict, kind) <- results } yield Row(Seq(
+      Cell(fid.name),
+      Cell((if (status.isTerminating) "\u2713" else "\u2717") + " " + verdict),
+      Cell(f"${time / 1000d}%3.3f")
+    ))
+
+    val valid = results count { _.status.isTerminating }
+    val validFromCache = 0
+    val invalid = results count { _.status.isNonTerminating }
+    val unknown = results count { _.status.isUnknown }
+    val time = (results map { _.time }).sum
+
+    val stats = ReportStats(results.size, time, valid, validFromCache, invalid, unknown)
+
+    Some((rows, stats))
+  }
+
+  override def emitJson: JArray = for { Record(fid, pos, time, status, verdict, kind) <- results } yield {
+    ("fd" -> fid.name) ~
+    ("_fid" -> fid.toJson) ~
+    ("pos" -> pos.toJson) ~
+    ("kind" -> kind) ~ // brief
+    ("verdict" -> verdict) ~ // detailed
+    ("status" -> status.toText) ~
+    ("time" -> time)
+  }
+
+}
+

--- a/core/src/main/scala/stainless/termination/TerminationReport.scala
+++ b/core/src/main/scala/stainless/termination/TerminationReport.scala
@@ -80,7 +80,7 @@ class TerminationReport(val results: Seq[TerminationReport.Record], lastGen: Lon
     Some((rows, stats))
   }
 
-  override def emitJson: Json = results.asJson
+  override def emitJson: Json = (results, lastGen).asJson
 
 }
 

--- a/core/src/main/scala/stainless/termination/TerminationReport.scala
+++ b/core/src/main/scala/stainless/termination/TerminationReport.scala
@@ -59,8 +59,8 @@ class TerminationReport(val results: Seq[TerminationReport.Record]) extends Abst
     new TerminationReport(results = fused)
   }
 
-  override def invalidate(ids: Seq[Identifier]) =
-    new TerminationReport(results filterNot { ids contains _.fid })
+  override def filter(ids: Set[Identifier]) =
+    new TerminationReport(results filter { ids contains _.fid })
 
   override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (results.isEmpty) None else {
     val rows = for { Record(fid, pos, time, status, verdict, kind) <- results } yield Row(Seq(

--- a/core/src/main/scala/stainless/termination/TerminationReport.scala
+++ b/core/src/main/scala/stainless/termination/TerminationReport.scala
@@ -28,10 +28,10 @@ object TerminationReport {
   implicit val statusEncoder: Encoder[Status] = deriveEncoder
 
   case class Record(
-    fid: Identifier, pos: inox.utils.Position, time: Long,
+    id: Identifier, pos: inox.utils.Position, time: Long,
     status: Status, verdict: String, kind: String,
     generation: Long = 0 // "age" of the record, usefull to determine which ones are "NEW".
-  )
+  ) extends AbstractReportHelper.Record
 
   implicit val recordDecoder: Decoder[Record] = deriveDecoder
   implicit val recordEncoder: Encoder[Record] = deriveEncoder
@@ -62,9 +62,9 @@ class TerminationReport(val results: Seq[TerminationReport.Record], lastGen: Lon
   }
 
   override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (results.isEmpty) None else {
-    val rows = for { Record(fid, pos, time, status, verdict, kind, gen) <- results } yield Row(Seq(
+    val rows = for { Record(id, pos, time, status, verdict, kind, gen) <- results } yield Row(Seq(
       Cell(if (gen == lastGen) "NEW" else ""),
-      Cell(fid.name),
+      Cell(id.name),
       Cell((if (status.isTerminating) "\u2713" else "\u2717") + " " + verdict),
       Cell(f"${time / 1000d}%3.3f")
     ))

--- a/core/src/main/scala/stainless/utils/AtomicMarks.scala
+++ b/core/src/main/scala/stainless/utils/AtomicMarks.scala
@@ -1,0 +1,28 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package utils
+
+/** Set of marks that are atomically set. */
+class AtomicMarks[A] {
+
+  /**
+   * Atomically set the mark for [[a]].
+   *
+   * Returns [[true]] if the mark was **not** set before,
+   * [[false]] on subsequent call for the same [[a]] until
+   * a call to [[clear]].
+   */
+  def compareAndSet(a: A): Boolean = underlying.putIfAbsent(a, unusedValue).isEmpty
+
+  /**
+   * Clear all marks.
+   */
+  def clear(): Unit = underlying.clear()
+
+  private type UnusedType = Unit
+  private val unusedValue = ()
+  private val underlying = scala.collection.concurrent.TrieMap[A, UnusedType]()
+
+}
+

--- a/core/src/main/scala/stainless/utils/Caches.scala
+++ b/core/src/main/scala/stainless/utils/Caches.scala
@@ -20,22 +20,33 @@ object Caches {
    *
    * The cache file itself is not created. Return None when the switch if off.
    */
-  def getCacheFile(ctx: inox.Context, optCacheSwitch: inox.FlagOptionDef, cacheFilename: String): Option[File] = {
-    if (ctx.options findOptionOrDefault optCacheSwitch) Some(getCacheFile(ctx, cacheFilename))
-    else None
+  def getCacheFile(ctx: inox.Context, optCacheSwitch: inox.FlagOptionDef, filename: String): Option[File] = {
+    val cacheEnabled = ctx.options findOptionOrDefault optCacheSwitch
+    if (cacheEnabled) Some(getCacheFile(ctx, filename)) else None
   }
+
+  /**
+   * Get the cache file after creating the cache directory and its subdirectory [[subdir]].
+   *
+   * The cache file itself is not created. Return None when the switch if off.
+   */
+  def getCacheFile(ctx: inox.Context, optCacheSwitch: inox.FlagOptionDef, subdir: String, filename: String): Option[File] =
+    getCacheFile(ctx, optCacheSwitch, subdir) map { getSubFile(_, filename) }
 
   /**
    * Get the cache file after creating the cache directory.
    *
    * The cache file itself is not created.
    */
-  def getCacheFile(ctx: inox.Context, cacheFilename: String): File = {
-    val dir = new File(ctx.options findOptionOrDefault optCacheDir).getAbsoluteFile
-    dir.mkdirs()
-    assert(dir.isDirectory)
-    new File(dir, cacheFilename)
+  def getCacheFile(ctx: inox.Context, filename: String): File = {
+    val cacheDir = new File(ctx.options findOptionOrDefault optCacheDir).getAbsoluteFile
+    getSubFile(cacheDir, filename)
   }
 
+  private def getSubFile(dir: File, filename: String): File = {
+    dir.mkdirs()
+    assert(dir.isDirectory)
+    new File(dir, filename)
+  }
 }
 

--- a/core/src/main/scala/stainless/utils/Caches.scala
+++ b/core/src/main/scala/stainless/utils/Caches.scala
@@ -1,0 +1,41 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package utils
+
+import java.io.File
+
+object Caches {
+
+  /** Caches used by stainless' components are stored in the same directory, denoted by this option. */
+  object optCacheDir extends inox.OptionDef[String] {
+    val name = "cache-dir"
+    val default = "cache/"
+    val parser = inox.OptionParsers.stringParser
+    val usageRhs = "directory"
+  }
+
+  /**
+   * Get the cache file after creating the cache directory.
+   *
+   * The cache file itself is not created. Return None when the switch if off.
+   */
+  def getCacheFile(ctx: inox.Context, optCacheSwitch: inox.FlagOptionDef, cacheFilename: String): Option[File] = {
+    if (ctx.options findOptionOrDefault optCacheSwitch) Some(getCacheFile(ctx, cacheFilename))
+    else None
+  }
+
+  /**
+   * Get the cache file after creating the cache directory.
+   *
+   * The cache file itself is not created.
+   */
+  def getCacheFile(ctx: inox.Context, cacheFilename: String): File = {
+    val dir = new File(ctx.options findOptionOrDefault optCacheDir).getAbsoluteFile
+    dir.mkdirs()
+    assert(dir.isDirectory)
+    new File(dir, cacheFilename)
+  }
+
+}
+

--- a/core/src/main/scala/stainless/utils/CanonicalFormBuilder.scala
+++ b/core/src/main/scala/stainless/utils/CanonicalFormBuilder.scala
@@ -25,7 +25,7 @@ object CanonicalFormBuilder {
 
 /** Canonical form for functions, expressions, ... */
 class CanonicalForm(val bytes: Array[Byte]) {
-  override def hashCode: Int = java.util.Arrays.hashCode(bytes)
+  override lazy val hashCode: Int = java.util.Arrays.hashCode(bytes)
 
   override def equals(other: Any): Boolean = other match {
     // Because cf.bytes == bytes doesn't work, obviously.

--- a/core/src/main/scala/stainless/utils/CanonicalFormBuilder.scala
+++ b/core/src/main/scala/stainless/utils/CanonicalFormBuilder.scala
@@ -29,7 +29,10 @@ class CanonicalForm(val bytes: Array[Byte]) {
 
   override def equals(other: Any): Boolean = other match {
     // Because cf.bytes == bytes doesn't work, obviously.
-    case cf: CanonicalForm => (bytes zip cf.bytes) forall { p => p._1 == p._2 }
+    case cf: CanonicalForm =>
+      (bytes.length == cf.bytes.length) &&
+      ((bytes zip cf.bytes) forall { p => p._1 == p._2 })
+
     case _ => false
   }
 }
@@ -123,12 +126,15 @@ private class CanonicalFormBuilderImpl {
   /******************* Internal Helpers ***********************************************************/
 
   /** Register a new, unique & fresh UID for the given [[id]]. */
-  private val registerId: Identifier => Unit = { id =>
+  private val registerId: Identifier => Unit = {
     var nextId: UID = 0
-    assert(nextId != -1) // waaay too many UID were used! (after wrap around)
-    val uid = nextId
-    mapping += id -> uid
-    nextId = (nextId + 1).toShort // safely wraps around, thankfully!
+    def regFn: Identifier => Unit = { id =>
+      assert(nextId != -1) // waaay too many UID were used! (after wrap around)
+      val uid = nextId
+      mapping += id -> uid
+      nextId = (nextId + 1).toShort // safely wraps around, thankfully!
+    }
+    regFn
   }
 
   /** Idem, but for Type Parameter. */

--- a/core/src/main/scala/stainless/utils/IncrementalComputationalGraph.scala
+++ b/core/src/main/scala/stainless/utils/IncrementalComputationalGraph.scala
@@ -53,6 +53,9 @@ trait IncrementalComputationalGraph[Id, Input, Result] {
     process()
   }
 
+  /** Get a read-only version of the graph. */
+  def getNodes: Map[Id, (Input, Set[Id])] = nodes.toMap map { case (id, n) => (id, n.in -> n.deps) }
+
 
   /******************* Customisation Points *******************************************************/
 

--- a/core/src/main/scala/stainless/utils/JsonConvertions.scala
+++ b/core/src/main/scala/stainless/utils/JsonConvertions.scala
@@ -7,8 +7,9 @@ import inox.utils.{ NoPosition, OffsetPosition, Position, RangePosition }
 
 import java.io.File
 
-import org.json4s.JsonDSL._
-import org.json4s.JsonAST._
+import io.circe._
+import io.circe.syntax._
+import io.circe.generic.semiauto._
 
 /**
  * Provide basic tools to convert some stainless/inox data into
@@ -16,52 +17,71 @@ import org.json4s.JsonAST._
  */
 object JsonConvertions {
 
-  private def pos2JsonImpl(pos: OffsetPosition): JObject = {
-    ("line" -> pos.line) ~ ("col" -> pos.col) ~
-    ("point" -> pos.point) ~ ("fullpath" -> pos.file.getAbsolutePath)
+  private object PositionHelpers {
+    sealed abstract class Kind
+    case object Unknown extends Kind
+    case object Offset extends Kind
+    case object Range extends Kind
+
+    implicit val kindEncoder: Encoder[Kind] = deriveEncoder
+    implicit val kindDecoder: Decoder[Kind] = deriveDecoder
   }
 
-  implicit class Position2Json(pos: Position) {
-    def toJson: JValue = pos match {
-      case NoPosition =>
-        "Unknown"
+  import PositionHelpers._
 
-      case pos @ OffsetPosition(_, _, _, file) =>
-        pos2JsonImpl(pos) ~ ("file" -> file.getPath)
+  implicit val positionDecoder: Decoder[Position] = Decoder.instance[Position] { cursor =>
+    def impl(c: ACursor): Decoder.Result[Position] = for {
+      line <- c.get[Int]("line").right
+      col <- c.get[Int]("col").right
+      point <- c.get[Int]("point").right
+      file <- c.get[String]("file").right
+    } yield OffsetPosition(line, col, point, new File(file))
 
-      case range: RangePosition =>
-        ("begin" -> pos2JsonImpl(range.focusBegin)) ~
-        ("end" -> pos2JsonImpl(range.focusEnd)) ~
-        ("file" -> range.file.getPath)
+    cursor.downField("kind").as[Kind].right flatMap {
+      case Unknown => Right(NoPosition)
+      case Offset => impl(cursor)
+      case Range =>
+        for {
+          begin <- impl(cursor.downField("begin")).right
+          end <- impl(cursor.downField("end")).right
+        } yield Position.between(begin, end)
     }
   }
 
-  def parsePosition(json: JValue): Position = json match {
-    case JString("Unknown") => NoPosition
-    case json @ JObject(fields) if fields exists { _._1 == "begin" } =>
-      val start = parsePosition(json \ "begin")
-      val end = parsePosition(json \ "end")
-      Position.between(start, end)
+  implicit val positionEncoder: Encoder[Position] = Encoder.instance[Position] { pos =>
+    def impl(p: OffsetPosition): Seq[(String, Json)] = Seq(
+      "line" -> p.line.asJson,
+      "col" -> p.col.asJson,
+      "point" -> p.point.asJson,
+      "file" -> p.file.getAbsolutePath.asJson
+    )
 
-    case json =>
-      val JInt(line) = json \ "line"
-      val JInt(col) = json \ "col"
-      val JInt(point) = json \ "point"
-      val JString(path) = json \ "fullpath"
-      val file = new File(path)
-      OffsetPosition(line.intValue, col.intValue, point.intValue, file)
+    pos match {
+      case NoPosition =>
+        Json.obj("kind" -> (Unknown: Kind).asJson)
+        // Mind the explicit cast.. It helps circe find the right implicit encoder.
+
+      case pos @ OffsetPosition(_, _, _, file) =>
+        Json.fromFields(("kind" -> (Offset: Kind).asJson) +: impl(pos))
+
+      case range: RangePosition =>
+        Json.obj(
+          "kind" -> (Range: Kind).asJson,
+          "begin" -> Json.fromFields(impl(range.focusBegin)),
+          "end" -> Json.fromFields(impl(range.focusEnd))
+        )
+    }
   }
 
-  implicit class Identifier2Json(id: Identifier) {
-    def toJson: JValue = ("name" -> id.name) ~ ("gid" -> id.globalId) ~ ("id" -> id.id)
-  }
+  implicit val identifierDecoder: Decoder[Identifier] =
+    Decoder.forProduct3[String, Int, Int, Identifier]("name", "gid", "id") {
+      case (name, gid, id) => new Identifier(name, gid, id)
+    }
 
-  def parseIdentifier(json: JValue): Identifier = {
-    val JString(name) = json \ "name"
-    val JInt(gid) = json \ "gid"
-    val JInt(id) = json \ "id"
+  implicit val identifierEncoder: Encoder[Identifier] =
+    Encoder.forProduct3("name", "gid", "id") {
+      id: Identifier => (id.name, id.globalId, id.id)
+    }
 
-    new Identifier(name, gid.intValue, id.intValue)
-  }
 }
 

--- a/core/src/main/scala/stainless/utils/JsonUtils.scala
+++ b/core/src/main/scala/stainless/utils/JsonUtils.scala
@@ -6,21 +6,27 @@ package utils
 import java.io.{ File, PrintWriter }
 import java.util.Scanner
 
-import org.json4s.JValue
-import org.json4s.native.JsonMethods._
+import scala.util.{ Left, Right }
+
+import io.circe.Json
+import io.circe.parser._
 
 object JsonUtils {
 
-  def parseFile(file: File): JValue = {
+  def parseString(str: String): Json = parse(str) match {
+    case Right(json) => json
+    case Left(error) => throw error
+  }
+
+  def parseFile(file: File): Json = {
     val sc = new Scanner(file)
     val sb = new StringBuilder
     while (sc.hasNextLine) { sb ++= sc.nextLine + "\n" }
-    val json = parse(sb.toString)
-    json
+    parseString(sb.toString)
   }
 
-  def writeFile(file: File, json: JValue): Unit = {
-    val string = compact(render(json))
+  def writeFile(file: File, json: Json): Unit = {
+    val string = json.noSpaces
     val pw = new PrintWriter(file)
     try pw.write(string) finally pw.close()
   }

--- a/core/src/main/scala/stainless/utils/JsonUtils.scala
+++ b/core/src/main/scala/stainless/utils/JsonUtils.scala
@@ -1,0 +1,29 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+package stainless
+package utils
+
+import java.io.{ File, PrintWriter }
+import java.util.Scanner
+
+import org.json4s.JValue
+import org.json4s.native.JsonMethods._
+
+object JsonUtils {
+
+  def parseFile(file: File): JValue = {
+    val sc = new Scanner(file)
+    val sb = new StringBuilder
+    while (sc.hasNextLine) { sb ++= sc.nextLine + "\n" }
+    val json = parse(sb.toString)
+    json
+  }
+
+  def writeFile(file: File, json: JValue): Unit = {
+    val string = compact(render(json))
+    val pw = new PrintWriter(file)
+    try pw.write(string) finally pw.close()
+  }
+
+}
+

--- a/core/src/main/scala/stainless/utils/Registry.scala
+++ b/core/src/main/scala/stainless/utils/Registry.scala
@@ -382,6 +382,19 @@ trait Registry {
     }
 
     graph.freeze() // (re-)freeze for next cycle
+
+    val missings = graph.getMissing
+    if (missings.nonEmpty) {
+      graph.getNodes foreach { case (id, (node, deps)) =>
+        if ((deps & missings).nonEmpty) {
+          val unknowns = (deps & missings) map { _.uniqueName } mkString ", "
+          reporter.error(s"${id.uniqueName} depends on missing dependencies: $unknowns.")
+          reporter.debug(node)
+        }
+      }
+      reporter.internalError(s"Missing some nodes in Registry: ${missings map { _.uniqueName } mkString ", "}")
+    }
+
     res
   }
 

--- a/core/src/main/scala/stainless/utils/Registry.scala
+++ b/core/src/main/scala/stainless/utils/Registry.scala
@@ -365,7 +365,7 @@ trait Registry {
       case Right(fd) if !(recentFunctions contains fd) => fd.id
     }
 
-    reporter.debug(s"Removing <${toRemove mkString ", "}> from graph")
+    reporter.debug(s"Removing <${toRemove map { _.uniqueName } mkString ", "}> from graph")
 
     toRemove foreach graph.remove
 

--- a/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
+++ b/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
@@ -1,0 +1,24 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package verification
+
+trait VerificationAnalysis extends AbstractAnalysis {
+  val program: Program { val trees: stainless.trees.type }
+  val results: Map[VC[program.trees.type], VCResult[program.Model]]
+
+  lazy val vrs: Seq[(VC[stainless.trees.type], VCResult[program.Model])] =
+    results.toSeq.sortBy { case (vc, _) => (vc.fd.name, vc.kind.toString) }
+
+  override val name = VerificationComponent.name
+
+  override type Report = VerificationReport
+
+  override def toReport = new VerificationReport(vrs map { case (vc, vr) =>
+    val time = vr.time.getOrElse(0L) // TODO make time mandatory (?)
+    val status = VerificationReport.Status(vr.status)
+    val solverName = vr.solver map { _.name }
+    VerificationReport.Record(vc.fd, vc.getPos, time, status, solverName, vc.kind.name)
+  })
+}
+

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -4,10 +4,13 @@ package stainless
 package verification
 
 
+import java.io.File
 import java.io.ObjectInputStream
 import java.io.FileInputStream
 import java.io.ObjectOutputStream
 import java.io.FileOutputStream
+
+import scala.collection.concurrent.TrieMap
 
 import inox.solvers.SolverFactory
 
@@ -20,6 +23,12 @@ class AppendingObjectOutputStream(os: java.io.OutputStream) extends ObjectOutput
   }
 }
 
+/**
+ * VerificationChecker with cache for VC results.
+ *
+ * NOTE Several instance of this trait can be created, but under the constraint that they
+ *      all share the same [[inox.Context]] because the cache file is shared among all instances.
+ */
 trait VerificationCache extends VerificationChecker { self =>
 
   import context._
@@ -27,18 +36,18 @@ trait VerificationCache extends VerificationChecker { self =>
   import program.symbols._
   import program.trees._
 
-  val uniq = new PrinterOptions(printUniqueIds = true)
-
   override def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }) = {
-    import VerificationCache._
-
-    reporter.synchronized {
-      reporter.info(s" - Checking cache: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
-    }
+    reporter.info(s" - Checking cache: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
 
     val canonic = transformers.Canonization.canonize(program)(vc)
 
-    if (VerificationCache.contains(program.trees)(canonic)) {
+    // NOTE This algorithm is not 100% perfect: it is possible that two equivalent VCs in
+    //      the same program are both computed concurrently (contains return false twice),
+    //      and both added to the cache. Assuming the VC result is always the same, the
+    //      second result will override the first one in the cache without creating bugs.
+    //      The cache file will also contain twice the same information, but it is expected
+    //      that the even is rare enough and therefore will not result in huge cache files.
+    if (contains(canonic)) {
       reporter.synchronized {
         reporter.info(s"Cache hit: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
         reporter.debug("The following VC has already been verified:")(DebugSectionCacheHit)
@@ -52,87 +61,98 @@ trait VerificationCache extends VerificationChecker { self =>
         reporter.debug("Cache miss for VC")(DebugSectionCacheMiss)
         reporter.debug(vc.condition)(DebugSectionCacheMiss)
         reporter.debug("Canonical form:")(DebugSectionCacheMiss)
-        reporter.debug(serialize(program.trees)(canonic))(DebugSectionCacheMiss)
+        reporter.debug(serialize(canonic))(DebugSectionCacheMiss)
         reporter.debug("--------------")(DebugSectionCacheMiss)
       }
+
       val result = super.checkVC(vc,sf)
       if (result.isValid) {
-        VerificationCache.add(program.trees)(canonic)
-        VerificationCache.persist(program.trees)(canonic, vc.toString, context)
+        add(canonic)
       }
+
       result
     }
   }
 
-}
+  private val cacheFile: File = utils.Caches.getCacheFile(context, "vccache.bin")
+  private val vccache: Cache = CacheLoader.get(cacheFile)
 
-object VerificationCache {
-  private val cacheFile = ".vccache.bin"
-  private var vccache = scala.collection.concurrent.TrieMap[String,Unit]()
-  VerificationCache.loadPersistentCache()
-  
-  // output stream used to save verified VCs 
-  private val oos = if (new java.io.File(cacheFile).exists) {
-    new AppendingObjectOutputStream(new FileOutputStream(cacheFile, true))
-  } else {
-    new ObjectOutputStream(new FileOutputStream(cacheFile))
-  }
-  
-  def contains(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr)) = {
-    vccache.contains(serialize(tt)(p))
-  }
-    
-  def add(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr)) = {
-    vccache += ((serialize(tt)(p), ()))
-  }
+  private def contains(p: (Symbols, Expr)) = vccache contains serialize(p)
+  private def add(p: (Symbols, Expr)) = vccache addPersistently serialize(p)
 
   /**
     * Transforms the dependencies of a VC and a VC to a String
     * The functions and ADTs representations are sorted to avoid non-determinism
     */
-  def serialize(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr)): String = {
-    val uniq = new tt.PrinterOptions(printUniqueIds = true, printTypes = true, symbols = Some(p._1))
-    p._1.functions.values.map(fd => fd.asString(uniq)).toList.sorted.mkString("\n\n") + 
-    "\n#\n" + 
-    p._1.adts.values.map(adt => adt.asString(uniq)).toList.sorted.mkString("\n\n") + 
-    "\n#\n" + 
+  private def serialize(p: (Symbols, Expr)): String = {
+    val uniq = new PrinterOptions(printUniqueIds = true, printTypes = true, symbols = Some(p._1))
+    p._1.functions.values.map(fd => fd.asString(uniq)).toList.sorted.mkString("\n\n") +
+    "\n#\n" +
+    p._1.adts.values.map(adt => adt.asString(uniq)).toList.sorted.mkString("\n\n") +
+    "\n#\n" +
     p._2.asString(uniq)
   }
 
-  /**
-    * Creates a task that adds a VC (and its dependencies) to the cache file
-    */
-  def persist(tt: inox.ast.Trees)(p: (tt.Symbols, tt.Expr), descr: String, ctx: inox.Context): Unit = {
-    val task = new java.util.concurrent.Callable[String] {
-      override def call(): String = {
-        val s = serialize(tt)(p)
-        VerificationCache.synchronized {
-          oos.writeObject(s)
-        }
-        descr
-      }
-    }
-    MainHelpers.executor.submit(task)
+}
+
+/** Cache with the ability to save itself to disk. */
+private class Cache(cacheFile: File) {
+  // API
+  def contains(serialized: String): Boolean = underlying contains serialized
+  def +=(serialized: String) = underlying += serialized -> unusedCacheValue
+  def addPersistently(serialized: String): Unit = {
+    this += serialized
+    this.synchronized { oos writeObject serialized }
   }
-  
+
+  // Implementation details
+  private val underlying = TrieMap[String, Unit]() // Thread safe
+  private val unusedCacheValue = ()
+
+  // output stream used to save verified VCs
+  private val oos = if (cacheFile.exists) {
+    new AppendingObjectOutputStream(new FileOutputStream(cacheFile, true))
+  } else {
+    new ObjectOutputStream(new FileOutputStream(cacheFile))
+  }
+}
+
+/**
+ * Only two tasks for the cache loader:
+ *  - initialize the cache from the file,
+ *  - return the same [[Cache]] instance for the same [[File]].
+ */
+private object CacheLoader {
+
+  private val db = scala.collection.mutable.Map[File, Cache]()
+
   /**
-    * Loads all the VCs stored in the cache file and puts them in the
-    * `vccache` map.
-    */
-  private def loadPersistentCache(): Unit = {
-    if (new java.io.File(cacheFile).exists) {
-      VerificationCache.synchronized {
+   * Create a cache with the data stored in the given file if it exists.
+   *
+   * NOTE This function assumes the file is not written by another process
+   *      while being loaded!
+   */
+  def get(cacheFile: File): Cache = this.synchronized {
+    db.getOrElseUpdate(cacheFile, {
+      val cache = new Cache(cacheFile)
+
+      if (cacheFile.exists) {
         val ois = new ObjectInputStream(new FileInputStream(cacheFile))
         try {
           while (true) {
             val s = ois.readObject.asInstanceOf[String]
-            vccache += ((s, ()))
+            cache += s
           }
         } catch {
-          case e: java.io.EOFException => ois.close()
+          case e: java.io.EOFException => // Silently consume expected exception.
+        } finally {
+          ois.close()
         }
       }
-    }
+
+      cache
+    })
   }
 
 }
+

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -26,7 +26,7 @@ final class VerificationCallBack(override val context: inox.Context) extends Cal
     VerificationComponent(program, context)
   }
 
-  override val cacheFilename = VerificationComponent.name + ".bin"
+  override val cacheSubDirectory = VerificationComponent.name
 
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -12,9 +12,9 @@ final class VerificationCallBack(override val context: inox.Context) extends Cal
 
   private implicit val debugSection = DebugSectionVerification
 
-  override type Report = VerificationComponent.Report
+  override type Report = VerificationComponent.VerificationReport
   override val cacheSubDirectory = VerificationComponent.name
-  override def parseReportCache(json: org.json4s.JValue) = ???
+  override def parseReportCache(json: org.json4s.JValue): Report = VerificationComponent.VerificationReport.parse(json)
 
   override def onCycleBegin(): Unit = VerificationComponent.onCycleBegin()
 
@@ -25,7 +25,7 @@ final class VerificationCallBack(override val context: inox.Context) extends Cal
       "\n\tclasses   = [" + (program.symbols.classes.keySet mkString ", ") + "]"
     )
 
-    VerificationComponent(program, context)
+    VerificationComponent(program, context).toReport
   }
 
 }

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -23,5 +23,8 @@ class VerificationCallBack(override val context: inox.Context) extends CallBackW
 
     VerificationComponent(program, context)
   }
+
+  override def onCycleEnd(): Unit = VerificationComponent.onCycleEnd()
+
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -8,13 +8,13 @@ import frontend.CallBackWithRegistry
 import utils.CheckFilter
 
 /** Callback for verification */
-class VerificationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
+final class VerificationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
 
   private implicit val debugSection = DebugSectionVerification
 
   override type Report = VerificationComponent.Report
 
-  final override def beginExtractions(): Unit = VerificationComponent.onCycleBegin()
+  override def onCycleBegin(): Unit = VerificationComponent.onCycleBegin()
 
   override def solve(program: Program { val trees: extraction.xlang.trees.type }): Report = {
     context.reporter.debug(
@@ -25,6 +25,8 @@ class VerificationCallBack(override val context: inox.Context) extends CallBackW
 
     VerificationComponent(program, context)
   }
+
+  override val cacheFilename = VerificationComponent.name + ".bin"
 
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -12,9 +12,9 @@ final class VerificationCallBack(override val context: inox.Context) extends Cal
 
   private implicit val debugSection = DebugSectionVerification
 
-  override type Report = VerificationComponent.VerificationReport
+  override type Report = VerificationReport
   override val cacheSubDirectory = VerificationComponent.name
-  override def parseReportCache(json: org.json4s.JValue): Report = VerificationComponent.VerificationReport.parse(json)
+  override def parseReportCache(json: org.json4s.JValue): Report = VerificationReport.parse(json)
 
   override def onCycleBegin(): Unit = VerificationComponent.onCycleBegin()
 

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -14,6 +14,8 @@ class VerificationCallBack(override val context: inox.Context) extends CallBackW
 
   override type Report = VerificationComponent.Report
 
+  final override def beginExtractions(): Unit = VerificationComponent.onCycleBegin()
+
   override def solve(program: Program { val trees: extraction.xlang.trees.type }): Report = {
     context.reporter.debug(
       s"Verifying the following program: " +
@@ -23,8 +25,6 @@ class VerificationCallBack(override val context: inox.Context) extends CallBackW
 
     VerificationComponent(program, context)
   }
-
-  override def onCycleEnd(): Unit = VerificationComponent.onCycleEnd()
 
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -13,6 +13,8 @@ final class VerificationCallBack(override val context: inox.Context) extends Cal
   private implicit val debugSection = DebugSectionVerification
 
   override type Report = VerificationComponent.Report
+  override val cacheSubDirectory = VerificationComponent.name
+  override def parseReportCache(json: org.json4s.JValue) = ???
 
   override def onCycleBegin(): Unit = VerificationComponent.onCycleBegin()
 
@@ -25,8 +27,6 @@ final class VerificationCallBack(override val context: inox.Context) extends Cal
 
     VerificationComponent(program, context)
   }
-
-  override val cacheSubDirectory = VerificationComponent.name
 
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -3,9 +3,10 @@
 package stainless
 package verification
 
-import extraction.xlang.{ trees => xt }
 import frontend.CallBackWithRegistry
 import utils.CheckFilter
+
+import io.circe.Json
 
 /** Callback for verification */
 final class VerificationCallBack(override val context: inox.Context) extends CallBackWithRegistry with CheckFilter {
@@ -14,7 +15,7 @@ final class VerificationCallBack(override val context: inox.Context) extends Cal
 
   override type Report = VerificationReport
   override val cacheSubDirectory = VerificationComponent.name
-  override def parseReportCache(json: org.json4s.JValue): Report = VerificationReport.parse(json)
+  override def parseReportCache(json: Json): Report = VerificationReport.parse(json)
 
   override def onCycleBegin(): Unit = VerificationComponent.onCycleBegin()
 

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -92,6 +92,7 @@ object VerificationComponent extends SimpleComponent {
 
       val report: JArray = for { (vc, vr) <- vrs } yield {
         ("fd" -> vc.fd.name) ~
+        ("_fd" -> vc.fd.toJson) ~
         ("pos" -> vc.getPos.toJson) ~
         ("kind" -> vc.kind.name) ~
         status2Json(vr.status) ~

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -27,25 +27,6 @@ object VerificationComponent extends SimpleComponent {
 
   implicit val debugSection = DebugSectionVerification
 
-  trait VerificationAnalysis extends AbstractAnalysis {
-    val program: Program { val trees: stainless.trees.type }
-    val results: Map[VC[program.trees.type], VCResult[program.Model]]
-
-    lazy val vrs: Seq[(VC[stainless.trees.type], VCResult[program.Model])] =
-      results.toSeq.sortBy { case (vc, _) => (vc.fd.name, vc.kind.toString) }
-
-    override val name = VerificationComponent.name
-
-    override type Report = VerificationReport
-
-    override def toReport = new VerificationReport(vrs map { case (vc, vr) =>
-      val time = vr.time.getOrElse(0L) // TODO make time mandatory (?)
-      val status = VerificationReport.Status(vr.status)
-      val solverName = vr.solver map { _.name }
-      VerificationReport.Record(vc.fd, vc.getPos, time, status, solverName, vc.kind.name)
-    })
-  }
-
   private def check(funs: Seq[Identifier], p: StainlessProgram, ctx: inox.Context): Map[VC[p.trees.type], VCResult[p.Model]] = {
     val injector = AssertionInjector(p, ctx)
     val encoder = inox.ast.ProgramEncoder(p)(injector)

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -3,13 +3,6 @@
 package stainless
 package verification
 
-import inox.utils.ASCIIHelpers._
-import stainless.utils.JsonConvertions._
-import stainless.verification.VCStatus.Invalid
-
-import org.json4s.JsonDSL._
-import org.json4s.JsonAST._
-
 import scala.language.existentials
 
 /**
@@ -37,15 +30,15 @@ object VerificationComponent extends SimpleComponent {
   // TODO re-introduce program in Analysis
   trait VerificationAnalysis extends AbstractAnalysis {
 
-    override val name = VerificationComponent.this.name
+    override val name = VerificationComponent.name
 
     override type Report = VerificationReport
 
     override def toReport = new VerificationReport(vrs map { case (vc, vr) =>
       val time = vr.time.getOrElse(0L) // TODO make time mandatory (?)
-      val status = VCTextStatus(vr.status)
+      val status = VerificationReport.Status(vr.status)
       val solverName = vr.solver map { _.name }
-      TextRecord(vc.fd, vc.getPos, time, status, solverName, vc.kind.name)
+      VerificationReport.Record(vc.fd, vc.getPos, time, status, solverName, vc.kind.name)
     })
 
     type Model = StainlessProgram#Model
@@ -54,106 +47,6 @@ object VerificationComponent extends SimpleComponent {
 
     lazy val vrs: Seq[(VC[stainless.trees.type], VCResult[Model])] =
       results.toSeq.sortBy { case (vc, _) => (vc.fd.name, vc.kind.toString) }
-  }
-
-  /**
-   * Similar interface to [[VCStatus]], but with text only data and all
-   * inconclusive status mapped to [[Inconclusive]].
-   */
-  sealed abstract class VCTextStatus(val name: String) {
-    def isValid = this == VCTextStatus.Valid || isValidFromCache
-    def isValidFromCache = this == VCTextStatus.ValidFromCache
-    def isInvalid = this.isInstanceOf[VCTextStatus.Invalid]
-    def isInconclusive = this.isInstanceOf[VCTextStatus.Inconclusive]
-
-    def toJson: JObject = this match {
-      case VCTextStatus.Invalid(vars) => ("status" -> name) ~ ("counterexample" -> vars)
-      case _ => "status" -> name
-    }
-  }
-
-  object VCTextStatus {
-    type VariableName = String
-    type Value = String
-
-    case object Valid extends VCTextStatus("valid")
-    case object ValidFromCache extends VCTextStatus("valid from cache")
-    case class Inconclusive(reason: String) extends VCTextStatus(reason)
-    case class Invalid(counterexample: Map[VariableName, Value]) extends VCTextStatus("invalid")
-
-    def apply[Model <: Program#Model](status: VCStatus[Model]): VCTextStatus = status match {
-      case VCStatus.Invalid(model) => Invalid(model.vars map { case (vd, e) => vd.id.name -> e.toString })
-      case VCStatus.Valid => Valid
-      case VCStatus.ValidFromCache => ValidFromCache
-      case inconclusive => Inconclusive(inconclusive.name)
-    }
-  }
-
-  case class TextRecord(
-    fid: Identifier, pos: inox.utils.Position, time: Long,
-    status: VCTextStatus, solverName: Option[String], kind: String
-  )
-
-  // TODO move to its own file (and do the same for Termination)
-  // TODO create generic interface to reduce work with TerminationReport
-  class VerificationReport(val results: Seq[TextRecord]) extends AbstractReport[VerificationReport] {
-
-    lazy val totalConditions: Int = results.size
-    lazy val totalTime = results.map(_.time).sum
-    lazy val totalValid = results.count(_.status.isValid)
-    lazy val totalValidFromCache = results.count(_.status.isValidFromCache)
-    lazy val totalInvalid = results.count(_.status.isInvalid)
-    lazy val totalUnknown = results.count(_.status.isInconclusive)
-
-    override val name = VerificationComponent.this.name
-
-    override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (totalConditions == 0) None else Some((
-      results map { case TextRecord(fid, pos, time, status, solverName, kind) =>
-        Row(Seq(
-          Cell(fid),
-          Cell(kind),
-          Cell(pos.fullString),
-          Cell(status.name),
-          Cell(solverName getOrElse ""),
-          Cell(f"${time / 1000d}%3.3f")
-        ))
-      },
-      ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
-    ))
-
-    override def ~(other: VerificationReport): VerificationReport = {
-      def buildMapping(subs: Seq[TextRecord]): Map[Identifier, Seq[TextRecord]] = subs groupBy { _.fid }
-
-      val prev = buildMapping(this.results)
-      val next = buildMapping(other.results)
-
-      val fused = (prev ++ next).values.fold(Seq.empty)(_ ++ _)
-
-      new VerificationReport(fused)
-    }
-
-    override def invalidate(ids: Seq[Identifier]) =
-      new VerificationReport(results filterNot { ids contains _.fid })
-
-    override def emitJson: JArray =
-      for { TextRecord(fid, pos, time, status, solverName, kind) <- results } yield {
-        val solver: JValue = solverName match {
-          case Some(name) => JString(name)
-          case None => JNull
-        }
-
-        ("fd" -> fid.name) ~
-        ("_fd" -> fid.toJson) ~
-        ("pos" -> pos.toJson) ~
-        ("time" -> time)
-        status.toJson ~
-        ("solver" -> solver) ~
-        ("kind" -> kind)
-      }
-  }
-
-  object VerificationReport {
-    def parse(json: JValue) = ??? // TODO
   }
 
   private def check(funs: Seq[Identifier], p: StainlessProgram, ctx: inox.Context): Map[VC[p.trees.type], VCResult[p.Model]] = {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -94,7 +94,8 @@ object VerificationComponent extends SimpleComponent {
         ("fd" -> vc.fd.name) ~
         ("pos" -> vc.getPos.toJson) ~
         ("kind" -> vc.kind.name) ~
-        status2Json(vr.status)
+        status2Json(vr.status) ~
+        ("time" -> vr.time)
       }
 
       report

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -88,10 +88,6 @@ object VerificationComponent extends SimpleComponent {
     }
   }
 
-  // The marks are stored here in order to be shared among multiple VerificationChecker.
-  private val marks = new utils.AtomicMarks[Identifier]
-  def onCycleBegin(): Unit = marks.clear()
-
   def check(funs: Seq[Identifier], p: StainlessProgram, ctx: inox.Context): Map[VC[p.trees.type], VCResult[p.Model]] = {
     val injector = AssertionInjector(p, ctx)
     val encoder = inox.ast.ProgramEncoder(p)(injector)
@@ -101,7 +97,7 @@ object VerificationComponent extends SimpleComponent {
     import encoder.targetProgram.trees._
     import encoder.targetProgram.symbols._
 
-    val toVerify = funs.sortBy(getFunction(_).getPos) filter marks.compareAndSet
+    val toVerify = funs.sortBy(getFunction(_).getPos)
     ctx.reporter.debug(s"Generating VCs for those functions: ${toVerify map { _.uniqueName } mkString ", "}")
 
     for (id <- toVerify) {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -90,7 +90,7 @@ object VerificationComponent extends SimpleComponent {
 
   // The marks are stored here in order to be shared among multiple VerificationChecker.
   private val marks = new utils.AtomicMarks[Identifier]
-  def onCycleEnd(): Unit = marks.clear()
+  def onCycleBegin(): Unit = marks.clear()
 
   def check(funs: Seq[Identifier], p: StainlessProgram, ctx: inox.Context): Map[VC[p.trees.type], VCResult[p.Model]] = {
     val injector = AssertionInjector(p, ctx)
@@ -102,6 +102,7 @@ object VerificationComponent extends SimpleComponent {
     import encoder.targetProgram.symbols._
 
     val toVerify = funs.sortBy(getFunction(_).getPos) filter marks.compareAndSet
+    ctx.reporter.debug(s"Generating VCs for those functions: ${toVerify map { _.uniqueName } mkString ", "}")
 
     for (id <- toVerify) {
       if (getFunction(id).flags contains "library") {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -51,8 +51,6 @@ object VerificationComponent extends SimpleComponent {
 
     override val name = VerificationComponent.this.name
 
-    override val width = 6
-
     override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (totalConditions == 0) None else Some((
       vrs.map { case (vc, vr) =>
         Row(Seq(

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -97,8 +97,8 @@ class VerificationReport(val results: Seq[VerificationReport.Record]) extends Ab
     new VerificationReport(fused)
   }
 
-  override def invalidate(ids: Seq[Identifier]) =
-    new VerificationReport(results filterNot { ids contains _.fid })
+  override def filter(ids: Set[Identifier]) =
+    new VerificationReport(results filter { ids contains _.fid })
 
   override def emitJson: Json = results.asJson
 

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -1,0 +1,112 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package verification
+
+import inox.utils.ASCIIHelpers._
+import stainless.utils.JsonConvertions._
+
+import org.json4s.JsonDSL._
+import org.json4s.JsonAST._
+
+object VerificationReport {
+  def parse(json: JValue) = ??? // TODO
+
+  /**
+   * Similar interface to [[VCStatus]], but with text only data and all
+   * inconclusive status mapped to [[Inconclusive]].
+   */
+  sealed abstract class Status(val name: String) {
+    def isValid = this == Status.Valid || isValidFromCache
+    def isValidFromCache = this == Status.ValidFromCache
+    def isInvalid = this.isInstanceOf[Status.Invalid]
+    def isInconclusive = this.isInstanceOf[Status.Inconclusive]
+
+    def toJson: JObject = this match {
+      case Status.Invalid(vars) => ("status" -> name) ~ ("counterexample" -> vars)
+      case _ => "status" -> name
+    }
+  }
+
+  object Status {
+    type VariableName = String
+    type Value = String
+
+    case object Valid extends Status("valid")
+    case object ValidFromCache extends Status("valid from cache")
+    case class Inconclusive(reason: String) extends Status(reason)
+    case class Invalid(counterexample: Map[VariableName, Value]) extends Status("invalid")
+
+    def apply[Model <: StainlessProgram#Model](status: VCStatus[Model]): Status = status match {
+      case VCStatus.Invalid(model) => Invalid(model.vars map { case (vd, e) => vd.id.name -> e.toString })
+      case VCStatus.Valid => Valid
+      case VCStatus.ValidFromCache => ValidFromCache
+      case inconclusive => Inconclusive(inconclusive.name)
+    }
+  }
+
+  case class Record(
+    fid: Identifier, pos: inox.utils.Position, time: Long,
+    status: Status, solverName: Option[String], kind: String
+  )
+
+}
+
+// TODO create generic interface to reduce work with TerminationReport
+class VerificationReport(val results: Seq[VerificationReport.Record]) extends AbstractReport[VerificationReport] {
+  import VerificationReport._
+
+  lazy val totalConditions: Int = results.size
+  lazy val totalTime = results.map(_.time).sum
+  lazy val totalValid = results.count(_.status.isValid)
+  lazy val totalValidFromCache = results.count(_.status.isValidFromCache)
+  lazy val totalInvalid = results.count(_.status.isInvalid)
+  lazy val totalUnknown = results.count(_.status.isInconclusive)
+
+  override val name = VerificationComponent.name
+
+  override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (totalConditions == 0) None else Some((
+    results map { case Record(fid, pos, time, status, solverName, kind) =>
+      Row(Seq(
+        Cell(fid),
+        Cell(kind),
+        Cell(pos.fullString),
+        Cell(status.name),
+        Cell(solverName getOrElse ""),
+        Cell(f"${time / 1000d}%3.3f")
+      ))
+    },
+    ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
+  ))
+
+  override def ~(other: VerificationReport): VerificationReport = {
+    def buildMapping(subs: Seq[Record]): Map[Identifier, Seq[Record]] = subs groupBy { _.fid }
+
+    val prev = buildMapping(this.results)
+    val next = buildMapping(other.results)
+
+    val fused = (prev ++ next).values.fold(Seq.empty)(_ ++ _)
+
+    new VerificationReport(fused)
+  }
+
+  override def invalidate(ids: Seq[Identifier]) =
+    new VerificationReport(results filterNot { ids contains _.fid })
+
+  override def emitJson: JArray =
+    for { Record(fid, pos, time, status, solverName, kind) <- results } yield {
+      val solver: JValue = solverName match {
+        case Some(name) => JString(name)
+        case None => JNull
+      }
+
+      ("fd" -> fid.name) ~
+      ("_fd" -> fid.toJson) ~
+      ("pos" -> pos.toJson) ~
+      ("time" -> time)
+      status.toJson ~
+      ("solver" -> solver) ~
+      ("kind" -> kind)
+    }
+}
+

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -89,26 +89,16 @@ class VerificationReport(val results: Seq[VerificationReport.Record], lastGen: L
     ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
   ))
 
-  override def ~(other: VerificationReport): VerificationReport = {
-    def buildMapping(subs: Seq[Record]): Map[Identifier, Seq[Record]] = subs groupBy { _.fid }
-
-    val prev = buildMapping(this.results)
-    val next0 = buildMapping(other.results)
-
-    // Update the generation only if we are not simply adding things to the current (parallel) generation.
-    val nextGen = if ((prev.keySet & next0.keySet).isEmpty) lastGen else lastGen + 1
-
-    val next = next0 mapValues {
-      records => records map { r => r.copy(generation = nextGen) }
-    }
-
-    val fused = (prev ++ next).values.fold(Seq.empty)(_ ++ _)
-
+  override def ~(other: VerificationReport) = {
+    def updater(nextGen: Long)(r: Record) = r.copy(generation = nextGen)
+    val (fused, nextGen) = AbstractReportHelper.merge(this.results, other.results, lastGen, updater)
     new VerificationReport(fused, nextGen)
   }
 
-  override def filter(ids: Set[Identifier]) =
-    new VerificationReport(results filter { ids contains _.fid }, lastGen + 1)
+  override def filter(ids: Set[Identifier]) = {
+    val (filtered, nextGen) = AbstractReportHelper.filter(results, ids, lastGen)
+    new VerificationReport(filtered, nextGen)
+  }
 
   override def emitJson: Json = (results, lastGen).asJson
 

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -46,10 +46,10 @@ object VerificationReport {
   implicit val statusEncoder: Encoder[Status] = deriveEncoder
 
   case class Record(
-    fid: Identifier, pos: inox.utils.Position, time: Long,
+    id: Identifier, pos: inox.utils.Position, time: Long,
     status: Status, solverName: Option[String], kind: String,
     generation: Long = 0 // "age" of the record, usefull to determine which ones are "NEW".
-  )
+  ) extends AbstractReportHelper.Record
 
   implicit val recordDecoder: Decoder[Record] = deriveDecoder
   implicit val recordEncoder: Encoder[Record] = deriveEncoder
@@ -75,10 +75,10 @@ class VerificationReport(val results: Seq[VerificationReport.Record], lastGen: L
   override val name = VerificationComponent.name
 
   override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (totalConditions == 0) None else Some((
-    results sortBy { _.fid } map { case Record(fid, pos, time, status, solverName, kind, gen) =>
+    results sortBy { _.id } map { case Record(id, pos, time, status, solverName, kind, gen) =>
       Row(Seq(
         Cell(if (gen == lastGen) "NEW" else ""),
-        Cell(fid),
+        Cell(id),
         Cell(kind),
         Cell(pos.fullString),
         Cell(status.name),

--- a/frontends/benchmarks/extraction/Arrays.scala
+++ b/frontends/benchmarks/extraction/Arrays.scala
@@ -1,0 +1,50 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+import stainless.lang._
+
+object Arrays {
+
+  def len[T](a: Array[T]): Boolean = {
+    a.length == a.size
+  }.holds
+
+  def update[T](a: Array[T], i: Int, t: T) = {
+    require(i >= 0 && i < a.length)
+    val array = Array(0, 1)
+    array(0) = 1
+    // Shadowed implicit conversion not supported.
+    // (array: scala.collection.mutable.ArrayOps[Int]).update(1, 2)
+    a.update(i, t)
+  }
+
+
+  // ArraySeq not supported.
+  /*
+   * import scala.collection.mutable.ArraySeq
+   * def updated[T](a: Array[T], i: Int, t: T): ArraySeq[T] = {
+   *   require(i >= 0 && i < a.length)
+   *   a.updated(i, t)
+   * }
+   */
+
+  // ClassTag not supported.
+  /*
+   * import scala.reflect.ClassTag
+   * def updated[T](a: Array[T], i: Int, u: T)(implicit m: ClassTag[T]): Array[T] = {
+   *   require(i >= 0 && i < a.length)
+   *   a.updated(i, u)
+   * }
+   */
+
+  def updated(a: Array[Int], i: Int, v: Int): Array[Int] = {
+    require(i >= 0 && i < a.length)
+    a.updated(i, v)
+  }
+
+  def select[T](a: Array[T], i: Int) = {
+    require(i >= 0 && i < a.length)
+    a(i)
+  }
+
+}
+

--- a/frontends/benchmarks/verification/valid/LambdaEquality.scala
+++ b/frontends/benchmarks/verification/valid/LambdaEquality.scala
@@ -1,21 +1,21 @@
 /* Copyright 2009-2016 EPFL, Lausanne */
 
- 
+
 import stainless.lang._
 import stainless.annotation._
 import stainless.collection._
- 
+
 object LambdaEquality {
   def app[A, B](x: A)(f: A => B): B = f(x)
 
   @induct
   def mapId[A](xs: List[A]): Boolean = {
-    xs.map(id) == xs && {
+    xs.map[A](id) == xs && {
       xs match {
         case Nil() => true
         case Cons(x, xs) =>
           mapId(xs) &&
-          id(x) :: xs.map(id) == x :: xs &&
+          id(x) :: xs.map[A](id) == x :: xs &&
           true
       }
     }

--- a/frontends/common/src/test/scala/stainless/InputUtils.scala
+++ b/frontends/common/src/test/scala/stainless/InputUtils.scala
@@ -3,7 +3,7 @@
 package stainless
 
 import extraction.xlang.{ trees => xt }
-import frontend.CallBack
+import frontend.{ CallBack, MasterCallBack }
 
 import scala.collection.mutable.ListBuffer
 
@@ -39,7 +39,7 @@ trait InputUtils {
     val callback = new CallBack {
       override def join(): Unit = ()
       override def stop(): Unit = ()
-      override def getReports = Seq.empty
+      override def getReport = None
 
       override def beginExtractions(): Unit = ()
       override def apply(file: String, unit: xt.UnitDef,
@@ -51,7 +51,8 @@ trait InputUtils {
       override def endExtractions(): Unit = ()
     }
 
-    val compiler = Main.factory(context, files, callback)
+    val master = new MasterCallBack(Seq(callback))
+    val compiler = Main.factory(context, files, master)
     compiler.run()
 
     // Wait for compilation to finish to produce the whole program

--- a/frontends/common/src/test/scala/stainless/InputUtils.scala
+++ b/frontends/common/src/test/scala/stainless/InputUtils.scala
@@ -4,6 +4,7 @@ package stainless
 
 import extraction.xlang.{ trees => xt }
 import frontend.{ CallBack, MasterCallBack }
+import utils.{ DependenciesFinder, Registry }
 
 import scala.collection.mutable.ListBuffer
 
@@ -28,37 +29,68 @@ trait InputUtils {
   }
 
   /** Compile and extract the given files (& the library). */
-  def loadFiles(context: inox.Context, files: Seq[String]):
+  def loadFiles(ctx: inox.Context, files: Seq[String]):
                (Seq[xt.UnitDef], Program { val trees: xt.type }) = {
 
     // Use the callback to collect the trees.
     val units = ListBuffer[xt.UnitDef]()
     val cls = ListBuffer[xt.ClassDef]()
     val funs = ListBuffer[xt.FunDef]()
+    var syms = xt.NoSymbols
+    var done = false
+
+    def updateSyms(extra: xt.Symbols) = {
+      syms = syms.withClasses(extra.classes.values.toSeq)
+                 .withFunctions(extra.functions.values.toSeq)
+    }
 
     val callback = new CallBack {
       override def join(): Unit = ()
       override def stop(): Unit = ()
       override def getReport = None
 
+      private val registry = new Registry {
+        override val context = ctx
+
+        override def computeDirectDependencies(fd: xt.FunDef): Set[Identifier] = new DependenciesFinder()(fd)
+        override def computeDirectDependencies(cd: xt.ClassDef): Set[Identifier] = new DependenciesFinder()(cd)
+
+        override def shouldBeChecked(fd: xt.FunDef): Boolean = true
+        override def shouldBeChecked(cd: xt.ClassDef): Boolean = true
+      }
+
       override def beginExtractions(): Unit = ()
+
       override def apply(file: String, unit: xt.UnitDef,
                          classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Unit = {
         units += unit
         cls ++= classes
         funs ++= functions
+
+        val extraOpt = registry.update(classes, functions)
+        extraOpt foreach updateSyms
       }
-      override def endExtractions(): Unit = ()
+
+      override def endExtractions(): Unit = {
+        // Ensure all symbols were loaded properly: the registry should check that no symbol is missing.
+        val extraOpt = registry.checkpoint()
+        extraOpt foreach updateSyms
+        done = true
+      }
     }
 
     val master = new MasterCallBack(Seq(callback))
-    val compiler = Main.factory(context, files, master)
+    val compiler = Main.factory(ctx, files, master)
     compiler.run()
 
     // Wait for compilation to finish to produce the whole program
     compiler.join()
 
-    val syms = xt.NoSymbols.withClasses(cls.toSeq).withFunctions(funs.toSeq)
+    // Ensure the registry yields all classes and functions
+    assert(done)
+    assert(syms.classes.values.toSet == cls.toSet)
+    assert(syms.functions.values.toSet == funs.toSet)
+
     val program = inox.Program(xt)(syms)
 
     (units.toSeq, program)

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -3,7 +3,7 @@
 package stainless
 
 import extraction.xlang.{ trees => xt }
-import frontend.{ CallBackWithRegistry, Frontend }
+import frontend.{ CallBackWithRegistry, Frontend, MasterCallBack }
 import utils.CheckFilter
 
 import inox.utils.ASCIIHelpers._
@@ -81,8 +81,9 @@ class RegistryTestSuite extends FunSuite {
 
     // Create our frontend with a mock callback
     val callback = new MockCallBack(testSuiteContext, filter)
+    val master = new MasterCallBack(Seq(callback))
     val filePaths = fileMapping.values.toSeq map { _.getAbsolutePath }
-    val compiler = Main.factory(testSuiteContext, filePaths, callback)
+    val compiler = Main.factory(testSuiteContext, filePaths, master)
 
     // Process all events
     val allEvents = initialState +: events

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -145,6 +145,7 @@ class RegistryTestSuite extends FunSuite {
   private class MockCallBack(override val context: inox.Context, filter: Filter) extends CallBackWithRegistry {
 
     override val cacheSubDirectory = "mockcallback" // shouldn't be used here...
+    override def parseReportCache(json: org.json4s.JValue) = ??? // unused
     assert(context.options.findOption(frontend.optPersistentRegistryCache).isEmpty)
 
     override def shouldBeChecked(fd: xt.FunDef): Boolean = filter.shouldBeChecked(fd)

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -13,7 +13,7 @@ import java.nio.file.Files
 
 import scala.collection.mutable.ListBuffer
 
-import org.json4s.JsonAST.JArray
+import _root_.io.circe.Json
 
 import org.scalatest._
 
@@ -145,7 +145,7 @@ class RegistryTestSuite extends FunSuite {
   private class MockCallBack(override val context: inox.Context, filter: Filter) extends CallBackWithRegistry {
 
     override val cacheSubDirectory = "mockcallback" // shouldn't be used here...
-    override def parseReportCache(json: org.json4s.JValue) = ??? // unused
+    override def parseReportCache(json: Json) = ??? // unused
     assert(context.options.findOption(frontend.optPersistentRegistryCache).isEmpty)
 
     override def shouldBeChecked(fd: xt.FunDef): Boolean = filter.shouldBeChecked(fd)

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -120,7 +120,6 @@ class RegistryTestSuite extends FunSuite {
   private case class MockReport(functions: Set[FunctionName], classes: Set[ClassName]) extends AbstractReport[MockReport] {
     override val name = "dummy"
     override def emitJson = ???
-    override val width = ???
     override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = ???
     override def removeSubreports(ids: Seq[Identifier]) = ???
     override def ~(other: MockReport): MockReport =

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -120,9 +120,15 @@ class RegistryTestSuite extends FunSuite {
   /** A simply dummy report for our [[MockCallBack]]. */
   private case class MockReport(functions: Set[FunctionName], classes: Set[ClassName]) extends AbstractReport[MockReport] {
     override val name = "dummy"
+
     override def emitJson = ???
     override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = ???
-    override def removeSubreports(ids: Seq[Identifier]) = ???
+
+    override def removeSubreports(ids: Seq[Identifier]) = {
+      assert(ids.isEmpty)
+      this
+    }
+
     override def ~(other: MockReport): MockReport =
       MockReport(functions ++ other.functions, classes ++ other.classes)
   }
@@ -132,6 +138,9 @@ class RegistryTestSuite extends FunSuite {
    *
    * [[filter]] needs to be set/updated before every frontend run.
    * It also provides a way to clear previously generated reports with [[popReports]].
+   *
+   * NOTE here we don't use the report from [[CallBackWithRegistry]] because it
+   *      is not cleared upon new compilation.
    */
   private class MockCallBack(override val context: inox.Context, filter: Filter) extends CallBackWithRegistry {
     override val cacheFilename = "mockcallback" // shouldn't be used here...

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -144,7 +144,7 @@ class RegistryTestSuite extends FunSuite {
 
     override val cacheSubDirectory = "mockcallback" // shouldn't be used here...
     override def parseReportCache(json: Json) = ??? // unused
-    assert(context.options.findOption(frontend.optPersistentRegistryCache).isEmpty)
+    assert(context.options.findOption(frontend.optPersistentCache).isEmpty)
 
     override def shouldBeChecked(fd: xt.FunDef): Boolean = filter.shouldBeChecked(fd)
     override def shouldBeChecked(cd: xt.ClassDef): Boolean = filter.shouldBeChecked(cd)

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -6,7 +6,7 @@ import extraction.xlang.{ trees => xt }
 import frontend.{ CallBackWithRegistry, Frontend, MasterCallBack }
 import utils.CheckFilter
 
-import inox.utils.ASCIIHelpers._
+import inox.utils.ASCIIHelpers.Row
 
 import java.io.{ File, BufferedWriter, FileWriter }
 import java.nio.file.Files
@@ -124,7 +124,7 @@ class RegistryTestSuite extends FunSuite {
     override def emitJson = ???
     override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = ???
 
-    override def removeSubreports(ids: Seq[Identifier]) = {
+    override def invalidate(ids: Seq[Identifier]) = {
       assert(ids.isEmpty)
       this
     }

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -143,7 +143,8 @@ class RegistryTestSuite extends FunSuite {
    *      is not cleared upon new compilation.
    */
   private class MockCallBack(override val context: inox.Context, filter: Filter) extends CallBackWithRegistry {
-    override val cacheFilename = "mockcallback" // shouldn't be used here...
+
+    override val cacheSubDirectory = "mockcallback" // shouldn't be used here...
     assert(context.options.findOption(frontend.optPersistentRegistryCache).isEmpty)
 
     override def shouldBeChecked(fd: xt.FunDef): Boolean = filter.shouldBeChecked(fd)

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -124,10 +124,8 @@ class RegistryTestSuite extends FunSuite {
     override def emitJson = ???
     override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = ???
 
-    override def invalidate(ids: Seq[Identifier]) = {
-      assert(ids.isEmpty)
-      this
-    }
+    override def filter(ids: Set[Identifier]) = this // intentionally not filtering a thing!
+    // here we don't test the reports themselves, but the registry.
 
     override def ~(other: MockReport): MockReport =
       MockReport(functions ++ other.functions, classes ++ other.classes)

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -173,7 +173,7 @@ class RegistryTestSuite extends FunSuite {
     def popReport(): Report = {
       val res = reports.toSeq
       reports.clear()
-      if (res.isEmpty) MockReport(Set.empty, Set.empty) else res reduce reduceReports
+      if (res.isEmpty) MockReport(Set.empty, Set.empty) else res reduce { _ ~ _ }
     }
   }
 

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -142,6 +142,8 @@ class RegistryTestSuite extends FunSuite {
    */
   private class MockCallBack(override val context: inox.Context, filter: Filter) extends CallBackWithRegistry {
 
+    override def beginExtractions() = ()
+
     override def shouldBeChecked(fd: xt.FunDef): Boolean = filter.shouldBeChecked(fd)
     override def shouldBeChecked(cd: xt.ClassDef): Boolean = filter.shouldBeChecked(cd)
 

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1010,6 +1010,10 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     ), Seq(Apply(_, _))) if s.toString contains "Array" =>
       xt.ArrayUpdated(extractTree(lhs), extractTree(index), extractTree(value))
 
+    case Select(Apply(ExSymbol("scala", "Predef$", s), Seq(lhs)), ExNamed("size"))
+         if s.toString contains "Array" =>
+      xt.ArrayLength(extractTree(lhs))
+
     case Apply(TypeApply(ExSymbol("stainless", "collection", "List$", "apply"), Seq(tpt)), args) =>
       val tpe = extractType(tpt)
       val cons = xt.ClassType(getIdentifier(consSymbol), Seq(tpe))

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1320,6 +1320,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     case tpe if tpe.typeSymbol == defn.LongClass    => xt.Int64Type()
     case tpe if tpe.typeSymbol == defn.BooleanClass => xt.BooleanType()
     case tpe if tpe.typeSymbol == defn.UnitClass    => xt.UnitType()
+    case tpe if tpe.typeSymbol == defn.NothingClass => xt.NothingType()
 
     case tpe if isBigIntSym(tpe.typeSymbol) => xt.IntegerType()
     case tpe if isRealSym(tpe.typeSymbol)   => xt.RealType()
@@ -1409,9 +1410,6 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     case tp: TypeVar => extractType(tp.stripTypeVar)
 
     case AnnotatedType(tpe, _) => extractType(tpe)
-
-    // @nv: we want this case to be close to the end as it otherwise interferes with other cases
-    case tpe if tpe.typeSymbol == defn.NothingClass => xt.NothingType()
 
     case _ =>
       if (tpt ne null) {

--- a/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
@@ -78,7 +78,7 @@ trait ComponentTestSuite extends inox.TestSuite with inox.ResourceUtils with Inp
 
   protected def filter(ctx: inox.Context, name: String): FilterStatus = Test
 
-  def testAll(dir: String)(block: (component.Report, inox.Reporter) => Unit): Unit = {
+  def testAll(dir: String)(block: (component.Analysis, inox.Reporter) => Unit): Unit = {
     val fs = resourceFiles(dir, _.endsWith(".scala")).toList
 
     // Toggle this variable if you need to debug one specific test.

--- a/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
@@ -24,8 +24,8 @@ class LibrarySuite extends FunSpec with InputUtils {
 
       import exProgram.trees._
       val funs = exProgram.symbols.functions.values.filterNot(_.flags contains Unchecked).map(_.id).toSeq
-      val analysis: VerificationAnalysis = apply(funs, exProgram, ctx)
-      val report: VerificationReport = analysis.toReport
+      val analysis = apply(funs, exProgram, ctx)
+      val report = analysis.toReport
       assert(report.totalConditions == report.totalValid,
         "Only " + report.totalValid + " valid out of " + report.totalConditions + "\n" +
         "Invalids are:\n" + analysis.vrs.filter(_._2.isInvalid).mkString("\n") + "\n" +

--- a/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
@@ -40,9 +40,11 @@ class LibrarySuite extends FunSpec with InputUtils {
       val funs = exProgram.symbols.functions.values.filterNot(_.flags contains Unchecked).map(_.id).toSeq
       val report = apply(funs, exProgram, ctx)
 
-      assert(report.results.forall(_._2.isGuaranteed),
+      assert(
+        report.results forall { case (_, (g, _)) => g.isGuaranteed },
         "Library functions couldn't be shown terminating:\n" +
-        report.results.filterNot(_._2.isGuaranteed).map(p => p._1.id.name -> p._2).mkString("\n"))
+        (report.results collect { case (fd, (g, _)) if !g.isGuaranteed => fd.id.name -> g } mkString "\n")
+      )
     }
   }
 }

--- a/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
@@ -39,7 +39,7 @@ class LibrarySuite extends FunSpec with InputUtils {
 
       import exProgram.trees._
       val funs = exProgram.symbols.functions.values.filterNot(_.flags contains Unchecked).map(_.id).toSeq
-      val analysis: TerminationAnalysis = apply(funs, exProgram, ctx)
+      val analysis = apply(funs, exProgram, ctx)
 
       assert(
         analysis.results forall { case (_, (g, _)) => g.isGuaranteed },

--- a/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
@@ -24,11 +24,12 @@ class LibrarySuite extends FunSpec with InputUtils {
 
       import exProgram.trees._
       val funs = exProgram.symbols.functions.values.filterNot(_.flags contains Unchecked).map(_.id).toSeq
-      val report = apply(funs, exProgram, ctx)
+      val analysis: VerificationAnalysis = apply(funs, exProgram, ctx)
+      val report: VerificationReport = analysis.toReport
       assert(report.totalConditions == report.totalValid,
         "Only " + report.totalValid + " valid out of " + report.totalConditions + "\n" +
-        "Invalids are:\n" + report.vrs.filter(_._2.isInvalid).mkString("\n") + "\n" +
-        "Unknowns are:\n" + report.vrs.filter(_._2.isInconclusive).mkString("\n"))
+        "Invalids are:\n" + analysis.vrs.filter(_._2.isInvalid).mkString("\n") + "\n" +
+        "Unknowns are:\n" + analysis.vrs.filter(_._2.isInconclusive).mkString("\n"))
     }
 
     it("should terminate") {
@@ -38,12 +39,12 @@ class LibrarySuite extends FunSpec with InputUtils {
 
       import exProgram.trees._
       val funs = exProgram.symbols.functions.values.filterNot(_.flags contains Unchecked).map(_.id).toSeq
-      val report = apply(funs, exProgram, ctx)
+      val analysis: TerminationAnalysis = apply(funs, exProgram, ctx)
 
       assert(
-        report.results forall { case (_, (g, _)) => g.isGuaranteed },
+        analysis.results forall { case (_, (g, _)) => g.isGuaranteed },
         "Library functions couldn't be shown terminating:\n" +
-        (report.results collect { case (fd, (g, _)) if !g.isGuaranteed => fd.id.name -> g } mkString "\n")
+        (analysis.results collect { case (fd, (g, _)) if !g.isGuaranteed => fd.id.name -> g } mkString "\n")
       )
     }
   }

--- a/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
@@ -22,26 +22,26 @@ class TerminationSuite extends ComponentTestSuite {
   }
 
   testAll("termination/valid") { (report, _) =>
-    val failures = report.results.collect { case (fd, guarantee) if !guarantee.isGuaranteed => fd }
+    val failures = report.results collect { case (fd, (guarantee, _)) if !guarantee.isGuaranteed => fd }
     assert(failures.isEmpty, "Functions " + failures.map(_.id) + " should terminate")
   }
 
   testAll("verification/valid") { (report, _) =>
-    val failures = report.results.collect { case (fd, guarantee) if !guarantee.isGuaranteed => fd }
+    val failures = report.results collect { case (fd, (guarantee, _)) if !guarantee.isGuaranteed => fd }
     assert(failures.isEmpty, "Functions " + failures.map(_.id) + " should terminate")
   }
 
   testAll("termination/looping") { (report, _) =>
-    val looping = report.results.filter { case (fd, guarantee) => fd.id.name.startsWith("looping") }
-    val notLooping = looping.filterNot(_._2.isInstanceOf[report.checker.NonTerminating])
+    val looping = report.results filter { case (fd, _) => fd.id.name.startsWith("looping") }
+    val notLooping = looping filterNot { case (_, (g, _)) => g.isInstanceOf[report.checker.NonTerminating] }
     assert(notLooping.isEmpty, "Functions " + notLooping.map(_._1.id) + " should not terminate")
 
-    val calling = report.results.filter { case (fd, guarantee) => fd.id.name.startsWith("calling") }
-    val notCalling = calling.filterNot(_._2.isInstanceOf[report.checker.CallsNonTerminating])
+    val calling = report.results filter { case (fd, _) => fd.id.name.startsWith("calling") }
+    val notCalling = calling filterNot { case (_, (g, _)) => g.isInstanceOf[report.checker.CallsNonTerminating] }
     assert(notCalling.isEmpty, "Functions " + notCalling.map(_._1.id) + " should call non-terminating")
 
-    val guaranteed = report.results.filter { case (fd, guarantee) => fd.id.name.startsWith("ok") }
-    val notGuaranteed = guaranteed.filterNot(_._2.isGuaranteed)
+    val guaranteed = report.results filter { case (fd, _) => fd.id.name.startsWith("ok") }
+    val notGuaranteed = guaranteed filterNot { case (_, (g, _)) => g.isGuaranteed }
     assert(notGuaranteed.isEmpty, "Functions " + notGuaranteed.map(_._1.id) + " should terminate")
   }
 }

--- a/frontends/scalac/src/it/scala/stainless/verification/ImperativeSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/ImperativeSuite.scala
@@ -23,7 +23,8 @@ class ImperativeSuite extends ComponentTestSuite {
     reporter.terminateIfError()
   }
 
-  testAll("imperative/invalid") { (report, _) =>
+  testAll("imperative/invalid") { (analysis, _) =>
+    val report = analysis.toReport
     assert(report.totalInvalid > 0, "There should be at least one invalid verification condition.")
   }
 }

--- a/frontends/scalac/src/it/scala/stainless/verification/StrictArithmeticSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/StrictArithmeticSuite.scala
@@ -23,7 +23,8 @@ class StrictArithmeticSuite extends ComponentTestSuite {
     reporter.terminateIfError()
   }
 
-  testAll("strictarithmetic/invalid") { (report, _) =>
+  testAll("strictarithmetic/invalid") { (analysis, _) =>
+    val report = analysis.toReport
     assert(report.totalInvalid > 0, "There should be at least one invalid verification condition.")
   }
 }

--- a/frontends/scalac/src/it/scala/stainless/verification/UncheckedSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/UncheckedSuite.scala
@@ -13,7 +13,8 @@ trait UncheckedSuite extends ComponentTestSuite {
 
   val component = VerificationComponent
 
-  testAll("verification/unchecked") { (report, _) =>
+  testAll("verification/unchecked") { (analysis, _) =>
+    val report = analysis.toReport
     assert(report.totalInvalid > 0 || report.totalUnknown > 0, "There should be at least one invalid/unknown verification condition.")
   }
 }

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -27,15 +27,17 @@ trait VerificationSuite extends ComponentTestSuite {
     case _ => super.filter(ctx, name)
   }
 
-  testAll("verification/valid") { (report, reporter) =>
-    for ((vc, vr) <- report.vrs) {
+  testAll("verification/valid") { (analysis, reporter) =>
+    val report = analysis.toReport
+    for ((vc, vr) <- analysis.vrs) {
       if (vr.isInvalid) fail(s"The following verification condition was invalid: $vc @${vc.getPos}")
       if (vr.isInconclusive) fail(s"The following verification condition was inconclusive: $vc @${vc.getPos}")
     }
     reporter.terminateIfError()
   }
 
-  testAll("verification/invalid") { (report, _) =>
+  testAll("verification/invalid") { (analysis, _) =>
+    val report = analysis.toReport
     assert(report.totalInvalid > 0, "There should be at least one invalid verification condition.")
   }
 }

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
@@ -4,7 +4,7 @@ package stainless
 package frontends.scalac
 
 import ast.SymbolIdentifier
-import frontend.{ Frontend, ThreadedFrontend, FrontendFactory, CallBack }
+import frontend.{ Frontend, ThreadedFrontend, FrontendFactory, MasterCallBack }
 
 import scala.tools.nsc.{ Global, Settings => NSCSettings, CompilerCommand }
 import scala.reflect.internal.Positions
@@ -67,7 +67,7 @@ class SymbolMapping {
 
 }
 
-class ScalaCompiler(settings: NSCSettings, ctx: inox.Context, callback: CallBack, cache: SymbolMapping)
+class ScalaCompiler(settings: NSCSettings, ctx: inox.Context, callback: MasterCallBack, cache: SymbolMapping)
   extends Global(settings, new SimpleReporter(settings, ctx.reporter))
      with Positions {
 
@@ -112,7 +112,7 @@ object ScalaCompiler {
     override val libraryPaths: Seq[String]
   ) extends FrontendFactory {
 
-    override def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: CallBack): Frontend =
+    override def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: MasterCallBack): Frontend =
       new ThreadedFrontend(callback, ctx) {
         var underlying: ScalaCompiler#Run = _
         val cache = SymbolMapping.empty

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessExtraction.scala
@@ -4,7 +4,7 @@ package stainless
 package frontends.scalac
 
 import extraction.xlang.{trees => xt}
-import frontend.CallBack
+import frontend.MasterCallBack
 import scala.tools.nsc._
 
 /** Extract each compilation unit and forward them to the Compiler callback */
@@ -14,7 +14,7 @@ trait StainlessExtraction extends SubComponent with CodeExtraction {
   val phaseName = "stainless"
 
   implicit val ctx: inox.Context
-  protected val callback: CallBack
+  protected val callback: MasterCallBack
 
   def newPhase(prev: scala.tools.nsc.Phase): StdPhase = new Phase(prev)
 

--- a/frontends/stainless-dotty/src/main/scala/stainless/frontends/dotc/DottyCompiler.scala
+++ b/frontends/stainless-dotty/src/main/scala/stainless/frontends/dotc/DottyCompiler.scala
@@ -9,9 +9,9 @@ import dotty.tools.dotc.transform._
 import dotty.tools.dotc.core.Phases._
 import dotty.tools.dotc.core.Contexts._
 
-import frontend.{ Frontend, ThreadedFrontend, FrontendFactory, CallBack }
+import frontend.{ Frontend, ThreadedFrontend, FrontendFactory, MasterCallBack }
 
-class DottyCompiler(ctx: inox.Context, callback: CallBack, cache: SymbolsContext) extends Compiler {
+class DottyCompiler(ctx: inox.Context, callback: MasterCallBack, cache: SymbolsContext) extends Compiler {
   override def phases: List[List[Phase]] = List(
     List(new FrontEnd),
     List(new PostTyper),
@@ -39,7 +39,7 @@ object DottyCompiler {
     override val libraryPaths: Seq[String]
   ) extends FrontendFactory {
 
-    override def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: CallBack): Frontend =
+    override def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: MasterCallBack): Frontend =
       new ThreadedFrontend(callback, ctx) {
 
         // Share the same symbols between several runs.

--- a/frontends/stainless-dotty/src/main/scala/stainless/frontends/dotc/StainlessExtraction.scala
+++ b/frontends/stainless-dotty/src/main/scala/stainless/frontends/dotc/StainlessExtraction.scala
@@ -8,9 +8,9 @@ import dotty.tools.dotc.core.Phases._
 import dotty.tools.dotc.core.Contexts._
 
 import extraction.xlang.{ trees => xt }
-import frontend.CallBack
+import frontend.MasterCallBack
 
-class StainlessExtraction(inoxCtx: inox.Context, callback: CallBack, cache: SymbolsContext) extends Phase {
+class StainlessExtraction(inoxCtx: inox.Context, callback: MasterCallBack, cache: SymbolsContext) extends Phase {
 
   def phaseName: String = "stainless extraction"
 


### PR DESCRIPTION
This adds the `--registry-cache=<optional director>` option. The idea is to be able to run stainless (regardless of `--watch`) based on the results of the previous run. The cache is about the extracted AST, not the VCs, as opposed to #65. This should also be a step forward toward a possible integration in Scastie.

This PR doesn't update the report system -- another PR will be dedicated to cache the components' results and restore them. It will also be useful for `--watch` to get a full report between two verification cycles.