### PR TITLE
Allow forcing the evaluation of ground function calls

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -84,6 +84,7 @@ trait MainHelpers extends inox.MainHelpers {
     termination.DebugSectionTermination,
     DebugSectionExtraction,
     frontend.DebugSectionFrontend,
+    forcing.DebugSectionForcing,
     utils.DebugSectionRegistry
   )
 

--- a/core/src/main/scala/stainless/ast/Definitions.scala
+++ b/core/src/main/scala/stainless/ast/Definitions.scala
@@ -8,11 +8,13 @@ import scala.collection.mutable.{Map => MutableMap}
 
 trait Definitions extends inox.ast.Definitions { self: Trees =>
 
+  case object Force extends Flag("force", Seq())
   case object Extern extends Flag("extern", Seq.empty)
   case object Unchecked extends Flag("unchecked", Seq.empty)
   case class Derived(id: Identifier) extends Flag("derived", Seq(id))
 
   override def extractFlag(name: String, args: Seq[Any]): Flag = (name, args) match {
+    case ("force", Seq()) => Force
     case ("extern", Seq()) => Extern
     case ("unchecked", Seq()) => Unchecked
     case _ => super.extractFlag(name, args)

--- a/core/src/main/scala/stainless/ast/Extractors.scala
+++ b/core/src/main/scala/stainless/ast/Extractors.scala
@@ -191,6 +191,7 @@ trait TreeDeconstructor extends inox.ast.TreeDeconstructor {
   }
 
   override def deconstruct(f: s.Flag): DeconstructedFlag = f match {
+    case s.Force => (Seq(), Seq(), Seq(), (_, _, _) => t.Force)
     case s.Extern => (Seq(), Seq(), Seq(), (_, _, _) => t.Extern)
     case s.Unchecked => (Seq(), Seq(), Seq(), (_, _, _) => t.Unchecked)
     case s.Derived(id) => (Seq(id), Seq(), Seq(), (ids, _, _) => t.Derived(ids.head))

--- a/core/src/main/scala/stainless/extraction/inlining/package.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/package.scala
@@ -4,7 +4,7 @@ package stainless
 package extraction
 
 package object inlining {
-  
+
   object trees extends Trees with inox.ast.SimpleSymbols {
     case class Symbols(
       functions: Map[Identifier, FunDef],

--- a/core/src/main/scala/stainless/forcing/Forcing.scala
+++ b/core/src/main/scala/stainless/forcing/Forcing.scala
@@ -1,0 +1,82 @@
+/* Copyright 2009-2017 EPFL, Lausanne */
+
+package stainless
+package forcing
+
+import inox.solvers.PurityOptions
+import inox.evaluators.EvaluationResults._
+
+import stainless.extraction.Trees
+
+object DebugSectionForcing extends inox.DebugSection("forcing")
+
+class Forcing(
+  override val sourceProgram: StainlessProgram,
+  val context: inox.Context
+) extends inox.ast.ProgramTransformer { self =>
+
+  import context._
+  import sourceProgram._
+  import sourceProgram.trees._
+  import sourceProgram.symbols._
+  import sourceProgram.trees.exprOps._
+
+  override final object encoder extends IdentityTreeTransformer
+  override final object decoder extends IdentityTreeTransformer
+
+  implicit val debugSection = DebugSectionForcing
+
+  implicit private val semantics = sourceProgram.getSemantics
+
+  override final lazy val targetProgram: Program { val trees: sourceProgram.trees.type } = {
+    inox.Program(sourceProgram.trees)(transform(sourceProgram.symbols))
+  }
+
+  object transformer extends IdentityTreeTransformer
+
+  private val evaluator = semantics.getEvaluator
+
+  private def transform(syms: Symbols): Symbols = {
+    def shouldForce(fi: FunctionInvocation): Boolean = {
+      syms.functions(fi.id).flags.contains(Force) && isGround(fi)
+    }
+
+    NoSymbols
+      .withADTs(symbols.adts.values.map(transformer.transform).toSeq)
+      .withFunctions(symbols.functions.values.toSeq.map { fd =>
+        val forcedBody = exprOps.postMap {
+          case fi: FunctionInvocation if shouldForce(fi) => Some(force(fi))
+          case _ => None
+        } (fd.fullBody)
+
+        transformer.transform(fd.copy(fullBody = forcedBody, flags = fd.flags - Force))
+      })
+  }
+
+  private def force(fi: FunctionInvocation): Expr = {
+    reporter.debug(s"Forcing invocation of `${fi.id}` @ ${fi.getPos}...")
+    reporter.debug(s" - Before: $fi...")
+    val res = evaluator.eval(fi) match {
+      case Successful(e) => exprOps.freshenLocals(e)
+      case error =>
+        context.reporter.error(ForcingError(fi, error))
+        fi
+    }
+    reporter.debug(s" - After: $res")
+    res
+  }
+
+  case class ForcingError(expr: Expr, result: Result[Expr]) {
+    val error: String = result match {
+      case RuntimeError(msg) =>
+        s"runtime error: $msg"
+      case EvaluatorError(msg) =>
+        s"evaluator error: $msg"
+      case _ => ""
+    }
+
+    override def toString: String = {
+      s"Forced evaluation of expression @ ${expr.getPos} failed because of a $error"
+    }
+  }
+}

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -21,7 +21,11 @@ trait InoxEncoder extends ProgramEncoder {
     inox.InoxProgram(t.NoSymbols
       .withADTs(sourceProgram.symbols.adts.values.toSeq.map(encoder.transform))
       .withFunctions(sourceProgram.symbols.functions.values.toSeq
-        .map(fd => fd.copy(flags = fd.flags.filter { case Derived(_) | Unchecked => false case _ => true }))
+        .map { fd =>
+          fd.copy(flags = fd.flags.filter {
+            case Derived(_) | Unchecked | Force => false case _ => true
+          })
+        }
         .map { fd =>
           if (fd.flags contains Extern) {
             val Lambda(Seq(vd), post) = fd.postOrTrue

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -49,11 +49,16 @@ object VerificationComponent extends SimpleComponent {
     }
   }
 
+  private def force(p: StainlessProgram, ctx: inox.Context): StainlessProgram = {
+    new forcing.Forcing(p, ctx).targetProgram
+  }
+
   override def apply(funs: Seq[Identifier], p: StainlessProgram, ctx: inox.Context): VerificationAnalysis = {
-    val res = check(funs, p, ctx)
+    val forced = force(p, ctx)
+    val res = check(funs, forced, ctx)
 
     new VerificationAnalysis {
-      override val program: p.type = p
+      override val program: forced.type = forced
       override val sources = funs.toSet
       override val results = res
     }

--- a/frontends/benchmarks/verification/valid/Factorial.scala
+++ b/frontends/benchmarks/verification/valid/Factorial.scala
@@ -1,0 +1,44 @@
+import stainless.lang._ // for the holds keyword
+import stainless.annotation._ // for the force annotation
+import scala.language.postfixOps // to avoid warnings about postfix holds
+
+object Factorial {
+  sealed abstract class Nat
+  case object O extends Nat
+  case class S(n: Nat) extends Nat
+
+  val one = S(O)
+  val two = S(one)
+  val three = S(two)
+  val four = S(three)
+  val five = S(four)
+  val six = S(five)
+  val seven = S(six)
+  val eight = S(seven)
+  val nine = S(eight)
+  val ten = S(nine)
+  val eleven = S(ten)
+  val twelve = S(eleven)
+
+  @force
+  def plus(n: Nat)(m: Nat): Nat = n match {
+    case O => m
+    case S(n2) => S(plus(n2)(m))
+  }
+
+  @force
+  def mult(n: Nat)(m: Nat): Nat = n match {
+    case O => O
+    case S(n2) => plus(m)(mult(n2)(m))
+  }
+
+  @force
+  def factorial(n: Nat): Nat = n match {
+    case O => S(O)
+    case S(n2) => mult(n)(factorial(n2))
+  }
+
+  def test_factorial2() = {
+    factorial(five) == mult(ten)(twelve)
+  } holds
+}

--- a/frontends/benchmarks/verification/valid/TVar.scala
+++ b/frontends/benchmarks/verification/valid/TVar.scala
@@ -1,0 +1,196 @@
+import stainless.lang._
+import stainless.collection._
+import stainless.annotation._
+
+import scala.language.postfixOps
+
+object tvar {
+
+  case class WaitMap(map: Map[BigInt, List[Process]]) {
+    def apply(tvarId: BigInt): List[Process] = {
+      if (map contains tvarId) map(tvarId)
+      else Nil()
+    }
+
+    def updated(tvarId: BigInt, processes: List[Process]): WaitMap = {
+      WaitMap(map.updated(tvarId, processes))
+    }
+
+    def waitOn(tvarId: BigInt, process: Process): WaitMap = {
+      updated(tvarId, apply(tvarId) :+ process)
+    }
+
+    def unwaitOn(tvarId: BigInt, process: Process): WaitMap = {
+      updated(tvarId, apply(tvarId) - process)
+    }
+  }
+
+  object WaitMap {
+    def empty: WaitMap = WaitMap(Map.empty[BigInt, List[Process]])
+  }
+
+  case class TVarMap(map: Map[BigInt, TVar]) {
+    def apply(id: BigInt): TVar = {
+      if (map contains id) map(id)
+      else TVar(id, None())
+    }
+
+    def update(tvar: TVar): TVarMap = {
+      TVarMap(map.updated(tvar.id, tvar))
+    }
+  }
+
+  object TVarMap {
+    def empty: TVarMap = TVarMap(Map.empty[BigInt, TVar])
+  }
+
+  sealed abstract class Op
+
+  case class Take(process: Process, tvar: BigInt) extends Op
+  case class Put(process: Process, tvar: BigInt, value: BigInt) extends Op
+
+  case class TVar(id: BigInt, value: Option[BigInt]) {
+    def isEmpty: Boolean  = !nonEmpty
+    def nonEmpty: Boolean = value.isDefined
+
+    def get: BigInt = {
+      require(nonEmpty)
+      value.get
+    }
+
+    def set(x: BigInt): TVar = {
+      require(isEmpty)
+      TVar(id, Some(x))
+    }
+
+    def empty: TVar = {
+      require(nonEmpty)
+      TVar(id, None())
+    }
+  }
+
+  case class Process(id: BigInt) {
+
+    def take(tvar: TVar): Op =
+      Take(this, tvar.id)
+
+    def put(tvar: TVar, value: BigInt): Op =
+      Put(this, tvar.id, value)
+
+  }
+
+  sealed abstract class Event
+  object Event {
+    case class Put(pid: BigInt, tid: BigInt, value: BigInt)  extends Event
+    case class Take(pid: BigInt, tid: BigInt, value: BigInt) extends Event
+    case class Deadlock(processId: BigInt, tvarId: BigInt)   extends Event
+  }
+
+  case class System(
+    tvars: TVarMap,
+    waitMap: WaitMap,
+    trace: List[Event],
+    ops: List[Op]
+  ) {
+
+    @inline
+    def isDeadlocked: Boolean = {
+      trace.nonEmpty && trace.last.isInstanceOf[Event.Deadlock]
+    }
+
+    def run: System = {
+      val next = step
+      if (next.isDeadlocked || next == this) next
+      else next.run
+    }
+
+    def step: System = {
+      ops match {
+        case Nil() => this
+        case op :: rest =>
+          op match {
+            case Take(process, tid) if tvars(tid).nonEmpty =>
+              val waitingOn = waitMap(tid)
+              val value     = tvars(tid).get
+
+              System(
+                tvars.update(tvars(tid).empty),
+                waitMap.unwaitOn(tid, process),
+                trace :+ Event.Take(process.id, tid, value),
+                rest
+              )
+
+            case Take(process, tid) if tvars(tid).isEmpty =>
+              val newTrace = if (rest.isEmpty) trace :+ Event.Deadlock(process.id, tid) else trace
+              System(
+                tvars,
+                waitMap.waitOn(tid, process),
+                newTrace,
+                rest :+ op
+              )
+
+            case Put(process, tid, _) if tvars(tid).nonEmpty =>
+              val newTrace = if (rest.isEmpty) trace :+ Event.Deadlock(process.id, tid) else trace
+              System(
+                tvars,
+                waitMap.waitOn(tid, process),
+                newTrace,
+                rest :+ op
+              )
+
+            case Put(process, tid, value) if tvars(tid).isEmpty =>
+              System(
+                tvars.update(tvars(tid).set(value)),
+                waitMap.unwaitOn(tid, process),
+                trace :+ Event.Put(process.id, tid, value),
+                rest
+              )
+          }
+      }
+    }
+  }
+
+  val a  = TVar(1, None())
+  val p1 = Process(1)
+  val p2 = Process(2)
+
+  val p1Ops = List(p1.take(a))
+  val p2Ops = List(p2.put(a, 42), p2.take(a))
+
+  @force
+  def traces[A](p1: List[A], p2: List[A]): List[List[A]] = {
+    (subTraces(p1, p2) ++ subTraces(p2, p1)).unique
+  }
+
+  def subTraces[A](p1: List[A], p2: List[A]): List[List[A]] = p1 match {
+    case Nil()   => List(p2)
+    case x :: xs => traces(xs, p2).map(x :: _)
+  }
+
+  def runs = traces(p1Ops, p2Ops)
+
+  def test = {
+    runs == List(
+      List(p1.take(a), p2.put(a, 42), p2.take(a)),
+      List(p2.put(a, 42), p2.take(a), p1.take(a)),
+      List(p2.put(a, 42), p1.take(a), p2.take(a))
+    )
+  } holds
+
+  @force
+  def deadlocks(ops: List[Op]) = {
+    val system = System(
+      TVarMap(Map(a.id -> a)),
+      WaitMap.empty,
+      List(),
+      ops
+    )
+
+    system.run.isDeadlocked
+  }
+
+  def run1 = deadlocks(runs(0)).holds
+  def run2 = deadlocks(runs(1)).holds
+  def run3 = deadlocks(runs(2)).holds
+
+}

--- a/frontends/library/stainless/annotation/package.scala
+++ b/frontends/library/stainless/annotation/package.scala
@@ -20,6 +20,8 @@ package object annotation {
   class internal   extends Annotation
   @ignore
   class pure       extends Annotation
+  @ignore
+  class force      extends Annotation
 
   // Orb annotations
   @ignore

--- a/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
@@ -15,6 +15,7 @@ class TerminationSuite extends ComponentTestSuite {
 
   override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
     case "termination/valid/NNF" => Skip
+    case "termination/valid/TVar" => Skip
     case "termination/valid/NNFSimple" => Ignore // Too slow, make regression unstable
     case "verification/valid/Nested14" => Ignore
     // smt-z3 crashes on some permutations of the MergeSort2 problem encoding due to Bags...


### PR DESCRIPTION
- Add a `@force` annotation which forces the evaluation of the function body.
- Add a `forcing` debug section which prints which functions are being forced, as well as the result of the evaluation.

This PR depends on https://github.com/epfl-lara/inox/pull/48.