### PR TITLE
Add holds on `check`

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -15,7 +15,7 @@ val isMac     = osInf.indexOf("Mac") >= 0
 val osName = if (isWindows) "win" else if (isMac) "mac" else "unix"
 val osArch = System.getProperty("sun.arch.data.model")
 
-val inoxVersion = "1.1.0-243-gd08df9b"
+val inoxVersion = "1.1.0-256-g525e430"
 val dottyVersion = "0.1.1-bin-20170429-10a2ce6-NIGHTLY"
 val circeVersion = "0.10.0-M2"
 

--- a/core/src/main/scala/stainless/ast/Expressions.scala
+++ b/core/src/main/scala/stainless/ast/Expressions.scala
@@ -11,7 +11,7 @@ trait Expressions extends inox.ast.Expressions with inox.ast.Types { self: Trees
     * respective type for value types.
     */
   sealed case class NoTree(tpe: Type) extends Expr with Terminal {
-    override def getType(implicit s: Symbols): Type = tpe
+    override def getType(implicit s: Symbols): Type = tpe.getType
   }
 
 
@@ -26,7 +26,7 @@ trait Expressions extends inox.ast.Expressions with inox.ast.Types { self: Trees
     * @param description The description of the error
     */
   sealed case class Error(tpe: Type, description: String) extends Expr with Terminal {
-    override def getType(implicit s: Symbols): Type = tpe
+    override def getType(implicit s: Symbols): Type = tpe.getType
   }
 
 
@@ -166,7 +166,7 @@ trait Expressions extends inox.ast.Expressions with inox.ast.Types { self: Trees
       .filter(_.params.size == 1)
       .getOrElse(throw extraction.MissformedStainlessCode(up, "Invalid unapply accessor"))
     val unapp = up.getFunction
-    val tpMap = s.instantiation(fd.params.head.tpe, unapp.returnType)
+    val tpMap = s.instantiation(fd.params.head.getType, unapp.getType)
       .getOrElse(throw extraction.MissformedStainlessCode(up, "Unapply pattern failed type instantiation"))
     fd.typed(fd.typeArgs map tpMap).applied(Seq(unapplied))
   }
@@ -193,7 +193,7 @@ trait Expressions extends inox.ast.Expressions with inox.ast.Types { self: Trees
       getUnapplied(unapplyScrut(scrut, this).copiedFrom(this))
 
     def subTypes(in: Type)(implicit s: Symbols): Seq[Type] =
-      unwrapTupleType(s.unapplyAccessorResultType(getGet, getFunction.returnType).get, subPatterns.size)
+      unwrapTupleType(s.unapplyAccessorResultType(getGet, getFunction.getType).get, subPatterns.size)
   }
 
 

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -828,6 +828,10 @@ trait TypeEncoding
         val newBody = scope.transform(body, inType)
         t.LetRec(newFuns.map(_.toLocal), newBody).copiedFrom(e)
 
+      // push conversions down into branches/leaves
+      case (_: s.IfExpr | _: s.MatchExpr | _: s.Let) => super.transform(e, inType)
+      case (_: s.Block | _: s.LetVar) => super.transform(e, inType)
+
       case e if isObject(e.getType) != isObject(inType) =>
         convert(transform(e), e.getType, inType)
 

--- a/frontends/benchmarks/termination/looping/Inconsistency5.scala
+++ b/frontends/benchmarks/termination/looping/Inconsistency5.scala
@@ -1,0 +1,14 @@
+object Inconsistency5 {
+  case class Machine(f: Any => Boolean)
+
+  def negateDiagonal(x: Any): Boolean = 
+    if (x.isInstanceOf[Machine])
+      !x.asInstanceOf[Machine].f(x)
+    else
+      true
+
+  def theorem() = {
+    val m = Machine(negateDiagonal _)
+    negateDiagonal(m) // reduces to !negateDiagonal(m)
+  }
+}

--- a/frontends/benchmarks/verification/valid/ADTInvariants4.scala
+++ b/frontends/benchmarks/verification/valid/ADTInvariants4.scala
@@ -1,0 +1,16 @@
+import stainless.lang._
+
+object ADTInvariants4 {
+  abstract class Foo {
+    def bar: Option[Bar]
+  }
+
+  case class Bar(bar: Option[Bar]) extends Foo {
+    require(bar.isDefined)
+  }
+
+  def test(foo: Foo): Boolean = (foo match {
+    case Bar(b) => b.nonEmpty
+    case _ => true
+  }).holds
+}

--- a/frontends/library/stainless/proof/package.scala
+++ b/frontends/library/stainless/proof/package.scala
@@ -35,7 +35,7 @@ package object proof {
   def check(prop: Boolean): Boolean = {
     require(prop)
     prop
-  }
+  }.holds
 
   /**
    * Relational reasoning.


### PR DESCRIPTION
Following a quick discussion with @jad-hamza & @romac from yesterday.

The idea is that, hopefully, the solver can benefit from this change when `check { ... }` expression are combined (e.g. through conjunctions): when verifying the n-th check expression, the solver shouldn't have to re-verify the n-1 previous ones.

I however don't have concrete proof that this actually makes things faster.