### PR TITLE
Robust watch: reset compiler upon error

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -126,7 +126,8 @@ trait MainHelpers extends inox.MainHelpers {
       baseRunCycle()
     } catch {
       case e: Throwable =>
-        reporter.error(e)
+        reporter.debug(e)(frontend.DebugSectionFrontend)
+        reporter.error(e.getMessage)
         compiler = newCompiler()
     }
 
@@ -134,8 +135,7 @@ trait MainHelpers extends inox.MainHelpers {
       baseRunCycle()
     } catch {
       case e: inox.FatalError => throw e
-      case e: Throwable =>
-        reporter.internalError(e)
+      case e: Throwable => reporter.internalError(e)
     }
 
     val watchMode = isWatchModeOn(ctx)

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -110,35 +110,45 @@ trait MainHelpers extends inox.MainHelpers {
     }
 
     val compilerArgs = args.toList filterNot { _.startsWith("--") }
-    val compiler = frontend.build(ctx, compilerArgs, factory)
+    def newCompiler() = frontend.build(ctx, compilerArgs, factory)
+    var compiler = newCompiler()
 
-    // For each cylce, passively wait until the compiler has finished
+    // For each cycle, passively wait until the compiler has finished
     // & print summary of reports for each component
-    def runCycle() = {
-      val (time, res) = timers.cycle.runAndGetTime {
-        compiler.run()
-        compiler.join()
+    def baseRunCycle(): Unit = timers.cycle.run {
+      compiler.run()
+      compiler.join()
 
-        compiler.getReports foreach { _.emit(ctx) }
-      }
-
-      res match {
-        case Failure(frontend.UnsupportedCodeException(pos, msg)) => reporter.error(pos, msg)
-        case Failure(ex) => reporter.internalError(ex)
-        case Success(()) => // nothing to do
-      }
-
-      reporter.info(s"Cycle took $time ms")
+      compiler.getReports foreach { _.emit(ctx) }
     }
 
-    // Run the first cycle
-    runCycle()
+    def watchRunCycle() = try {
+      baseRunCycle()
+    } catch {
+      case e: Throwable =>
+        reporter.error(e)
+        compiler = newCompiler()
+    }
+
+    def regularRunCycle() = try {
+      baseRunCycle()
+    } catch {
+      case e: inox.FatalError => throw e
+      case e: Throwable =>
+        reporter.internalError(e)
+    }
 
     val watchMode = isWatchModeOn(ctx)
     if (watchMode) {
-      val files: Set[File] = compiler.sources.toSet map { file: String => new File(file).getAbsoluteFile }
-      val watcher = new utils.FileWatcher(ctx, files, action = runCycle)
-      watcher.run()
+      val files: Set[File] = compiler.sources.toSet map {
+        file: String => new File(file).getAbsoluteFile
+      }
+      val watcher = new utils.FileWatcher(ctx, files, action = watchRunCycle)
+
+      watchRunCycle() // first run
+      watcher.run()   // subsequent runs on changes
+    } else {
+      regularRunCycle()
     }
 
     // Export final results to JSON if asked to.

--- a/core/src/main/scala/stainless/utils/IncrementalComputationalGraph.scala
+++ b/core/src/main/scala/stainless/utils/IncrementalComputationalGraph.scala
@@ -28,7 +28,7 @@ trait IncrementalComputationalGraph[Id, Input, Result] {
    * When [[compute]] is false the node doesn't trigger a call to [[compute]] when
    * all the [[deps]] -- and the indirect dependencies -- are present in the graph.
    */
-  def update(id: Id, in: Input, deps: Set[Id], compute: Boolean): Option[Result] = {
+  final def update(id: Id, in: Input, deps: Set[Id], compute: Boolean): Option[Result] = {
     update(Node(id, in, deps, compute))
   }
 
@@ -37,27 +37,27 @@ trait IncrementalComputationalGraph[Id, Input, Result] {
    *
    * Throw an [[java.lang.IllegalArgumentException]] if the node wasn't in the graph.
    */
-  def remove(id: Id): Unit = nodes get id match {
+  final def remove(id: Id): Unit = nodes get id match {
     case Some(n) => remove(n)
     case None => throw new java.lang.IllegalArgumentException(s"Node $id is not part of the graph")
   }
 
   /** Put on hold any computation. */
-  def freeze(): Unit = {
+  final def freeze(): Unit = {
     frozen = true
   }
 
   /** Resume computation. */
-  def unfreeze(): Option[Result] = {
+  final def unfreeze(): Option[Result] = {
     frozen = false
     process()
   }
 
   /** Get a read-only version of the graph. */
-  def getNodes: Map[Id, (Input, Set[Id])] = nodes.toMap map { case (id, n) => (id, n.in -> n.deps) }
+  final def getNodes: Map[Id, (Input, Set[Id])] = nodes.toMap map { case (id, n) => (id, n.in -> n.deps) }
 
   /** Get the current missing nodes' identifier from the graph. */
-  def getMissing: Set[Id] = allIds.toSet -- nodes.keySet
+  final def getMissing: Set[Id] = allIds.toSet -- nodes.keySet
 
 
   /******************* Customisation Points *******************************************************/

--- a/core/src/main/scala/stainless/utils/Registry.scala
+++ b/core/src/main/scala/stainless/utils/Registry.scala
@@ -71,7 +71,7 @@ trait Registry {
    *
    * TODO when caching is implemented further in the pipeline, s/Option/Seq/.
    */
-  def update(classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Option[xt.Symbols] = synchronized {
+  final def update(classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef]): Option[xt.Symbols] = synchronized {
     if (hasPersistentCache) {
       deferredClasses ++= classes
       deferredFunctions ++= functions
@@ -84,7 +84,7 @@ trait Registry {
   /**
    * To be called once every compilation unit were extracted.
    */
-  def checkpoint(): Option[xt.Symbols] = synchronized {
+  final def checkpoint(): Option[xt.Symbols] = synchronized {
     if (hasPersistentCache) {
       val res = process(deferredClasses, deferredFunctions)
       persistentCache = None // remove the persistent cache after it's used once, the ICG can take over from here.
@@ -98,7 +98,7 @@ trait Registry {
   }
 
   /** Import the canonical form cache from the given file. Not thread-safe. */
-  def loadCache(file: File): Unit = synchronized {
+  final def loadCache(file: File): Unit = synchronized {
     val stream = new FileInputStream(file)
 
     def assertValidCache(check: Boolean) = {
@@ -157,7 +157,7 @@ trait Registry {
   }
 
   /** Export the canonical form cache to the given file. Not thread-safe. */
-  def saveCache(file: File): Unit = synchronized {
+  final def saveCache(file: File): Unit = synchronized {
     val stream = new FileOutputStream(file)
 
     def writeInt(x: Int): Unit = {


### PR DESCRIPTION
Fixes #145.

This PR provides a quick patch for the `--watch` mode: the compiler is completely recreated when exceptions are caught.

An alternative patch would be to add `reset` methods to `Frontend`, `CallBack`, `Registry`, `ICG`, ... I feel using a `var` in the `main` is a good alternative.

In both case, this patch is somewhat imperfect as some VC will be generated/verified after an exception is caught. This is because of the `MainHelpers.par` usage in `VerificationChecker`. Fixing this would require an additional, non-trivial synchronisation mechanism.

This results in the following output:

```
stainless CrashInox.scala --watch
[ Error  ] Environment$0 depends on missing dependencies: Option$2.
[Internal] Missing some nodes in Registry: Option$2
[Internal] Please inform the authors of Inox about this message
[ Error  ] Error: Missing some nodes in Registry: Option$2. Trace:
[ Error  ] - inox.Reporter.onFatal(Reporter.scala:39)
[ Error  ] - inox.Reporter.internalError(Reporter.scala:57)
[ Error  ] - inox.Reporter.internalError(Reporter.scala:100)
[ Error  ] - stainless.utils.Registry$class.checkpointImpl(Registry.scala:420)
[ Error  ] - stainless.utils.Registry$class.checkpoint(Registry.scala:97)
[ Error  ] - stainless.frontend.CallBackWithRegistry$$anon$1.checkpoint(CallBackWithRegistry.scala:108)
[ Error  ] - stainless.frontend.CallBackWithRegistry$class.endExtractions(CallBackWithRegistry.scala:47)
[ Error  ] - stainless.verification.VerificationCallBack.endExtractions(VerificationCallBack.scala:12)
[ Error  ] - stainless.frontend.MasterCallBack$$anonfun$endExtractions$1.apply(MasterCallBack.scala:23)
[ Error  ] - stainless.frontend.MasterCallBack$$anonfun$endExtractions$1.apply(MasterCallBack.scala:23)
[ Error  ] - scala.collection.immutable.List.foreach(List.scala:381)
[ Error  ] - stainless.frontend.MasterCallBack.endExtractions(MasterCallBack.scala:23)
[ Error  ] - stainless.frontend.ThreadedFrontend$$anon$1.run(ThreadedFrontend.scala:33)
[ Error  ] - java.lang.Thread.run(Thread.java:748)
[  Info  ]
[  Info  ]
[  Info  ] Waiting for source changes...
[  Info  ]
[  Info  ]
[  Info  ]  - Now solving 'match exhaustiveness' VC for toString @16:41...
[  Info  ]  - Result for 'match exhaustiveness' VC for toString @16:41:
[  Info  ]  => VALID
[  Info  ] Detecting some file modifications...: CrashInox.scala
[  Info  ]  - Now solving 'match exhaustiveness' VC for toString @14:41...
[  Info  ]  - Result for 'match exhaustiveness' VC for toString @14:41:
[  Info  ]  => VALID
[  Info  ]   ┌──────────────────────┐
[  Info  ] ╔═╡ verification summary ╞═════════════════════════════════════════════════════════╗
[  Info  ] ║ └──────────────────────┘                                                         ║
[  Info  ] ╟┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄╢
[  Info  ] ║ total: 1    valid: 1    (0 from cache) invalid: 0    unknown: 0    time:   0.023 ║
[  Info  ] ╚══════════════════════════════════════════════════════════════════════════════════╝
[  Info  ]
[  Info  ]
[  Info  ] Waiting for source changes...
[  Info  ]
[  Info  ]
```

As you can see, some VCs are being verified between `Waiting for source changes...` and `Detecting some file modifications...: `.

There are several ways to fix this "printing" issue. The best one, IMO, would be to reject such invalid program as early as possible. In this case, in the exaction itself, i.e. before generating any VC.