### PR TITLE
Type alias support

### DIFF
--- a/frontends/benchmarks/extraction/valid/Typedef.scala
+++ b/frontends/benchmarks/extraction/valid/Typedef.scala
@@ -1,0 +1,19 @@
+object Typedef {
+  // Simple type alias
+  type MyInt = Int
+
+  // Also type lambdas
+  type MyType[x] = x
+
+  // Type aliases are correctly unaliased.
+  def add(a: MyInt, b: MyInt): MyInt = {
+    a + b
+  }
+
+  // Type lambdas are correctly evaluated and unaliased.
+  def succ(a: MyType[Int]): Int = {
+    require( a < 2147483647 )
+    val res = a + 1
+    res
+  } ensuring( res => res > a)
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -207,6 +207,9 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
       case t if t.symbol is Synthetic =>
         // ignore
 
+      case TypeDef(_,_) =>
+        // ignore, once the type is extracted we do not do anything with the typedef.
+
       case other =>
         reporter.warning(other.pos, "Could not extract tree in static container: " + other)
     }
@@ -1343,6 +1346,14 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     case ct: ConstantType => extractType(ct.value.tpe)
 
     case tr: TypeRef if dctx.tparams.isDefinedAt(tr.symbol) => dctx.tparams(tr.symbol)
+
+    // dotty < 0.4-RC01
+    case hk @ HKApply(tycon, args) =>
+      extractType(hk.dealias.appliedTo(args))
+
+    // dotty >= 0.4-RC01
+    case hk: LambdaType =>
+      extractType(hk.resultType)
 
     case tt @ TypeRef(_, _) if tt != tt.dealias =>
       extractType(tt.dealias)

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -221,6 +221,10 @@ trait CodeExtraction extends ASTExtractors {
       case t if t.symbol.isSynthetic =>
         // ignore
 
+      case t if t.symbol.isAliasType =>
+        // Ignore type alias definitions as units (we don't need it in the
+        // stainless AST).
+
       case other =>
         reporter.warning(other.pos, "Could not extract tree in static container: " + other)
     }
@@ -1310,6 +1314,9 @@ trait CodeExtraction extends ASTExtractors {
 
     case tr @ TypeRef(_, sym, tps) if sym.isClass =>
       xt.ClassType(getIdentifier(sym), tps.map(extractType))
+
+    case tr @ TypeRef(_, sym, tps) if sym.isAliasType =>
+      extractType(tr.dealias)
 
     case tt: ThisType =>
       xt.ClassType(getIdentifier(tt.sym), tt.sym.typeParams.map(dctx.tparams))


### PR DESCRIPTION
Add support for type aliases and type lamdas in code extraction for the scalac and dotty frontends.