### PR TITLE
VC filter

### DIFF
--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -15,7 +15,7 @@ trait CallBackWithRegistry extends CallBack { self =>
 
   /******************* Public Interface: Override CallBack ***************************************/
 
-  final override def beginExtractions(): Unit = { /* nothing */ }
+  override def beginExtractions(): Unit = { /* nothing */ }
 
   final override def apply(file: String, unit: xt.UnitDef,
                            classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Unit = {
@@ -63,8 +63,6 @@ trait CallBackWithRegistry extends CallBack { self =>
   protected def shouldBeChecked(fd: xt.FunDef): Boolean
   protected def shouldBeChecked(cd: xt.ClassDef): Boolean
 
-  /** Mark the end of a callback cycle. */
-  protected def onCycleEnd(): Unit = () // Nothing by default.
 
   /******************* Internal State *************************************************************/
 

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -15,8 +15,6 @@ trait CallBackWithRegistry extends CallBack { self =>
 
   /******************* Public Interface: Override CallBack ***************************************/
 
-  override def beginExtractions(): Unit = { /* nothing */ }
-
   final override def apply(file: String, unit: xt.UnitDef,
                            classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Unit = {
     context.reporter.debug(s"Got a unit for $file: ${unit.id} with:")

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -63,6 +63,8 @@ trait CallBackWithRegistry extends CallBack { self =>
   protected def shouldBeChecked(fd: xt.FunDef): Boolean
   protected def shouldBeChecked(cd: xt.ClassDef): Boolean
 
+  /** Mark the end of a callback cycle. */
+  protected def onCycleEnd(): Unit = () // Nothing by default.
 
   /******************* Internal State *************************************************************/
 

--- a/core/src/main/scala/stainless/termination/TerminationCallBack.scala
+++ b/core/src/main/scala/stainless/termination/TerminationCallBack.scala
@@ -13,6 +13,8 @@ class TerminationCallBack(override val context: inox.Context) extends CallBackWi
 
   override type Report = TerminationComponent.Report
 
+  final override def beginExtractions(): Unit = TerminationComponent.onCycleBegin()
+
   override def solve(program: Program { val trees: extraction.xlang.trees.type }): Report = {
     context.reporter.debug(
       s"Checking termination fo the following program: " +

--- a/core/src/main/scala/stainless/utils/AtomicMarks.scala
+++ b/core/src/main/scala/stainless/utils/AtomicMarks.scala
@@ -1,0 +1,28 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+package utils
+
+/** Set of marks that are atomically set. */
+class AtomicMarks[A] {
+
+  /**
+   * Atomically set the mark for [[a]].
+   *
+   * Returns [[true]] if the mark was **not** set before,
+   * [[false]] on subsequent call for the same [[a]] until
+   * a call to [[clear]].
+   */
+  def compareAndSet(a: A): Boolean = underlying.putIfAbsent(a, unusedValue).isEmpty
+
+  /**
+   * Clear all marks.
+   */
+  def clear(): Unit = underlying.clear()
+
+  private type UnusedType = Unit
+  private val unusedValue = ()
+  private val underlying = scala.collection.concurrent.TrieMap[A, UnusedType]()
+
+}
+

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -23,5 +23,8 @@ class VerificationCallBack(override val context: inox.Context) extends CallBackW
 
     VerificationComponent(program, context)
   }
+
+  override def onCycleEnd(): Unit = VerificationComponent.onCycleEnd()
+
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationCallBack.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCallBack.scala
@@ -14,6 +14,8 @@ class VerificationCallBack(override val context: inox.Context) extends CallBackW
 
   override type Report = VerificationComponent.Report
 
+  final override def beginExtractions(): Unit = VerificationComponent.onCycleBegin()
+
   override def solve(program: Program { val trees: extraction.xlang.trees.type }): Report = {
     context.reporter.debug(
       s"Verifying the following program: " +
@@ -23,8 +25,6 @@ class VerificationCallBack(override val context: inox.Context) extends CallBackW
 
     VerificationComponent(program, context)
   }
-
-  override def onCycleEnd(): Unit = VerificationComponent.onCycleEnd()
 
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -88,10 +88,6 @@ object VerificationComponent extends SimpleComponent {
     }
   }
 
-  // The marks are stored here in order to be shared among multiple VerificationChecker.
-  private val marks = new utils.AtomicMarks[Identifier]
-  def onCycleBegin(): Unit = marks.clear()
-
   def check(funs: Seq[Identifier], p: StainlessProgram, ctx: inox.Context): Map[VC[p.trees.type], VCResult[p.Model]] = {
     val injector = AssertionInjector(p, ctx)
     val encoder = inox.ast.ProgramEncoder(p)(injector)
@@ -101,7 +97,7 @@ object VerificationComponent extends SimpleComponent {
     import encoder.targetProgram.trees._
     import encoder.targetProgram.symbols._
 
-    val toVerify = funs.sortBy(getFunction(_).getPos) filter marks.compareAndSet
+    val toVerify = funs.sortBy(getFunction(_).getPos)
     ctx.reporter.debug(s"Generating VCs for those functions: ${toVerify map { _.uniqueName } mkString ", "}")
 
     for (id <- toVerify) {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -90,7 +90,7 @@ object VerificationComponent extends SimpleComponent {
 
   // The marks are stored here in order to be shared among multiple VerificationChecker.
   private val marks = new utils.AtomicMarks[Identifier]
-  def onCycleEnd(): Unit = marks.clear()
+  def onCycleBegin(): Unit = marks.clear()
 
   def check(funs: Seq[Identifier], p: StainlessProgram, ctx: inox.Context): Map[VC[p.trees.type], VCResult[p.Model]] = {
     val injector = AssertionInjector(p, ctx)
@@ -102,6 +102,7 @@ object VerificationComponent extends SimpleComponent {
     import encoder.targetProgram.symbols._
 
     val toVerify = funs.sortBy(getFunction(_).getPos) filter marks.compareAndSet
+    ctx.reporter.debug(s"Generating VCs for those functions: ${toVerify map { _.uniqueName } mkString ", "}")
 
     for (id <- toVerify) {
       if (getFunction(id).flags contains "library") {

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -142,6 +142,8 @@ class RegistryTestSuite extends FunSuite {
    */
   private class MockCallBack(override val context: inox.Context, filter: Filter) extends CallBackWithRegistry {
 
+    override def beginExtractions() = ()
+
     override def shouldBeChecked(fd: xt.FunDef): Boolean = filter.shouldBeChecked(fd)
     override def shouldBeChecked(cd: xt.ClassDef): Boolean = filter.shouldBeChecked(cd)
 


### PR DESCRIPTION
This filter avoids computing the same VCs twice during the same extraction cycle, which can yield several overlapping sub-programs.