### PR TITLE
sbt-stainless plugin

### DIFF
--- a/.larabot.conf
+++ b/.larabot.conf
@@ -1,6 +1,7 @@
 commands = [
     "sbt -batch -Dparallel=10 test"
     "sbt -batch -Dparallel=10 it:test"
+    "sbt -batch scripted"
 ]
 
 trusted = [

--- a/build.sbt
+++ b/build.sbt
@@ -37,7 +37,6 @@ lazy val script = taskKey[Unit]("Generate the stainless Bash script")
 lazy val scalaVersionSetting: Setting[_] = scalaVersion := "2.11.8"
 
 lazy val artifactSettings: Seq[Setting[_]] = Seq(
-  version := "0.1",
   organization := "ch.epfl.lara",
   scalaVersionSetting
 )

--- a/build.sbt
+++ b/build.sbt
@@ -103,6 +103,7 @@ lazy val commonFrontendSettings: Seq[Setting[_]] = Defaults.itSettings ++ Seq(
   unmanagedSourceDirectories in IntegrationTest += (root.base.getAbsoluteFile / "frontends" / "common" / "src" / "it" / "scala"),
 
   unmanagedResourceDirectories in Compile += root.base / "frontends" / "library",
+  test in assembly := {}, // Skip the test during assembly
 
   sourceGenerators in Compile += Def.task {
     val fullLibraryPaths = ((root.base / "frontends" / "library") ** "*.scala").getPaths
@@ -205,6 +206,7 @@ def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${versi
 lazy val IntegrationTest = config("it") extend(Test)
 
 lazy val `stainless-core` = (project in file("core"))
+  .disablePlugins(AssemblyPlugin)
   .settings(name := "stainless-core")
   .settings(commonSettings)
   //.dependsOn(inox % "compile->compile;test->test")
@@ -221,12 +223,14 @@ lazy val `stainless-scalac` = (project in file("frontends/scalac"))
   .settings(commonSettings, commonFrontendSettings, scriptSettings)
 
 lazy val `stainless-dotty-frontend` = (project in file("frontends/dotty"))
+  .disablePlugins(AssemblyPlugin)
   .settings(name := "stainless-dotty-frontend")
   .dependsOn(`stainless-core`)
   .settings(libraryDependencies += "ch.epfl.lamp" % "dotty_2.11" % dottyVersion % "provided")
   .settings(commonSettings)
 
 lazy val `stainless-dotty` = (project in file("frontends/stainless-dotty"))
+  .disablePlugins(AssemblyPlugin)
   .settings(
     name := "stainless-dotty",
     frontendClass := "dotc.DottyCompiler")
@@ -239,8 +243,11 @@ lazy val `stainless-dotty` = (project in file("frontends/stainless-dotty"))
   .settings(commonSettings, commonFrontendSettings, artifactSettings, scriptSettings)
 
 lazy val root = (project in file("."))
+  .disablePlugins(AssemblyPlugin)
   .settings(scalaVersionSetting, sourcesInBase in Compile := false)
   .dependsOn(`stainless-scalac`, `stainless-dotty`)
   .aggregate(`stainless-core`, `stainless-scalac`, `stainless-dotty`)
 
+// FIXME assembly should be disabled at the top level, but isn't
+// FIXME assembly is not compatible with dotty -- some conflict with scala versions?
 

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -70,7 +70,7 @@ package object frontend {
   }
 
   /** Get one callback for all active components. */
-  private def getMasterCallBack(ctx: inox.Context): MasterCallBack = {
+  def getMasterCallBack(ctx: inox.Context): MasterCallBack = {
     val activeComponents = getActiveComponents(ctx)
     val activeCallbacks = activeComponents map { c => getCallBack(c.name, ctx) }
 

--- a/frontends/scalac/src/main/resources/scalac-plugin.xml
+++ b/frontends/scalac/src/main/resources/scalac-plugin.xml
@@ -1,0 +1,4 @@
+<plugin>
+    <name>stainless-plugin</name>
+    <classname>stainless.frontends.scalac.StainlessPlugin</classname>
+</plugin>

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessPlugin.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessPlugin.scala
@@ -1,0 +1,41 @@
+package stainless.frontends.scalac
+
+import scala.reflect.internal.util.NoPosition
+import scala.tools.nsc.Global
+import scala.tools.nsc.plugins.Plugin
+import scala.tools.nsc.plugins.PluginComponent
+import scala.tools.nsc.reporters.{Reporter => ScalacReporter}
+import inox.{Context => InoxContext, Reporter => InoxReporter}
+import inox.DebugSection
+import stainless.frontend.MasterCallBack
+
+class StainlessPlugin(override val global: Global) extends Plugin {
+  override val name: String = "stainless-plugin"
+  override val description: String = "stainless scala compiler plugin"
+  override val components: List[PluginComponent] = {
+    List(new StainlessPluginComponent(global))
+  }
+}
+
+class StainlessPluginComponent(val global: Global) extends PluginComponent with StainlessExtraction {
+  override implicit val ctx: inox.Context = {
+    val adapter = new ReporterAdapter(global.reporter, Set())
+    InoxContext.empty.copy(reporter = adapter)
+  }
+  override protected val callback: MasterCallBack = stainless.frontend.getMasterCallBack(ctx)
+  override protected val cache: SymbolMapping = new SymbolMapping
+
+  // FIXME: Mind the duplication with ScalaCompiler#stainlessExtraction. Should we extract the common bits?
+  override val phaseName: String = "stainless"
+  override val runsAfter = List[String]("refchecks")
+}
+
+class ReporterAdapter(underlying: ScalacReporter, debugSections: Set[DebugSection]) extends InoxReporter(debugSections) {
+  // FIXME: Mapping of stainless -> scalac positions
+  override def emit(msg: Message): Unit = msg.severity match {
+    case INFO => underlying.echo(NoPosition, msg.msg.toString)
+    case WARNING => underlying.warning(NoPosition, msg.msg.toString)
+    case ERROR  | FATAL | INTERNAL => underlying.error(NoPosition, msg.msg.toString)
+    case _ => underlying.echo(NoPosition, msg.msg.toString) // DEBUG messages are at reported at INFO level
+  }
+}

--- a/project/assembly.sbt
+++ b/project/assembly.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("com.eed3si9n" % "sbt-assembly" % "0.14.5")

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.15
+sbt.version=0.13.17

--- a/project/plugins.sbt
+++ b/project/plugins.sbt
@@ -1,1 +1,4 @@
+libraryDependencies += { "org.scala-sbt" % "scripted-plugin" % sbtVersion.value }
+
 addSbtPlugin("com.typesafe.sbt" % "sbt-site" % "0.8.1")
+addSbtPlugin("com.eed3si9n" % "sbt-buildinfo" % "0.7.0")

--- a/sbt-plugin/src/main/scala/ch/epfl/lara/sbt/stainless/StainlessPlugin.scala
+++ b/sbt-plugin/src/main/scala/ch/epfl/lara/sbt/stainless/StainlessPlugin.scala
@@ -1,0 +1,99 @@
+package ch.epfl.lara.sbt.stainless
+
+import sbt._
+import sbt.Keys._
+
+object StainlessPlugin extends sbt.AutoPlugin {
+
+  private val IssueTracker = "https://github.com/epfl-lara/stainless/issues"
+
+  override def requires: Plugins = plugins.JvmPlugin
+
+  override def trigger: PluginTrigger = noTrigger // --> This plugin needs to be manually enabled
+
+  object autoImport {
+    val stainlessVersion = settingKey[String]("The version of stainless to use")
+  }
+
+  import autoImport._
+
+  private val StainlessLibSources = config("stainless-lib").hide
+
+  override def globalSettings = Seq(
+    onLoad := onLoad.value andThen checkProjectsScalaVersion
+  )
+
+  private def checkProjectsScalaVersion(state: State): State = {
+    val extracted = Project.extract(state)
+
+    val allBuildProjects = extracted.currentUnit.defined
+    for {
+      (id, proj) <- allBuildProjects
+      if proj.autoPlugins.toSet.contains(StainlessPlugin)
+      projRef = ProjectRef(extracted.currentUnit.unit.uri, id)
+      sv <- (scalaVersion in projRef).get(extracted.structure.data)
+      if !BuildInfo.supportedScalaVersions.contains(sv)
+      projName <- (name in projRef).get(extracted.structure.data)
+    } {
+      state.log.error(s"""[$projName] Project uses unsupported Scala version $sv. To use stainless use one of the following Scala versions: ${BuildInfo.supportedScalaVersions.mkString(",")}.""")
+    }
+    state
+  }
+
+  override lazy val projectSettings: Seq[Def.Setting[_]] = stainlessSettings
+
+  lazy val stainlessSettings: Seq[sbt.Def.Setting[_]] = Seq(
+    stainlessVersion := BuildInfo.stainlessVersion,
+    autoCompilerPlugins := true,
+    ivyConfigurations += StainlessLibSources,
+    // FIXME: The pluging currently expects that a SMT solver is in the $PATH. To fix this I need to know where the scalaz3 dependency
+    //        is deployed.
+    libraryDependencies ++= Seq(
+      compilerPlugin("ch.epfl.lara" % s"stainless-scalac-plugin_${scalaVersion.value}" % stainlessVersion.value),
+      ("ch.epfl.lara" % s"stainless-library_${scalaVersion.value}" % stainlessVersion.value).sources() % StainlessLibSources
+    )
+  ) ++ inConfig(Compile)(compileSettings)
+
+  private lazy val compileSettings: Seq[Def.Setting[_]] = inTask(compile)(compileInputsSettings)
+
+  private def compileInputsSettings: Seq[Setting[_]] = {
+    Seq(
+      compileInputs := {
+        val currentCompileInputs = compileInputs.value
+        val additionalScalacOptions = stainlessExtraScalacOptions.value
+
+        // FIXME: Properly merge possibly duplicate -sourcepath scalac options
+        val allScalacOptions = additionalScalacOptions ++ currentCompileInputs.config.options
+        val updatedConfig = currentCompileInputs.config.copy(options = allScalacOptions)
+        currentCompileInputs.copy(config = updatedConfig)
+      }
+    )
+  }
+
+  private def stainlessExtraScalacOptions: Def.Initialize[Task[Seq[String]]] = Def.task {
+    val config = StainlessLibSources
+    val sourceJars = fetchJars(update.value, config, _.classifier == Some(Artifact.SourceClassifier))
+
+    val projectName = (name in thisProject).value
+    val log = streams.value.log
+    log.debug(s"[$projectName] Configuration ${config.name} has modules: $sourceJars")
+
+    import java.io.File.pathSeparator
+    val sourcepath = Seq("-sourcepath", (sourceJars ++ sourceDirectories.value).mkString(pathSeparator))
+
+    log.debug(s"[$projectName] Extra scalacOptions injected by stainless: ${sourcepath.mkString(" ")}.")
+    sourcepath
+  }
+
+  // allows to fetch dependencies scoped to the passed configuration
+  private def fetchJars(report: UpdateReport, config: Configuration, filter: Artifact => Boolean): Seq[File] = {
+    val toolReport = report.configuration(config.name) getOrElse
+      sys.error(s"No ${config.name} configuration found. This is a bug on sbt-stainless, please report it: $IssueTracker")
+
+    for {
+      m <- toolReport.modules
+      (art, file) <- m.artifacts
+      if filter(art)
+    } yield file
+  }
+}

--- a/sbt-plugin/src/sbt-test/sbt-plugin/simple/build.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/simple/build.sbt
@@ -1,0 +1,49 @@
+
+def commonSettings = Seq(
+  version := "0.1",
+  scalaVersion := sys.props("scala.version")
+)
+
+val unsupportedScalaVersion = "2.11.7"
+
+val checkScalaFailures = taskKey[Unit]("checkScalaFailures")
+val assertLogMessage = taskKey[Unit]("checks a log message emitted")
+
+assertLogMessage := check("[unsupported] Project uses unsupported Scala version 2.11.7. To use stainless use one of the following Scala versions: 2.11.8.").value
+
+lazy val success = (project in file("success"))
+  .enablePlugins(StainlessPlugin)
+  .settings(commonSettings)
+
+lazy val failure = (project in file("failure"))
+  .enablePlugins(StainlessPlugin)
+  .settings(commonSettings)
+  .settings(checkScalaFailures := checkScalaFailuresTask("reqreq contains an unexpected `require`.").value)
+
+// This is a project on which the Stainless plugin is not enabled and hence the unsupported Scala version error should NOT be reported
+lazy val ignore = (project in file("ignore"))
+  .settings(scalaVersion := unsupportedScalaVersion)
+
+// This is a project on which the Stainless plugin is enabled and it's using an unsupported Scala version. Hence, an error should be reported
+lazy val unsupported = (project in file("unsupported"))
+  .enablePlugins(StainlessPlugin)
+  .settings(scalaVersion := unsupportedScalaVersion)
+
+def checkScalaFailuresTask(expectedErrorMessage: String) = Def.task {
+  val reporter = savedReporter.value
+  val ignore = (compile in Compile).failure.value
+  val ps = reporter.problems
+  assert(!ps.isEmpty, "Failed to report any problems!")
+  val first = ps(0)
+  assert(first.message == expectedErrorMessage, s"Reported error doesn't match. Expected `$expectedErrorMessage` but was `${first.message}`.")
+}
+
+def check(expectedLogMessage: String) = Def.task {
+  val lastLog: File = BuiltinCommands.lastLogFile(state.value).get
+  val last: String = IO.read(lastLog)
+  val contains = last.contains(expectedLogMessage)
+  if (!contains)
+    sys.error(s"sbt output does not contain expected log message: `$expectedLogMessage`")
+  else
+    IO.write(lastLog, "") // clear the backing log for for 'last'.
+}

--- a/sbt-plugin/src/sbt-test/sbt-plugin/simple/failure/src/main/scala/BadPre1.scala
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/simple/failure/src/main/scala/BadPre1.scala
@@ -1,0 +1,10 @@
+import stainless.annotation._
+import stainless.lang._
+
+object BadPre1 {
+  def reqreq(x: BigInt, y: BigInt): BigInt = {
+    require(x > 0)
+    require(y > 0) // should be rejected
+    x + y
+  } ensuring { _ > 0 }
+}

--- a/sbt-plugin/src/sbt-test/sbt-plugin/simple/project/TestPlugin.scala
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/simple/project/TestPlugin.scala
@@ -1,0 +1,52 @@
+// copied from https://github.com/sbt/sbt-zero-thirteen/blob/0.13/sbt/src/sbt-test/compiler-project/semantic-errors/project/src/main/scala/sbt/TestPlugin.scala
+package sbt
+
+import Keys._
+import xsbti.{Position, Severity}
+
+object TestPlugin extends AutoPlugin {
+  override def requires = plugins.JvmPlugin
+  override def trigger = allRequirements
+
+  object autoImport {
+    val savedReporter = settingKey[xsbti.Reporter]("Saved reporter that collects compilation failures.")
+    val problems = taskKey[Array[xsbti.Problem]]("Problems reported during compilation.")
+  }
+  import autoImport._
+  override def projectSettings = Seq(
+    savedReporter := new CollectingReporter,
+    compilerReporter in (Compile, compile) := Some(savedReporter.value),
+    problems := savedReporter.value.problems
+  )
+}
+
+class CollectingReporter extends xsbti.Reporter {
+  val buffer = collection.mutable.ArrayBuffer.empty[xsbti.Problem]
+
+  def reset(): Unit = {
+    //System.err.println(s"DEBUGME: Clearing errors: $buffer")
+    buffer.clear()
+  }
+  def hasErrors: Boolean = buffer.exists(_.severity == Severity.Error)
+  def hasWarnings: Boolean = buffer.exists(_.severity == Severity.Warn)
+  def printSummary(): Unit = ()
+  def problems: Array[xsbti.Problem] = buffer.toArray
+
+  /** Logs a message. */
+  def log(pos: xsbti.Position, msg: String, sev: xsbti.Severity): Unit = {
+    object MyProblem extends xsbti.Problem {
+      def category: String = null
+      def severity: Severity = sev
+      def message: String = msg
+      def position: Position = pos
+      override def toString = s"$position:$severity: $message"
+    }
+    //System.err.println(s"DEBUGME: Logging: $MyProblem")
+    buffer.append(MyProblem)
+  }
+
+  /** Reports a comment. */
+  def comment(pos: xsbti.Position, msg: String): Unit = ()
+
+  override def toString = "CollectingReporter"
+}

--- a/sbt-plugin/src/sbt-test/sbt-plugin/simple/project/plugins.sbt
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/simple/project/plugins.sbt
@@ -1,0 +1,1 @@
+addSbtPlugin("ch.epfl.lara" % "sbt-stainless" % sys.props("plugin.version"))

--- a/sbt-plugin/src/sbt-test/sbt-plugin/simple/success/src/main/scala/ADTInvariants1.scala
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/simple/success/src/main/scala/ADTInvariants1.scala
@@ -1,0 +1,11 @@
+
+object ADTInvariants1 {
+
+  case class Positive(i: BigInt) {
+    require(i > 0)
+  }
+
+  def theorem(f: Positive => Positive) = {
+    f(Positive(1))
+  } ensuring(res => res.i > 0)
+}

--- a/sbt-plugin/src/sbt-test/sbt-plugin/simple/test
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/simple/test
@@ -1,0 +1,3 @@
+> assertLogMessage
+> success/compile
+> failure/checkScalaFailures

--- a/version.sbt
+++ b/version.sbt
@@ -1,0 +1,1 @@
+version in ThisBuild  := "0.2.0-SNAPSHOT"


### PR DESCRIPTION
This PR adds a sbt-stainless plugin. Please, read the commits message for details.

I expect this PR will fail to execute the scripted test because currently the sbt-stainless plugin requires an external solver to be installed (and I assume that will be missing on the machine running the PR validation). To fix this issue I need a repository to fetch the scalaz3 dependency.