### PR TITLE
Fix reporting under --watch 

### DIFF
--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -115,14 +115,15 @@ object AbstractReportHelper {
     records filter { ids contains _.derivedFrom }
 
   /**
-   * Merge two sets of records [[R]] into one.
+   * Merge two sets of records [[R]] into one, keeping only the latest information.
    *
-   * Records in [[prevs]] which have the same `id` as the ones in [[news]] are removed.
+   * Obselete records for a source X are removed from [[prevs]]
+   * and replaced by the ones in [[news]] (if it contains some records for X).
    */
-  def merge[R <: Record](prevs: Seq[R], news: Seq[R]): Seq[R] = {
+  def merge[R <: Record](prevs: Seq[R], newSources: Set[Identifier], news: Seq[R]): Seq[R] = {
     def buildMapping(subs: Seq[R]): Map[Identifier, Seq[R]] = subs groupBy { _.derivedFrom }
 
-    val prev = buildMapping(prevs)
+    val prev = buildMapping(prevs) -- newSources // erase all the obselete information
     val next = buildMapping(news)
     val fused = (prev ++ next).values.fold(Seq.empty) { _ ++ _ }
 

--- a/core/src/main/scala/stainless/evaluators/EvaluatorAnalysis.scala
+++ b/core/src/main/scala/stainless/evaluators/EvaluatorAnalysis.scala
@@ -8,11 +8,10 @@ trait EvaluatorAnalysis extends AbstractAnalysis {
   import EvaluatorReport.Record
 
   val program: StainlessProgram
+  val sources: Set[Identifier] // set of functions that were considered for the analysis
   val results: Seq[Result]
 
-  override type Report = EvaluatorReport
-  override val name = EvaluatorComponent.name
-  override def toReport = new EvaluatorReport(results map { case Result(fd, status, time) =>
+  private lazy val records = results map { case Result(fd, status, time) =>
     val textStatus = status match {
       case EvaluatorComponent.BodyFailed(error)       => EvaluatorReport.BodyFailed(error)
       case EvaluatorComponent.PostFailed(body, error) => EvaluatorReport.PostFailed(body.toString, error)
@@ -21,6 +20,10 @@ trait EvaluatorAnalysis extends AbstractAnalysis {
       case EvaluatorComponent.NoPost(body)            => EvaluatorReport.NoPost(body.toString)
     }
     Record(fd.id, fd.getPos, textStatus, time)
-  })
+  }
+
+  override type Report = EvaluatorReport
+  override val name = EvaluatorComponent.name
+  override def toReport = new EvaluatorReport(records, sources)
 }
 

--- a/core/src/main/scala/stainless/evaluators/EvaluatorComponent.scala
+++ b/core/src/main/scala/stainless/evaluators/EvaluatorComponent.scala
@@ -123,8 +123,9 @@ object EvaluatorComponent extends SimpleComponent { self =>
     reporter.debug(s"Processing ${toEval.size} parameterless functions: ${toEval mkString ", "}")
 
     new EvaluatorAnalysis {
-      val program = p
-      val results = toEval map processFunction
+      override val program = p
+      override val sources = funs.toSet
+      override val results = toEval map processFunction
     }
   }
 }

--- a/core/src/main/scala/stainless/evaluators/EvaluatorReport.scala
+++ b/core/src/main/scala/stainless/evaluators/EvaluatorReport.scala
@@ -44,8 +44,13 @@ object EvaluatorReport {
 }
 
 class EvaluatorReport(val results: Seq[EvaluatorReport.Record], val sources: Set[Identifier])
-  extends AbstractReport[EvaluatorReport] {
+  extends BuildableAbstractReport[EvaluatorReport.Record, EvaluatorReport] {
   import EvaluatorReport._
+
+  override val encoder = recordEncoder
+
+  override def build(results: Seq[Record], sources: Set[Identifier]) =
+    new EvaluatorReport(results, sources)
 
   override val name = EvaluatorComponent.name
 
@@ -60,17 +65,6 @@ class EvaluatorReport(val results: Seq[EvaluatorReport.Record], val sources: Set
 
   override lazy val stats =
     ReportStats(results.size, totalTime, totalValid, validFromCache = 0, totalInvalid, unknown = 0)
-
-  override def ~(other: EvaluatorReport) =
-    new EvaluatorReport(
-      AbstractReportHelper.merge(this.results, other.sources, other.results),
-      this.sources ++ other.sources
-    )
-
-  override def filter(ids: Set[Identifier]) =
-    new EvaluatorReport(AbstractReportHelper.filter(results, ids), sources & ids)
-
-  override def emitJson: Json = (results, sources).asJson
 
   private def levelOf(status: Status) = status match {
     case PostHeld(_) | NoPost(_) => Level.Normal

--- a/core/src/main/scala/stainless/evaluators/EvaluatorReport.scala
+++ b/core/src/main/scala/stainless/evaluators/EvaluatorReport.scala
@@ -37,13 +37,14 @@ object EvaluatorReport {
   implicit val recordDecoder: Decoder[Record] = deriveDecoder
   implicit val recordEncoder: Encoder[Record] = deriveEncoder
 
-  def parse(json: Json) = json.as[Seq[Record]] match {
-    case Right(records) => new EvaluatorReport(records)
+  def parse(json: Json) = json.as[(Seq[Record], Set[Identifier])] match {
+    case Right((records, sources)) => new EvaluatorReport(records, sources)
     case Left(error) => throw error
   }
 }
 
-class EvaluatorReport(val results: Seq[EvaluatorReport.Record]) extends AbstractReport[EvaluatorReport] {
+class EvaluatorReport(val results: Seq[EvaluatorReport.Record], val sources: Set[Identifier])
+  extends AbstractReport[EvaluatorReport] {
   import EvaluatorReport._
 
   override val name = EvaluatorComponent.name
@@ -61,12 +62,15 @@ class EvaluatorReport(val results: Seq[EvaluatorReport.Record]) extends Abstract
     ReportStats(results.size, totalTime, totalValid, validFromCache = 0, totalInvalid, unknown = 0)
 
   override def ~(other: EvaluatorReport) =
-    new EvaluatorReport(AbstractReportHelper.merge(this.results, other.results))
+    new EvaluatorReport(
+      AbstractReportHelper.merge(this.results, other.sources, other.results),
+      this.sources ++ other.sources
+    )
 
   override def filter(ids: Set[Identifier]) =
-    new EvaluatorReport(AbstractReportHelper.filter(results, ids))
+    new EvaluatorReport(AbstractReportHelper.filter(results, ids), sources & ids)
 
-  override def emitJson: Json = results.asJson
+  override def emitJson: Json = (results, sources).asJson
 
   private def levelOf(status: Status) = status match {
     case PostHeld(_) | NoPost(_) => Level.Normal

--- a/core/src/main/scala/stainless/termination/TerminationAnalysis.scala
+++ b/core/src/main/scala/stainless/termination/TerminationAnalysis.scala
@@ -16,14 +16,17 @@ trait TerminationAnalysis extends AbstractAnalysis {
   type Duration = Long
   type Record = (TerminationGuarantee, Duration)
   val results: Map[FunDef, Record]
+  val sources: Set[Identifier] // set of functions that were considered for the analysis
 
   override val name: String = TerminationComponent.name
 
   override type Report = TerminationReport
 
-  override def toReport = new TerminationReport(results.toSeq map { case (fd, (g, time)) =>
+  override def toReport = new TerminationReport(records, sources)
+
+  private lazy val records = results.toSeq map { case (fd, (g, time)) =>
     TerminationReport.Record(fd.id, fd.getPos, time, status(g), verdict(g, fd), kind(g), derivedFrom = fd.source)
-  })
+  }
 
   private def kind(g: TerminationGuarantee): String = g match {
     case checker.LoopsGivenInputs(_, _) => "non-terminating loop"

--- a/core/src/main/scala/stainless/termination/TerminationComponent.scala
+++ b/core/src/main/scala/stainless/termination/TerminationComponent.scala
@@ -67,6 +67,7 @@ object TerminationComponent extends SimpleComponent {
     new TerminationAnalysis {
       override val checker: c.type = c
       override val results: Map[p.trees.FunDef, (c.TerminationGuarantee, Long)] = res.toMap
+      override val sources = funs.toSet
     }
   }
 }

--- a/core/src/main/scala/stainless/termination/TerminationReport.scala
+++ b/core/src/main/scala/stainless/termination/TerminationReport.scala
@@ -45,8 +45,13 @@ object TerminationReport {
 
 // Variant of the report without the checker, where all the data is mapped to text
 class TerminationReport(val results: Seq[TerminationReport.Record], val sources: Set[Identifier])
-  extends AbstractReport[TerminationReport] {
+  extends BuildableAbstractReport[TerminationReport.Record, TerminationReport] {
   import TerminationReport._
+
+  override val encoder = recordEncoder
+
+  override def build(results: Seq[Record], sources: Set[Identifier]) =
+    new TerminationReport(results, sources)
 
   override val name: String = TerminationComponent.name
 
@@ -55,15 +60,6 @@ class TerminationReport(val results: Seq[TerminationReport.Record], val sources:
   lazy val totalInvalid = results count { _.status.isNonTerminating }
   lazy val totalUnknown = results count { _.status.isUnknown }
   lazy val totalTime = (results map { _.time }).sum
-
-  override def ~(other: TerminationReport) =
-    new TerminationReport(
-      AbstractReportHelper.merge(this.results, other.sources, other.results),
-      this.sources ++ other.sources
-    )
-
-  override def filter(ids: Set[Identifier]) =
-    new TerminationReport(AbstractReportHelper.filter(results, ids), sources & ids)
 
   override lazy val annotatedRows = results map {
     case Record(id, pos, time, status, verdict, kind, _) =>
@@ -82,8 +78,6 @@ class TerminationReport(val results: Seq[TerminationReport.Record], val sources:
 
   override lazy val stats =
     ReportStats(results.size, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
-
-  override def emitJson: Json = (results, sources).asJson
 
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
+++ b/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
@@ -5,23 +5,26 @@ package verification
 
 trait VerificationAnalysis extends AbstractAnalysis {
   val program: StainlessProgram
+  val sources: Set[Identifier] // set of functions that were considered for the analysis
   import program.{ symbols, trees, Model }
   val results: Map[VC[trees.type], VCResult[Model]]
 
   lazy val vrs: Seq[(VC[trees.type], VCResult[Model])] =
     results.toSeq.sortBy { case (vc, _) => (vc.fd.name, vc.kind.toString) }
 
-  override val name = VerificationComponent.name
-
-  override type Report = VerificationReport
-
-  override def toReport = new VerificationReport(vrs map { case (vc, vr) =>
+  private lazy val records = vrs map { case (vc, vr) =>
     val time = vr.time.getOrElse(0L) // TODO make time mandatory (?)
     val status = VerificationReport.Status(vr.status)
     val solverName = vr.solver map { _.name }
     val source = symbols.getFunction(vc.fd).source
     VerificationReport.Record(vc.fd, vc.getPos, time, status, solverName, vc.kind.name, derivedFrom = source)
-  })
+  }
+
+  override val name = VerificationComponent.name
+
+  override type Report = VerificationReport
+
+  override def toReport = new VerificationReport(records, sources)
 
 }
 

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -54,6 +54,7 @@ object VerificationComponent extends SimpleComponent {
 
     new VerificationAnalysis {
       override val program: p.type = p
+      override val sources = funs.toSet
       override val results = res
     }
   }

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -62,8 +62,13 @@ object VerificationReport {
 }
 
 class VerificationReport(val results: Seq[VerificationReport.Record], val sources: Set[Identifier])
-  extends AbstractReport[VerificationReport] {
+  extends BuildableAbstractReport[VerificationReport.Record, VerificationReport] {
   import VerificationReport._
+
+  override val encoder = recordEncoder
+
+  override def build(results: Seq[Record], sources: Set[Identifier]) =
+    new VerificationReport(results, sources)
 
   lazy val totalConditions: Int = results.size
   lazy val totalTime = results.map(_.time).sum
@@ -91,17 +96,6 @@ class VerificationReport(val results: Seq[VerificationReport.Record], val source
 
   override lazy val stats =
     ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
-
-  override def ~(other: VerificationReport) =
-    new VerificationReport(
-      AbstractReportHelper.merge(this.results, other.sources, other.results),
-      this.sources ++ other.sources
-    )
-
-  override def filter(ids: Set[Identifier]) =
-    new VerificationReport(AbstractReportHelper.filter(results, ids), sources & ids)
-
-  override def emitJson: Json = (results, sources).asJson
 
 }
 


### PR DESCRIPTION
Closes #125.

In a nutshell, now reports keep track of which functions were verified/evaluated/... to generate them. This way, we can remove old VC that no longer exists (and are not replaced by another one).