### PR TITLE
Consider @unchecked functions as terminating

### DIFF
--- a/core/src/main/scala/stainless/termination/ProcessingPipeline.scala
+++ b/core/src/main/scala/stainless/termination/ProcessingPipeline.scala
@@ -177,7 +177,11 @@ trait ProcessingPipeline extends TerminationChecker with inox.utils.Interruptibl
 
     for (fd <- funDefs -- problemComponents.toSet.flatten) clearedMap(fd) = "Non-recursive"
     val newProblems = problemComponents.filter(fds => fds.forall { fd => !terminationMap.isDefinedAt(fd) })
-    newProblems.map(fds => Problem(fds.toSeq))
+
+    // Consider @unchecked functions as terminating.
+    val (uncheckedProblems, toCheck) = newProblems.partition(_.forall(_.flags contains "unchecked"))
+    for (fd <- uncheckedProblems.toSet.flatten) clearedMap(fd) = "Unchecked"
+    toCheck.map(fds => Problem(fds.toSeq))
   }
 
   def verifyTermination(funDef: FunDef): Set[FunDef] = {


### PR DESCRIPTION
Following up on https://github.com/epfl-lara/stainless/pull/78#issuecomment-345967833. The patch seems to work. For example, for [ConstructorArgsBoxing3.scala](https://github.com/romac/stainless/blob/88c9016dd095613ffc605e65541ecf1589b76aad/frontends/benchmarks/extraction/ConstructorArgsBoxing3.scala):

```
[  Info  ]   ┌─────────────────────┐
[  Info  ] ╔═╡ termination summary ╞═══════════════════════════════════════════════════════════════════════╗
[  Info  ] ║ └─────────────────────┘                                                                       ║
[  Info  ] ║ NEW     b            ✓ Terminates (Non-recursive)                                 0.010       ║
[  Info  ] ║ NEW     c            ✓ Terminates (Non-recursive)                                 0.001       ║
[  Info  ] ║ NEW     list0        ✓ Terminates (Non-recursive)                                 0.001       ║
[  Info  ] ║ NEW     list1        ✓ Terminates (Non-recursive)                                 0.001       ║
[  Info  ] ╟┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄╢
[  Info  ] ║ total: 4      valid: 4    (0 from cache)   invalid: 0      unknown: 0     time:   0.013       ║
[  Info  ] ╚═══════════════════════════════════════════════════════════════════════════════════════════════╝
```