### PR TITLE
Catch `ExecutionException` within the Registry

### DIFF
--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -73,9 +73,11 @@ package object extraction {
       innerfuns.extractor  andThen
       inlining.extractor
 
-    val extracted: Program { val trees: extraction.trees.type } =
-      program.transform(pipeline)
-
-    new PreconditionInference(extracted, ctx).targetProgram
+    try {
+      new PreconditionInference(program.transform(pipeline), ctx).targetProgram
+    } catch {
+      case MissformedStainlessCode(tree, msg) =>
+        ctx.reporter.fatalError(tree.getPos, msg)
+    }
   }
 }

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -63,7 +63,10 @@ trait CallBackWithRegistry extends CallBack { self =>
     // Save cache now that we have our report
     saveCaches()
   } catch {
-    case e: ExecutionException => ()
+    case e: ExecutionException =>
+      stop()
+      tasks.clear()
+      endExtractions()
   }
 
   // See assumption/requirements in [[CallBack]]

--- a/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
+++ b/core/src/main/scala/stainless/frontend/CallBackWithRegistry.scala
@@ -1,4 +1,4 @@
-/* Copyright 2009-2016 EPFL, Lausanne */
+/* Copyright 2009-2017 EPFL, Lausanne */
 
 package stainless
 package frontend
@@ -63,10 +63,14 @@ trait CallBackWithRegistry extends CallBack { self =>
     // Save cache now that we have our report
     saveCaches()
   } catch {
-    case e: ExecutionException =>
+    case e: ExecutionException if isFatalError(e) =>
       stop()
       tasks.clear()
       endExtractions()
+  }
+  
+  private def isFatalError(e: ExecutionException): Boolean = {
+    e.getCause != null && e.getCause.isInstanceOf[inox.FatalError]
   }
 
   // See assumption/requirements in [[CallBack]]


### PR DESCRIPTION
This allows to properly shutdown Stainless, whereas it would otherwise just hang and needed to be manually killed.