### PR TITLE
Ignore top level literal

### DIFF
--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -171,6 +171,9 @@ trait CodeExtraction extends ASTExtractors {
       case EmptyTree =>
         // ignore
 
+      case l: Literal =>
+        // top level literal are ignored
+
       case t if (
         (annotationsOf(t.symbol) contains xt.Ignore) ||
         (t.symbol.isSynthetic && !t.symbol.isImplicit)


### PR DESCRIPTION
Fixes NullPointerException because such trees have no symbol.

Addresses https://github.com/epfl-lara/stainless/issues/103#issuecomment-343167664.