### PR TITLE
Fix processing of `Old`

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -399,6 +399,7 @@ trait ImperativeCodeElimination extends inox.ast.SymbolTransformer {
       case (e: Assignment) => true
       case (e: While) => true
       case (e: LetVar) => true
+      case (e: Old) => true
       case _ => false
     }
 

--- a/frontends/benchmarks/imperative/valid/OldThis3.scala
+++ b/frontends/benchmarks/imperative/valid/OldThis3.scala
@@ -1,0 +1,11 @@
+import stainless.lang._
+
+object OldThis3 {
+
+  case class A(var a: Int) {
+    def foo(b: Int): Unit = {
+      a + b // no assignement
+    } ensuring(_ => a == old(this).a)
+  }
+
+}

--- a/frontends/benchmarks/imperative/valid/OldThis4.scala
+++ b/frontends/benchmarks/imperative/valid/OldThis4.scala
@@ -1,0 +1,11 @@
+import stainless.lang._
+
+object OldThis4 {
+
+  case class A(var a: Int) {
+    def foo(b: Int): Unit = {
+      b + b // a never used
+    } ensuring(_ => a == old(this).a)
+  }
+
+}


### PR DESCRIPTION
Small patch to properly get rid of `old` in the `ImperativeCodeElimination` transformation.