### PR TITLE
Increase memory limits when launching stainless

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -179,7 +179,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
                                |
                                |SCALACLASSPATH="$paths"
                                |
-                               |java -Xmx2G -Xms512M -Xss64M -classpath "$${SCALACLASSPATH}" -Dscala.usejavacp=true stainless.Main $$@ 2>&1 | tee -i last.log
+                               |java -Xmx8G -Xms2G -Xss1G -classpath "$${SCALACLASSPATH}" -Dscala.usejavacp=true stainless.Main $$@ 2>&1 | tee -i last.log
                                |""".stripMargin)
       scriptFile.setExecutable(true)
     } catch {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -61,7 +61,7 @@ object VerificationComponent extends SimpleComponent {
           Cell(vc.kind.name),
           Cell(vc.getPos.fullString),
           Cell(vr.status),
-          Cell(vr.solver.map(_.name).getOrElse("")),
+          Cell(vr.solverName.getOrElse("")),
           Cell(vr.time.map(t => f"${t / 1000d}%3.3f").getOrElse(""))
         ))
       },
@@ -109,8 +109,8 @@ object VerificationComponent extends SimpleComponent {
     val vcs = VerificationGenerator.gen(encoder.targetProgram, ctx)(funs)
 
     VerificationChecker.verify(encoder.targetProgram, ctx)(vcs).mapValues {
-      case VCResult(VCStatus.Invalid(model), s, t) =>
-        VCResult(VCStatus.Invalid(model.encode(encoder.reverse)), s, t)
+      case VCResult(VCStatus.Invalid(model), solverName, t) =>
+        VCResult(VCStatus.Invalid(model.encode(encoder.reverse)), solverName, t)
       case res => res.asInstanceOf[VCResult[p.Model]]
     }
   }

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -54,7 +54,7 @@ object VCStatus {
 
 case class VCResult[+Model](
   status: VCStatus[Model],
-  solver: Option[Solver],
+  solverName: Option[String],
   time: Option[Long]
 ) {
   def isValid           = status == VCStatus.Valid || isValidFromCache


### PR DESCRIPTION
This is a modest PR to fix issues I've been having when running stainless on Mac. Thanks @gsps for the tip! :-)

This fixes (or at least reduces) errors such as

    java(9672,0x70010ae84000) malloc: *** error for object 0x7f8e72294c00: double free

The main limitation was the stack size. Other parameters were also increased however.