### PR TITLE
command line options: update default values

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -8,7 +8,7 @@ val isMac     = osInf.indexOf("Mac") >= 0
 val osName = if (isWindows) "win" else if (isMac) "mac" else "unix"
 val osArch = System.getProperty("sun.arch.data.model")
 
-val inoxVersion = "1.0.2-238-gfecc51d"
+val inoxVersion = "1.0.2-253-gb56078e"
 val dottyVersion = "0.1.1-bin-20170429-10a2ce6-NIGHTLY"
 
 lazy val nParallel = {

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -38,6 +38,8 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
 
   def emitJson: Json
 
+  def stats: ReportStats
+
   final def emit(ctx: inox.Context): Unit = {
     val compact = isCompactModeOn(ctx)
     val table = emitTable(!compact)
@@ -67,7 +69,6 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
   )
 
   protected def annotatedRows: Seq[RecordRow]
-  protected def stats: ReportStats
 
   /** Filter, sort & process rows. */
   private def processRows(full: Boolean): Seq[Row] = {

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -9,7 +9,7 @@ import scala.util.{ Success, Failure }
 
 object optFailEarly extends inox.FlagOptionDef("fail-early", false)
 object optFailInvalid extends inox.FlagOptionDef("fail-invalid", false)
-object optVCCache extends inox.FlagOptionDef("vc-cache", false)
+object optVCCache extends inox.FlagOptionDef("vc-cache", true)
 
 object DebugSectionVerification extends inox.DebugSection("verification")
 

--- a/core/src/sphinx/options.rst
+++ b/core/src/sphinx/options.rst
@@ -157,7 +157,7 @@ Verification
 
 * ``--vc-cache``
 
-  Use a persistent cache mechanism to speed up verification.
+  Use a persistent cache mechanism to speed up verification; on by default.
 
 * ``--fail-early``
 

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -33,11 +33,9 @@ class RegistryTestSuite extends FunSuite {
   type FunctionName = String
 
   private val DEBUG = false
-  private val testSuiteContext = if (DEBUG) {
-    val reporter = new inox.DefaultReporter(Set(utils.DebugSectionRegistry, frontend.DebugSectionFrontend))
-    val intrMan = inox.TestContext.empty.interruptManager
-    inox.Context(reporter, intrMan).withOpts(inox.ast.optPrintUniqueIds(true))
-  } else inox.TestContext.empty
+  private val testSuiteContext =
+    if (DEBUG) stainless.TestContext.debug(utils.DebugSectionRegistry)
+    else stainless.TestContext.empty
 
   /** Expectation on classes and functions identifier name (ignoring ids). */
   case class Expectation(classes: Set[ClassName], functions: Set[FunctionName], strict: Boolean = true)

--- a/frontends/common/src/test/scala/stainless/TestContext.scala
+++ b/frontends/common/src/test/scala/stainless/TestContext.scala
@@ -1,0 +1,40 @@
+/* Copyright 2009-2016 EPFL, Lausanne */
+
+package stainless
+
+import inox.{ Context, DebugSection, Options, OptionValue }
+import stainless.verification.optVCCache
+
+object TestContext {
+
+  /**
+   * Create a context for testing purposes.
+   *
+   * Unless explicitely present in [[options]], the returned
+   * context is set to use no VC cache.
+   */
+  def apply(options: Options): Context = {
+    val newOptions =
+      if ((options findOption optVCCache).isDefined) options
+      else options + OptionValue(optVCCache)(false)
+    inox.TestContext(newOptions)
+  }
+
+  /**
+   * Use for debug purposes.
+   *
+   * The returned context has a DefaultReporter.
+   **/
+  def debug(sec: DebugSection, options: Options): Context = {
+    val reporter = new inox.DefaultReporter(Set(sec))
+    val ctx = apply(options)
+    Context(reporter, ctx.interruptManager, ctx.options, ctx.timers)
+  }
+
+  def debug(sec: DebugSection): Context = debug(sec, Options.empty)
+
+  def empty: Context = apply(Options.empty)
+
+}
+
+

--- a/frontends/common/src/test/scala/stainless/ast/ExplicitNumericPromotionSuite.scala
+++ b/frontends/common/src/test/scala/stainless/ast/ExplicitNumericPromotionSuite.scala
@@ -23,7 +23,7 @@ class ExplicitNumericPromotionSuite extends FunSuite with InputUtils {
 
   test("Catch unsupported expressions") {
     for (u <- unsupported) {
-      val ctx = inox.TestContext.empty
+      val ctx = stainless.TestContext.empty
       assertThrows[frontend.UnsupportedCodeException] {
         load(ctx, Seq(u))
       }
@@ -146,7 +146,7 @@ class ExplicitNumericPromotionSuite extends FunSuite with InputUtils {
        |} """.stripMargin
   )
 
-  val ctx = inox.TestContext.empty
+  val ctx = stainless.TestContext.empty
   val (_, xlangProgram) = load(ctx, sources)
   val program = verification.VerificationComponent.extract(xlangProgram, ctx)
 

--- a/frontends/common/src/test/scala/stainless/ast/LibraryLookupSuite.scala
+++ b/frontends/common/src/test/scala/stainless/ast/LibraryLookupSuite.scala
@@ -7,7 +7,7 @@ import org.scalatest._
 
 class LibraryLookupSuite extends FunSuite with InputUtils {
 
-  val ctx = inox.TestContext.empty
+  val ctx = stainless.TestContext.empty
 
   val contents = """
     import stainless.lang._

--- a/frontends/common/src/test/scala/stainless/ast/TupleExtractionSuite.scala
+++ b/frontends/common/src/test/scala/stainless/ast/TupleExtractionSuite.scala
@@ -35,7 +35,7 @@ class TupleExtrationSuite extends FunSuite with InputUtils {
        |} """.stripMargin
   )
 
-  val ctx = inox.TestContext.empty
+  val ctx = stainless.TestContext.empty
   val (_, xlangProgram) = load(ctx, sources)
   val program = verification.VerificationComponent.extract(xlangProgram, ctx)
 

--- a/frontends/common/src/test/scala/stainless/verification/InliningSuite.scala
+++ b/frontends/common/src/test/scala/stainless/verification/InliningSuite.scala
@@ -32,7 +32,7 @@ class InliningSuite extends FunSuite with InputUtils {
        |  } ensuring (_ >= BigInt(0))
        |}""".stripMargin
 
-  val ctx = inox.TestContext.empty
+  val ctx = stainless.TestContext.empty
   val (funs, xlangProgram) = load(ctx, List(source))
   val program = VerificationComponent.extract(xlangProgram, ctx)
 

--- a/frontends/common/src/test/scala/stainless/verification/RegistryVerificationSuite.scala
+++ b/frontends/common/src/test/scala/stainless/verification/RegistryVerificationSuite.scala
@@ -17,7 +17,7 @@ class RegistryVerificationSuite extends FunSuite with InputUtils {
 
   test(s"special --functions=theorem --check-models test") {
     val options = Seq(inox.solvers.optCheckModels(true), optFunctions("theorem" :: Nil))
-    val ctx = inox.TestContext(inox.Options(options)) // TODO use stainless.TestContext when #116 is merged.
+    val ctx = stainless.TestContext(inox.Options(options))
     val filter = utils.CheckFilter(xt, ctx)
     val component = VerificationComponent
 

--- a/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
@@ -12,6 +12,8 @@ trait ComponentTestSuite extends inox.TestSuite with inox.ResourceUtils with Inp
     Seq(inox.optSelectedSolvers(Set("smt-z3")), inox.optTimeout(300.seconds))
   )
 
+  final override def createContext(options: inox.Options) = stainless.TestContext(options)
+
   override protected def optionsString(options: inox.Options): String = {
     "solvr=" + options.findOptionOrDefault(inox.optSelectedSolvers).head + " " +
     "lucky=" + options.findOptionOrDefault(inox.solvers.unrolling.optFeelingLucky) + " " +

--- a/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/ComponentTestSuite.scala
@@ -20,6 +20,7 @@ trait ComponentTestSuite extends inox.TestSuite with inox.ResourceUtils with Inp
 
   private def extractStructure(files: Seq[String], ctx: inox.Context) = {
     val (structure, program) = loadFiles(ctx, files)
+
     program.symbols.ensureWellFormed
     val exProgram = component.extract(program, ctx)
     exProgram.symbols.ensureWellFormed
@@ -30,8 +31,8 @@ trait ComponentTestSuite extends inox.TestSuite with inox.ResourceUtils with Inp
   }
 
   // Ensure no tests share data inappropriately, but is really slow... Use with caution!
-  protected def extractOne(file: String, ctx: inox.Context)
-                : (String, Seq[Identifier], Program { val trees: component.trees.type }) = {
+  private def extractOne(file: String, ctx: inox.Context)
+              : (String, Seq[Identifier], Program { val trees: component.trees.type }) = {
     val (structure, program, exProgram) = extractStructure(Seq(file), ctx)
 
     assert((structure count { _.isMain }) == 1, "Expecting only one main unit")
@@ -54,8 +55,8 @@ trait ComponentTestSuite extends inox.TestSuite with inox.ResourceUtils with Inp
   }
 
   // More efficient, but might mix tests together...
-  protected def extractAll(files: Seq[String], ctx: inox.Context)
-                : (Seq[(String, Seq[Identifier])], Program { val trees: component.trees.type }) = {
+  private def extractAll(files: Seq[String], ctx: inox.Context)
+              : (Seq[(String, Seq[Identifier])], Program { val trees: component.trees.type }) = {
     val (structure, program, exProgram) = extractStructure(files, ctx)
 
     (for (u <- structure if u.isMain) yield {

--- a/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/LibrarySuite.scala
@@ -7,20 +7,20 @@ import org.scalatest._
 class LibrarySuite extends FunSpec with InputUtils {
 
   describe("stainless library") {
-    val reporter = new inox.TestSilentReporter
     val opts = inox.Options(Seq(inox.optSelectedSolvers(Set("smt-z3"))))
-    val ctx = inox.Context(reporter, new inox.utils.InterruptManager(reporter), opts)
+    val ctx = stainless.TestContext(opts)
+    import ctx.reporter
 
     val tryProgram = scala.util.Try(loadFiles(ctx, Seq.empty)._2)
     it("should be extractable") {
       assert(tryProgram.isSuccess, "Extraction crashed with exception")
-      assert(reporter.lastErrors.isEmpty, "Extraction had errors")
+      assert(reporter.errorCount == 0, "Extraction had errors")
     }
 
     it("should verify") {
       import verification.VerificationComponent._
       val exProgram = extract(tryProgram.get, ctx)
-      assert(reporter.lastErrors.isEmpty, "Verification extraction had errors")
+      assert(reporter.errorCount == 0, "Verification extraction had errors")
 
       import exProgram.trees._
       val funs = exProgram.symbols.functions.values.filterNot(_.flags contains Unchecked).map(_.id).toSeq
@@ -35,7 +35,7 @@ class LibrarySuite extends FunSpec with InputUtils {
     it("should terminate") {
       import termination.TerminationComponent._
       val exProgram = extract(tryProgram.get, ctx)
-      assert(reporter.lastErrors.isEmpty, "Verification extraction had errors")
+      assert(reporter.errorCount == 0, "Verification extraction had errors")
 
       import exProgram.trees._
       val funs = exProgram.symbols.functions.values.filterNot(_.flags contains Unchecked).map(_.id).toSeq

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -28,7 +28,8 @@ trait VerificationSuite extends ComponentTestSuite {
   }
 
   testAll("verification/valid") { (analysis, reporter) =>
-    val report = analysis.toReport
+    // TODO Once #115 is merged, make Report.stats public and tests this:
+    // assert(analysis.toReport.stats.validFromCache == 0, "no cache should be used for this tests")
     for ((vc, vr) <- analysis.vrs) {
       if (vr.isInvalid) fail(s"The following verification condition was invalid: $vc @${vc.getPos}")
       if (vr.isInconclusive) fail(s"The following verification condition was inconclusive: $vc @${vc.getPos}")

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -38,7 +38,7 @@ trait VerificationSuite extends ComponentTestSuite {
 
   testAll("verification/invalid") { (analysis, _) =>
     val report = analysis.toReport
-    assert(report.totalInvalid > 0, "There should be at least one invalid verification condition.")
+    assert(report.totalInvalid > 0, "There should be at least one invalid verification condition. " + report.stats)
   }
 }
 

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -28,8 +28,7 @@ trait VerificationSuite extends ComponentTestSuite {
   }
 
   testAll("verification/valid") { (analysis, reporter) =>
-    // TODO Once #115 is merged, make Report.stats public and tests this:
-    // assert(analysis.toReport.stats.validFromCache == 0, "no cache should be used for this tests")
+    assert(analysis.toReport.stats.validFromCache == 0, "no cache should be used for this tests")
     for ((vc, vr) <- analysis.vrs) {
       if (vr.isInvalid) fail(s"The following verification condition was invalid: $vc @${vc.getPos}")
       if (vr.isInconclusive) fail(s"The following verification condition was inconclusive: $vc @${vc.getPos}")


### PR DESCRIPTION
I suggest to enable *by default* termination *and* verification components. Explicitly writing `--verification` or `--termination` will disable the other component unless both options are present in the command line arguments.

Also, because the VC cache seems stable I think it makes sense to have it on all the time, except when otherwise stated (i.e. using `--vc-cache=false`).