### PR TITLE
Parallel off for macOS

### DIFF
--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -65,13 +65,14 @@ trait VerificationChecker { self =>
 
     val initMap: Map[VC, VCResult] = vcs.map(vc => vc -> unknownResult).toMap
 
-    val results =
-      for (vc <- MainHelpers.par(vcs) if !stop && !interruptManager.isInterrupted) yield {
+    val results = MainHelpers.par(vcs) flatMap { vc =>
+      if (stop) None else {
         val res = checkVC(vc, sf)
         if (interruptManager.isInterrupted) interruptManager.reset()
         stop = stopWhen(res)
-        vc -> res
+        Some(vc -> res)
       }
+    }
 
     initMap ++ results
   }


### PR DESCRIPTION
Built on top of #76 for testing purposes (the crash are much more frequent with the newest changes). This PR disables parallelism on Apple's OS to workaround z3 crashes (as far as I can tell). See Z3Prover/z3#1080 & #74.