### PR TITLE
Update for new Timer API

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val isMac     = osInf.indexOf("Mac") >= 0
 val osName = if (isWindows) "win" else if (isMac) "mac" else "unix"
 val osArch = System.getProperty("sun.arch.data.model")
 
-val inoxVersion = "1.0.2-182-g6bb5560"
+val inoxVersion = "1.0.2-191-g3b196ab"
 val dottyVersion = "0.1.1-bin-20170429-10a2ce6-NIGHTLY"
 
 lazy val nParallel = {

--- a/core/src/main/scala/stainless/termination/ChainProcessor.scala
+++ b/core/src/main/scala/stainless/termination/ChainProcessor.scala
@@ -25,9 +25,7 @@ trait ChainProcessor extends OrderingProcessor {
       case (path, e1) => path implies ordering.lessThan(Seq(recons(e1)), Seq(recons(e2)))
     }))
 
-  def run(problem: Problem) = {
-    val timer = timers.termination.processors.chains.start()
-
+  def run(problem: Problem) = timers.termination.processors.chains.run {
     strengthenPostconditions(problem.funSet)
     strengthenApplications(problem.funSet)
 
@@ -42,7 +40,6 @@ trait ChainProcessor extends OrderingProcessor {
 
     if (loopPoints.size > 1) {
       reporter.debug("-+> Multiple looping points, can't build chain proof")
-      timer.stop()
       None
     } else {
       val funDefs = if (loopPoints.nonEmpty) {
@@ -77,14 +74,8 @@ trait ChainProcessor extends OrderingProcessor {
         cleared = remaining.isEmpty
       }
 
-      val res = if (cleared) {
-        Some(problem.funDefs map Cleared)
-      } else {
-        None
-      }
-
-      timer.stop()
-      res
+      if (cleared) Some(problem.funDefs map Cleared)
+      else None
     }
   }
 }

--- a/core/src/main/scala/stainless/termination/ControlFlowAnalysis.scala
+++ b/core/src/main/scala/stainless/termination/ControlFlowAnalysis.scala
@@ -104,11 +104,8 @@ trait CICFA {
   case class Summary(in: AbsEnv, out: AbsEnv, ret: Set[AbsValue])
 
   private val cache: MutableMap[Identifier, Analysis] = MutableMap.empty
-  def analyze(id: Identifier): Analysis = cache.getOrElseUpdate(id, {
-    val timer = timers.termination.cfa.start()
-    val analysis = new Analysis(id)
-    timer.stop()
-    analysis
+  def analyze(id: Identifier): Analysis = cache.getOrElseUpdate(id, timers.termination.cfa.run {
+    new Analysis(id)
   })
 
   class Analysis(id: Identifier) {

--- a/core/src/main/scala/stainless/termination/DecreasesProcessor.scala
+++ b/core/src/main/scala/stainless/termination/DecreasesProcessor.scala
@@ -29,13 +29,11 @@ trait DecreasesProcessor extends Processor { self =>
   private val zero = IntegerLiteral(0)
   private val tru = BooleanLiteral(true)
 
-  def run(problem: Problem): Option[Seq[Result]] = {
-    val timer = timers.termination.processors.decreases.start()
-
+  def run(problem: Problem): Option[Seq[Result]] = timers.termination.processors.decreases.run {
     val fds = problem.funDefs
     val fdIds = problem.funSet.map(_.id)
 
-    val res = if (fds.exists { _.measure.isDefined }) {
+    if (fds.exists { _.measure.isDefined }) {
       val api = getAPI
 
       // Important:
@@ -147,8 +145,5 @@ trait DecreasesProcessor extends Processor { self =>
     } else {
       None // nothing is cleared here, so other phases will apply
     }
-
-    timer.stop()
-    res
   }
 }

--- a/core/src/main/scala/stainless/termination/LoopProcessor.scala
+++ b/core/src/main/scala/stainless/termination/LoopProcessor.scala
@@ -31,9 +31,7 @@ trait LoopProcessor extends OrderingProcessor {
     protected def transformADT(adt: ADTDefinition): ADTDefinition = adt
   }
 
-  def run(problem: Problem) = {
-    val timer = timers.termination.processors.loops.start()
-
+  def run(problem: Problem) = timers.termination.processors.loops.run {
     strengthenApplications(problem.funSet)
     val api = getAPI(withoutPosts)
 
@@ -66,13 +64,7 @@ trait LoopProcessor extends OrderingProcessor {
       cs.flatMap(c1 => chains.flatMap(c2 => c1.compose(c2)))
     }
 
-    val res = if (nonTerminating.nonEmpty) {
-      Some(nonTerminating.values.toSeq)
-    } else {
-      None
-    }
-
-    timer.stop()
-    res
+    if (nonTerminating.nonEmpty) Some(nonTerminating.values.toSeq)
+    else None
   }
 }

--- a/core/src/main/scala/stainless/termination/RecursionProcessor.scala
+++ b/core/src/main/scala/stainless/termination/RecursionProcessor.scala
@@ -29,14 +29,12 @@ trait RecursionProcessor extends Processor {
     rec(expr, true)
   }
 
-  def run(problem: Problem) = if (problem.funDefs.size > 1) None else {
-    val timer = timers.termination.processors.recursion.start()
-
+  def run(problem: Problem) = if (problem.funDefs.size > 1) None else timers.termination.processors.recursion.run {
     val funDef = problem.funDefs.head
     val relations = getRelations(funDef)
     val (recursive, others) = relations.partition { case Relation(fd, _, fi, _) => fd == fi.tfd.fd }
 
-    val res = if (others.exists({ case Relation(_, _, fi, _) => !checker.terminates(fi.tfd.fd).isGuaranteed })) {
+    if (others.exists({ case Relation(_, _, fi, _) => !checker.terminates(fi.tfd.fd).isGuaranteed })) {
       None
     } else if (recursive.isEmpty) {
       Some(Cleared(funDef) :: Nil)
@@ -59,8 +57,5 @@ trait RecursionProcessor extends Processor {
       else
         None
     }
-
-    timer.stop()
-    res
   }
 }

--- a/core/src/main/scala/stainless/termination/RelationProcessor.scala
+++ b/core/src/main/scala/stainless/termination/RelationProcessor.scala
@@ -18,9 +18,7 @@ trait RelationProcessor extends OrderingProcessor {
   import checker.program.symbols._
   import ordering._
 
-  def run(problem: Problem): Option[Seq[Result]] = {
-    val timer = timers.termination.processors.relation.start()
-
+  def run(problem: Problem): Option[Seq[Result]] = timers.termination.processors.relation.run {
     strengthenPostconditions(problem.funSet)
     strengthenApplications(problem.funSet)
 
@@ -83,13 +81,7 @@ trait RelationProcessor extends OrderingProcessor {
 
     assert(terminating ++ nonTerminating == problem.funSet)
 
-    val res = if (nonTerminating.isEmpty) {
-      Some(terminating.map(Cleared).toSeq)
-    } else {
-      None
-    }
-
-    timer.stop()
-    res
+    if (nonTerminating.isEmpty) Some(terminating.map(Cleared).toSeq)
+    else None
   }
 }

--- a/core/src/main/scala/stainless/termination/SelfCallsProcessor.scala
+++ b/core/src/main/scala/stainless/termination/SelfCallsProcessor.scala
@@ -16,21 +16,17 @@ trait SelfCallsProcessor extends Processor {
   import checker.program.trees._
   import checker.program.symbols._
 
-  def run(problem: Problem) = {
+  def run(problem: Problem) = timers.termination.processors.`self-calls`.run {
     reporter.debug("- Self calls processor...")
-    val timer = timers.termination.processors.`self-calls`.start()
 
     val nonTerminating = problem.funDefs
       .filter(fd => alwaysCalls(fd.fullBody, fd.id))
 
-    val res = if (nonTerminating.nonEmpty) {
+    if (nonTerminating.nonEmpty) {
       Some(nonTerminating.map(fd => Broken(fd, LoopsGivenInputs(name, fd.params.map(_.toVariable)))))
     } else {
       None
     }
-
-    timer.stop()
-    res
   }
 
   private def alwaysCalls(expr: Expr, fid: Identifier): Boolean = {

--- a/core/src/main/scala/stainless/termination/SolverProvider.scala
+++ b/core/src/main/scala/stainless/termination/SolverProvider.scala
@@ -44,8 +44,7 @@ trait SolverProvider { self =>
   private[termination] def clearSolvers(): Unit = cache.clear()
 
   private def solverFactory(transformer: inox.ast.SymbolTransformer { val s: trees.type; val t: trees.type }) =
-    cache.cached(transformer, {
-      val timer = timers.termination.encoding.start()
+    cache.cached(transformer, timers.termination.encoding.run {
       val transformEncoder = inox.ast.ProgramEncoder(checker.program)(transformer)
       val p: transformEncoder.targetProgram.type = transformEncoder.targetProgram
 
@@ -65,15 +64,12 @@ trait SolverProvider { self =>
         case None => 2.5.seconds
       }
 
-      val factory = solvers.SolverFactory
+      solvers.SolverFactory
         .getFromSettings(p, context.withOpts(
           inox.solvers.optSilentErrors(true),
           inox.solvers.optCheckModels(true)
         ))(programEncoder)(p.getSemantics)
         .withTimeout(timeout)
-
-      timer.stop()
-      factory
     })
 
   private def solverAPI(transformer: inox.ast.SymbolTransformer { val s: trees.type; val t: trees.type }) = {

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -129,6 +129,7 @@ object TerminationComponent extends SimpleComponent {
 
     val c = TerminationChecker(p, ctx)
 
+    // TODO update this code to use `.run { ... }` for timers when merging #67: persistent cache.
     val timer = timers.termination.start()
 
     val toVerify = funs.map(getFunction(_)).sortBy(_.getPos)

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -131,10 +131,11 @@ trait VerificationChecker { self =>
         }
       } catch {
         case u: Unsupported =>
-          val t = timer.selfTimer.get
-          val time = if (t.isRunning) t.stop else t.runs.last
+          val time = if (timer.isRunning) timer.stop else timer.time
           reporter.warning(u.getMessage)
           VCResult(VCStatus.Unsupported, Some(s), Some(time))
+      } finally {
+        if (timer.isRunning) timer.stop()
       }
 
       reporter.synchronized {


### PR DESCRIPTION
Adapt stainless to changes introduced in epfl-lara/inox#39. Doesn't compile as-is: `build.sbt` needs to be updated and refer to a newest version of inox.

`TerminationComponent` will be updated after #67 is merged (merge conflict anyway).