### PR TITLE
Fix a bug in a generated `assume` clause during TypeEncoding

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -837,7 +837,7 @@ trait TypeEncoding extends inox.ast.SymbolTransformer { self =>
           t.Assert(check, Some("Cast error"), result)
 
         case (_: s.ADTSelector | _: s.MapApply) if isObject(e.getType) =>
-          let("res" :: tpe, super.transform(e)) { res =>
+          let("res" :: obj, super.transform(e)) { res =>
             t.Assume(instanceOf(res, encodeType(e.getType)), res)
           }
 


### PR DESCRIPTION
This fixes the bug originally described in #128, but not the one in https://github.com/epfl-lara/stainless/issues/128#issuecomment-349359953.