### PR TITLE
Improved watch mode

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -51,15 +51,6 @@ trait MainHelpers extends inox.MainHelpers {
   case object Verification extends Category
   case object Termination extends Category
 
-  object optJson extends inox.OptionDef[String] {
-    val name = "json"
-    val default = "report.json"
-    val parser = inox.OptionParsers.stringParser
-    val usageRhs = "file"
-  }
-
-  object optWatch extends inox.FlagOptionDef("watch", false)
-
   override protected def getOptions = super.getOptions - inox.solvers.optAssumeChecked ++ Map(
     optFunctions -> Description(General, "Only consider functions s1,s2,..."),
     evaluators.optCodeGen -> Description(Evaluators, "Use code generating evaluator"),
@@ -132,7 +123,7 @@ trait MainHelpers extends inox.MainHelpers {
     // Run the first cycle
     runCycle()
 
-    val watchMode = ctx.options.findOptionOrDefault(optWatch)
+    val watchMode = isWatchModeOn(ctx)
     if (watchMode) {
       val files: Set[File] = compiler.sources.toSet map { file: String => new File(file).getAbsoluteFile }
       val watcher = new utils.FileWatcher(ctx, files, action = runCycle)

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -65,13 +65,13 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
 }
 
 object AbstractReportHelper {
-  trait Record { val id: Identifier }
+  trait Record { val derivedFrom: Identifier }
 
   /**
    * Keep records which `id` are present in [[ids]], and returns the next generation counter.
    */
   def filter[R <: Record](records: Seq[R], ids: Set[Identifier], lastGen: Long): (Seq[R], Long) =
-    (records filter { ids contains _.id }, lastGen + 1)
+    (records filter { ids contains _.derivedFrom }, lastGen + 1)
 
   /**
    * Merge two sets of records [[R]] into one, and returns the next generation counter.
@@ -80,7 +80,7 @@ object AbstractReportHelper {
    * The [[updater0]] function takes as first parameter the next generation counter.
    */
   def merge[R <: Record](prevs: Seq[R], news: Seq[R], lastGen: Long, updater0: Long => R => R): (Seq[R], Long) = {
-    def buildMapping(subs: Seq[R]): Map[Identifier, Seq[R]] = subs groupBy { _.id }
+    def buildMapping(subs: Seq[R]): Map[Identifier, Seq[R]] = subs groupBy { _.derivedFrom }
 
     val prev = buildMapping(prevs)
     val next0 = buildMapping(news)

--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -14,6 +14,17 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
   import trees.exprOps._
   import symbols._
 
+  /**
+   * Get the source of this function
+   *
+   * i.e. either its identifier or the identifier of its (recursively) outer function.
+   *
+   * NOTE no need to actually recurse here as [[Derived]] already
+   *      holds the requested data.
+   */
+  def source(fd: FunDef): Identifier =
+    fd.flags collectFirst { case Derived(id) => id } getOrElse fd.id
+
   override protected def createSimplifier(opts: inox.solvers.PurityOptions) =
     new SimplifierWithPC(opts) with transformers.SimplifierWithPC
 

--- a/core/src/main/scala/stainless/package.scala
+++ b/core/src/main/scala/stainless/package.scala
@@ -4,6 +4,16 @@ package object stainless {
 
   object DebugSectionExtraction extends inox.DebugSection("extraction")
 
+  object optJson extends inox.OptionDef[String] {
+    val name = "json"
+    val default = "report.json"
+    val parser = inox.OptionParsers.stringParser
+    val usageRhs = "file"
+  }
+
+  object optWatch extends inox.FlagOptionDef("watch", false)
+  def isWatchModeOn(implicit ctx: inox.Context) = ctx.options.findOptionOrDefault(optWatch)
+
   type Program = inox.Program { val trees: ast.Trees }
 
   type StainlessProgram = Program { val trees: stainless.trees.type }

--- a/core/src/main/scala/stainless/termination/TerminationAnalysis.scala
+++ b/core/src/main/scala/stainless/termination/TerminationAnalysis.scala
@@ -22,7 +22,8 @@ trait TerminationAnalysis extends AbstractAnalysis {
   override type Report = TerminationReport
 
   override def toReport = new TerminationReport(results.toSeq map { case (fd, (g, time)) =>
-    TerminationReport.Record(fd.id, fd.getPos, time, status(g), verdict(g, fd), kind(g))
+    val source = symbols.source(fd)
+    TerminationReport.Record(fd.id, fd.getPos, time, status(g), verdict(g, fd), kind(g), derivedFrom = source)
   })
 
   private def kind(g: TerminationGuarantee): String = g match {

--- a/core/src/main/scala/stainless/termination/TerminationReport.scala
+++ b/core/src/main/scala/stainless/termination/TerminationReport.scala
@@ -30,6 +30,7 @@ object TerminationReport {
   case class Record(
     id: Identifier, pos: inox.utils.Position, time: Long,
     status: Status, verdict: String, kind: String,
+    derivedFrom: Identifier,
     generation: Long = 0 // "age" of the record, usefull to determine which ones are "NEW".
   ) extends AbstractReportHelper.Record
 
@@ -70,7 +71,7 @@ class TerminationReport(val results: Seq[TerminationReport.Record], lastGen: Lon
   }
 
   override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (results.isEmpty) None else {
-    val rows = for { Record(id, pos, time, status, verdict, kind, gen) <- results } yield Row(Seq(
+    val rows = for { Record(id, pos, time, status, verdict, kind, _, gen) <- results } yield Row(Seq(
       Cell(if (gen == lastGen) "NEW" else ""),
       Cell(id.name),
       Cell((if (status.isTerminating) "\u2713" else "\u2717") + " " + verdict),

--- a/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
+++ b/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
@@ -5,9 +5,10 @@ package verification
 
 trait VerificationAnalysis extends AbstractAnalysis {
   val program: Program { val trees: stainless.trees.type }
-  val results: Map[VC[program.trees.type], VCResult[program.Model]]
+  import program.{ symbols, trees, Model }
+  val results: Map[VC[trees.type], VCResult[Model]]
 
-  lazy val vrs: Seq[(VC[stainless.trees.type], VCResult[program.Model])] =
+  lazy val vrs: Seq[(VC[trees.type], VCResult[Model])] =
     results.toSeq.sortBy { case (vc, _) => (vc.fd.name, vc.kind.toString) }
 
   override val name = VerificationComponent.name
@@ -18,7 +19,9 @@ trait VerificationAnalysis extends AbstractAnalysis {
     val time = vr.time.getOrElse(0L) // TODO make time mandatory (?)
     val status = VerificationReport.Status(vr.status)
     val solverName = vr.solver map { _.name }
-    VerificationReport.Record(vc.fd, vc.getPos, time, status, solverName, vc.kind.name)
+    val source = symbols.source(symbols.getFunction(vc.fd))
+    VerificationReport.Record(vc.fd, vc.getPos, time, status, solverName, vc.kind.name, derivedFrom = source)
   })
+
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -48,6 +48,7 @@ object VerificationReport {
   case class Record(
     id: Identifier, pos: inox.utils.Position, time: Long,
     status: Status, solverName: Option[String], kind: String,
+    derivedFrom: Identifier,
     generation: Long = 0 // "age" of the record, usefull to determine which ones are "NEW".
   ) extends AbstractReportHelper.Record
 
@@ -77,7 +78,7 @@ class VerificationReport(val results: Seq[VerificationReport.Record], lastGen: L
   override def isSuccess = totalUnknown + totalInvalid == 0
 
   override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = if (totalConditions == 0) None else Some((
-    results sortBy { _.id } map { case Record(id, pos, time, status, solverName, kind, gen) =>
+    results sortBy { _.id } map { case Record(id, pos, time, status, solverName, kind, _, gen) =>
       Row(Seq(
         Cell(if (gen == lastGen) "NEW" else ""),
         Cell(id),

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -48,21 +48,20 @@ object VerificationReport {
   case class Record(
     id: Identifier, pos: inox.utils.Position, time: Long,
     status: Status, solverName: Option[String], kind: String,
-    derivedFrom: Identifier,
-    generation: Long = 0 // "age" of the record, usefull to determine which ones are "NEW".
+    derivedFrom: Identifier
   ) extends AbstractReportHelper.Record
 
   implicit val recordDecoder: Decoder[Record] = deriveDecoder
   implicit val recordEncoder: Encoder[Record] = deriveEncoder
 
-  def parse(json: Json) = json.as[(Seq[Record], Long)] match {
-    case Right((records, lastGen)) => new VerificationReport(records, lastGen + 1)
+  def parse(json: Json) = json.as[Seq[Record]] match {
+    case Right(records) => new VerificationReport(records)
     case Left(error) => throw error
   }
 
 }
 
-class VerificationReport(val results: Seq[VerificationReport.Record], lastGen: Long = 0)
+class VerificationReport(val results: Seq[VerificationReport.Record])
   extends AbstractReport[VerificationReport] {
   import VerificationReport._
 
@@ -76,7 +75,7 @@ class VerificationReport(val results: Seq[VerificationReport.Record], lastGen: L
   override val name = VerificationComponent.name
 
   override lazy val annotatedRows = results map {
-    case Record(id, pos, time, status, solverName, kind, _, gen) =>
+    case Record(id, pos, time, status, solverName, kind, _) =>
       val level = levelOf(status)
       val solver = solverName getOrElse ""
       val extra = Seq(kind, status.name, solver)
@@ -93,18 +92,13 @@ class VerificationReport(val results: Seq[VerificationReport.Record], lastGen: L
   override lazy val stats =
     ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
 
-  override def ~(other: VerificationReport) = {
-    def updater(nextGen: Long)(r: Record) = r.copy(generation = nextGen)
-    val (fused, nextGen) = AbstractReportHelper.merge(this.results, other.results, lastGen, updater)
-    new VerificationReport(fused, nextGen)
-  }
+  override def ~(other: VerificationReport) =
+    new VerificationReport(AbstractReportHelper.merge(this.results, other.results))
 
-  override def filter(ids: Set[Identifier]) = {
-    val (filtered, nextGen) = AbstractReportHelper.filter(results, ids, lastGen)
-    new VerificationReport(filtered, nextGen)
-  }
+  override def filter(ids: Set[Identifier]) =
+    new VerificationReport(AbstractReportHelper.filter(results, ids))
 
-  override def emitJson: Json = (results, lastGen).asJson
+  override def emitJson: Json = results.asJson
 
 }
 

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -137,8 +137,8 @@ class RegistryTestSuite extends FunSuite {
     override val name = "dummy"
 
     override def emitJson = ???
-    override def isSuccess = true
-    override def emitRowsAndStats: Option[(Seq[Row], ReportStats)] = ???
+    override def annotatedRows = ???
+    override def stats = ???
 
     override def filter(ids: Set[Identifier]) = this // intentionally not filtering a thing!
     // here we don't test the reports themselves, but the registry.


### PR DESCRIPTION
This fix some issues with the reports displayed under `--watch` mode (basically, nested functions are no longer removed from the report when no noticeable changes were detected from the input source files and a new cycle was run without re-verifying anything).

This PR also adds some colors to the terminal output using ANSI colors. But it also trimmed down reports under `--watch` mode to show only unknown/invalid VC/TG.

Finally, it sorts VC/TG slightly better according to the function's id **and** the VC position.