### PR TITLE
Use native packager to generate runner scripts.

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -35,8 +35,6 @@ lazy val extraClasspath = taskKey[String]("Classpath extensions passed directly 
 
 lazy val scriptPath = taskKey[String]("Classpath used in the stainless Bash script")
 
-lazy val script = taskKey[Unit]("Generate the stainless Bash script")
-
 lazy val baseSettings: Seq[Setting[_]] = Seq(
   organization := "ch.epfl.lara"
 )
@@ -140,63 +138,9 @@ lazy val commonFrontendSettings: Seq[Setting[_]] = Defaults.itSettings ++ Seq(
   ))
 
 val scriptSettings: Seq[Setting[_]] = Seq(
-  compile := (compile in Compile).dependsOn(script).value,
-
-  clean := {
-    clean.value
-    val scriptFile = root.base / "bin" / name.value
-    if (scriptFile.exists && scriptFile.isFile) {
-      scriptFile.delete
-    }
-  },
-
-  scriptPath := {
-    val cps = (managedClasspath in Runtime).value ++
-      (unmanagedClasspath in Runtime).value ++
-      (internalDependencyClasspath in Runtime).value
-
-    val out = (classDirectory      in Compile).value
-    val res = (resourceDirectory   in Compile).value
-
-    (res.getAbsolutePath +: out.getAbsolutePath +: cps.map(_.data.absolutePath)).mkString(System.getProperty("path.separator"))
-  },
-
   extraClasspath := {
     ((classDirectory in Compile).value.getAbsolutePath +: (dependencyClasspath in Compile).value.map(_.data.absolutePath))
       .mkString(System.getProperty("path.separator"))
-  },
-
-  script := {
-    val s = streams.value
-    try {
-      val binDir = root.base / "bin"
-      binDir.mkdirs
-
-      val scriptFile = binDir / name.value
-
-      if (scriptFile.exists) {
-        s.log.info("Regenerating '" + scriptFile.getName + "' script")
-        scriptFile.delete
-      } else {
-        s.log.info("Generating '" + scriptFile.getName + "' script")
-      }
-
-      val paths = scriptPath.value
-      IO.write(scriptFile, s"""|#!/usr/bin/env bash
-                               |
-                               |set -o posix
-                               |
-                               |set -o pipefail
-                               |
-                               |SCALACLASSPATH="$paths"
-                               |
-                               |java -Xmx2G -Xms512M -Xss64M -classpath "$${SCALACLASSPATH}" -Dscala.usejavacp=true stainless.Main $$@ 2>&1 | tee -i last.log
-                               |""".stripMargin)
-      scriptFile.setExecutable(true)
-    } catch {
-      case e: Throwable =>
-        s.log.error("There was an error while generating the script file: " + e.getLocalizedMessage)
-    }
   }
 )
 
@@ -226,6 +170,7 @@ lazy val `stainless-library` = (project in file("frontends") / "library")
   )
 
 lazy val `stainless-scalac` = (project in file("frontends/scalac"))
+  .enablePlugins(JavaAppPackaging)
   .settings(
     name := "stainless-scalac",
     frontendClass := "scalac.ScalaCompiler",
@@ -261,6 +206,7 @@ lazy val `stainless-dotty-frontend` = (project in file("frontends/dotty"))
   .settings(commonSettings)
 
 lazy val `stainless-dotty` = (project in file("frontends/stainless-dotty"))
+  .enablePlugins(JavaAppPackaging)
   .disablePlugins(AssemblyPlugin)
   .settings(
     name := "stainless-dotty",

--- a/core/src/sphinx/installation.rst
+++ b/core/src/sphinx/installation.rst
@@ -16,8 +16,6 @@ written and tested improvements to the information below.
 * SBT 0.13.x (Available from http://www.scala-sbt.org/)
 * `Sphinx restructured text tool <http://sphinx-doc.org/>`_ (for building local documentation)
 
-Linux & Mac OS-X
-----------------
 
 Get the sources of Stainless by cloning the official Stainless repository:
 
@@ -27,18 +25,25 @@ Get the sources of Stainless by cloning the official Stainless repository:
   Cloning into 'stainless'...
   // ...
   $ cd stainless
-  $ sbt clean compile
+  $ sbt clean universal:stage
   // takes about 1 minute
 
 The compilation will automatically generate the following two bash scripts:
-1. ``bin/stainless-scalac`` that will use the ``scalac`` compiler as frontend,
-2. ``bin/stainless-dotty`` that uses the ``dotc`` compiler as frontend (experimental).
+1. ``frontends/scalac/target/universal/stage/bin/stainless-scalac`` that will use the ``scalac`` compiler as frontend,
+2. ``frontends/stainless-dotty/target/universal/stage/bin/stainless-dotty`` that uses the ``dotc`` compiler as frontend (experimental).
 
-You may want to introduce a soft-link from ``bin/stainless-scalac`` to ``stainless``:
+You may want to introduce a soft-link from ``frontends/scalac/target/universal/stage/bin/stainless-scalac`` to ``stainless``:
 
 .. code-block:: bash
 
-  $ ln -s bin/stainless-scalac stainless
+  $ ln -s frontends/scalac/target/universal/stage/bin/stainless-scalac stainless
+
+These scripts work for all platforms and allow additional control over the execution, such as
+passing JVM arguments or system properties:
+
+.. code-block:: bash
+
+  $ frontends/scalac/target/universal/stage/bin/stainless-scalac -Dscalaz3.debug.load=true -J-Xmx6G --help
 
 Note that Stainless is organized as a structure of several
 projects. The main project lives in ``core`` while the two available
@@ -60,15 +65,13 @@ repository. You will need a Git shell for windows, e.g.
   Cloning into 'stainless'...
   // ...
   $ cd stainless
-  $ sbt clean compile
+  $ sbt clean universal:stage
   // takes about 1 minutes
  
 Compilation will automatically generate the following two bash scripts:
-1. ``bin/stainless-scalac`` that will use the ``scalac`` compiler as frontend,
-2. ``bin/stainless-dotty`` that uses the ``dotc`` compiler as frontend (experimental).
+1. ``frontends/scalac/target/universal/stage/bin/stainless-scalac.bat`` that will use the ``scalac`` compiler as frontend,
+2. ``frontends/stainless-dotty/target/universal/stage/bin/stainless-dotty.bat`` that uses the ``dotc`` compiler as frontend (experimental).
 
-You will now need to either port the bash scripts to Windows, or to run them
-under Cygwin.
 
 .. _smt-solvers:
 

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,4 +1,7 @@
 libraryDependencies += { "org.scala-sbt" % "scripted-plugin" % sbtVersion.value }
 
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
+
 addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")
+
+addSbtPlugin("com.typesafe.sbt" % "sbt-native-packager" % "1.3.3")


### PR DESCRIPTION
This Sbt plugin is the standard way to make executable projects in Scala
and gives a few more options, like the way to pass JVM arguments or system
properties, in addition to working on all platforms, including Windows.

The `universal:packageBin` task can produce an archive that can be used to
distribute the jars and runner scripts on all platforms.

PS. I did not remove the old scripts that are generated on `compile`, but that should be eventually the case.