### PR TITLE
Jar library

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -80,6 +80,8 @@ trait MainHelpers extends inox.MainHelpers {
   /* NOTE: Should be implemented by a generated Main class in each compiler-specific project: */
   val factory: frontend.FrontendFactory
 
+  final lazy val libraryFiles = factory.libraryFiles
+
   // TODO add (optional) customisation points for CallBacks to access intermediate reports(?)
 
   def main(args: Array[String]): Unit = try {

--- a/core/src/main/scala/stainless/frontend/FrontendFactory.scala
+++ b/core/src/main/scala/stainless/frontend/FrontendFactory.scala
@@ -11,7 +11,33 @@ trait FrontendFactory {
   def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: CallBack): Frontend
 
   protected val extraCompilerArguments: Seq[String] = Nil
-  val libraryFiles: Seq[String]
+  protected val libraryPaths: Seq[String]
+  private lazy val cl = getClass.getClassLoader
+
+  /** Paths to the library files used by this frontend. */
+  final lazy val libraryFiles: Seq[String] = libraryPaths map cl.getResource map { url =>
+    // There are two run modes: either the library is not packaged in a jar, and therefore
+    // directly available as is from the disk, or it is embedded in stainless' jar file, in
+    // which case we need to extract the files to a temporary location in order to let the
+    // underlying compiler read them.
+    val path = url.getFile
+    val file = new File(path)
+    if (file.exists && file.isFile) path
+    else {
+      // JAR URL syntax: jar:<url>!/{filepath}, Expected path syntax: file:/path/a.jar!/{filepath}
+      assert(path startsWith "file:")
+      val Array(_, filepath) = path split "!/"
+      val filename = filepath.replaceAllLiterally(File.separator, "_")
+      val splitPos = filename lastIndexOf '.'
+      val (prefix, suffix) = filename splitAt splitPos
+      val tmpFilePath = Files.createTempFile(prefix, suffix)
+      val stream = url.openStream()
+      Files.copy(stream, tmpFilePath, StandardCopyOption.REPLACE_EXISTING)
+      stream.close()
+      tmpFilePath.toFile.deleteOnExit()
+      tmpFilePath.toString
+    }
+  }
 
   /** All the arguments for the underlying compiler. */
   protected def allCompilerArguments(compilerArgs: Seq[String]): Seq[String] =

--- a/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
@@ -30,6 +30,7 @@ trait ComponentTestSuite extends inox.TestSuite with inox.ResourceUtils with Inp
 
     assert(reporter.lastErrors.isEmpty)
 
+    assert((structure count { _.isMain }) == 1, "Expecting only one main unit")
     val uOpt = structure find { _.isMain }
     val u = uOpt.get
 

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
@@ -109,7 +109,7 @@ object ScalaCompiler {
   /** Complying with [[frontend]]'s interface */
   class Factory(
     override val extraCompilerArguments: Seq[String],
-    override val libraryFiles: Seq[String]
+    override val libraryPaths: Seq[String]
   ) extends FrontendFactory {
 
     override def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: CallBack): Frontend =

--- a/frontends/stainless-dotty/src/main/scala/stainless/frontends/dotc/DottyCompiler.scala
+++ b/frontends/stainless-dotty/src/main/scala/stainless/frontends/dotc/DottyCompiler.scala
@@ -36,7 +36,7 @@ object DottyCompiler {
   /** Complying with [[frontend]]'s interface */
   class Factory(
     override val extraCompilerArguments: Seq[String],
-    override val libraryFiles: Seq[String]
+    override val libraryPaths: Seq[String]
   ) extends FrontendFactory {
 
     override def apply(ctx: inox.Context, compilerArgs: Seq[String], callback: CallBack): Frontend =


### PR DESCRIPTION
Further improvement toward Scastie integration. With this PR, the stainless library files are embedded in the produced jar file(s).

 - The files are embedded in the default produced jar with `sbt package` is run. This means that the `assembly` plugin is not *required*. But do we want to be able to ship stainless with all its dependencies more easily (i.e. as a standalone binary)? If yes, it seems a reasonable thing to use. ([There seem to be some issues with assembly and stainless-dotty.](https://gist.github.com/mantognini/eb4a4b9de144bdd22943e3b5354eac9b))
 - It is also possible to run stainless as of now, that is without having the library embedded in a jar (it will get read from another directory however, namely some `target` directory).
 - You can use [this gist](https://gist.github.com/mantognini/6bd315a8063275baeec40b3cbc8b4edc) to test the jar. Add a `println` statement around `core/src/main/scala/stainless/frontend/Frontend.scala:130` if you want to check where the library is read from.

