### PR TITLE
Add missing case for type `Any` in `dotc.CodeExtraction`

### DIFF
--- a/frontends/benchmarks/extraction/ExtractAny.scala
+++ b/frontends/benchmarks/extraction/ExtractAny.scala
@@ -1,0 +1,16 @@
+import stainless.lang._
+
+object any {
+
+  def add(x: Any, s: Set[Any]): Set[Any] = {
+    s + x
+  }
+
+  def e: Set[Any] = Set.empty[Any]
+
+  def test(x: Any): Set[Any] = {
+    add(x, e)
+  } ensuring { _ contains x }
+
+}
+

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1322,6 +1322,10 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     case tpe if tpe.typeSymbol == defn.UnitClass    => xt.UnitType()
     case tpe if tpe.typeSymbol == defn.NothingClass => xt.NothingType()
 
+    // `isRef` seems to be needed here instead of `==`, as the latter
+    // seems to be too lax, and makes the whole test suite fail. - @romac
+    case tpe if tpe.isRef(defn.AnyClass)            => xt.AnyType()
+
     case tpe if isBigIntSym(tpe.typeSymbol) => xt.IntegerType()
     case tpe if isRealSym(tpe.typeSymbol)   => xt.RealType()
     case tpe if isStringSym(tpe.typeSymbol) => xt.StringType()


### PR DESCRIPTION
The type `Any` was previously not extracted, which would yield the following error, when referencing it:

```
[ Error  ] foo$0 depends on missing dependencies: Any$0.
[Internal] Missing some nodes in Registry: Any$0
[Internal] Please inform the authors of Inox about this message
```

This seems to be what is currently making #77's test suite fail.