### PR TITLE
Add a partial evaluator for PureScala programs

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -55,6 +55,7 @@ trait MainHelpers extends inox.MainHelpers {
     termination.DebugSectionTermination,
     DebugSectionExtraction,
     frontend.DebugSectionFrontend,
+    partialeval.DebugSectionPartialEval,
     utils.DebugSectionRegistry
   )
 

--- a/core/src/main/scala/stainless/ast/Definitions.scala
+++ b/core/src/main/scala/stainless/ast/Definitions.scala
@@ -11,6 +11,7 @@ trait Definitions extends inox.ast.Definitions { self: Trees =>
   case object Extern extends Flag("extern", Seq.empty)
   case object Opaque extends Flag("opaque", Seq.empty)
   case object Unchecked extends Flag("unchecked", Seq.empty)
+  case object PartialEval extends Flag("partialEval", Seq.empty)
   case class Derived(id: Identifier) extends Flag("derived", Seq(id))
   case class IsField(isLazy: Boolean) extends Flag("field", Seq.empty)
   case class IsUnapply(isEmpty: Identifier, get: Identifier) extends Flag("unapply", Seq(isEmpty, get))
@@ -19,6 +20,7 @@ trait Definitions extends inox.ast.Definitions { self: Trees =>
     case ("extern", Seq()) => Extern
     case ("opaque", Seq()) => Opaque
     case ("unchecked", Seq()) => Unchecked
+    case ("partialEval", Seq()) => PartialEval
     case _ => Annotation(name, args)
   }
 

--- a/core/src/main/scala/stainless/ast/Expressions.scala
+++ b/core/src/main/scala/stainless/ast/Expressions.scala
@@ -250,4 +250,5 @@ trait Expressions extends inox.ast.Expressions with inox.ast.Types { self: Trees
       case _ => Untyped
     }
   }
+
 }

--- a/core/src/main/scala/stainless/ast/Extractors.scala
+++ b/core/src/main/scala/stainless/ast/Extractors.scala
@@ -201,6 +201,7 @@ trait TreeDeconstructor extends inox.ast.TreeDeconstructor {
     case s.Derived(id) => (Seq(id), Seq(), Seq(), (ids, _, _) => t.Derived(ids.head))
     case s.IsField(isLazy) => (Seq(), Seq(), Seq(), (_, _, _) => t.IsField(isLazy))
     case s.IsUnapply(isEmpty, get) => (Seq(isEmpty, get), Seq(), Seq(), (ids, _, _) => t.IsUnapply(ids(0), ids(1)))
+    case s.PartialEval => (Seq(), Seq(), Seq(), (_, _, _) => t.PartialEval)
     case _ => super.deconstruct(f)
   }
 }

--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -3,6 +3,8 @@
 package stainless
 package ast
 
+import scala.collection.mutable.{Map => MutableMap}
+
 trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
   import trees._
   import trees.exprOps._

--- a/core/src/main/scala/stainless/partialeval/PartialEvaluatorWithPC.scala
+++ b/core/src/main/scala/stainless/partialeval/PartialEvaluatorWithPC.scala
@@ -1,0 +1,498 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package partialeval
+
+import scala.language.existentials
+import scala.concurrent.duration._
+import scala.collection.mutable.{Map => MutableMap}
+import scala.util.DynamicVariable
+
+import inox.{Context, Semantics}
+import inox.utils._
+import inox.solvers._
+import inox.solvers.SolverResponses._
+import inox.evaluators.EvaluationResults
+
+import stainless.transformers._
+
+case class PartialEvalError(msg: String) extends Exception(msg)
+
+class PartialEvaluatorWithPC(
+  val program: StainlessProgram,
+  val context: Context
+) extends TransformerWithPC { self =>
+
+  val trees: program.trees.type = program.trees
+  val symbols: program.symbols.type = program.symbols
+
+  import program._
+  import trees._
+  import symbols.{simplifier => _, _}
+  import exprOps._
+  import dsl._
+
+  import context.reporter
+
+  type Env = Path
+
+  override implicit def pp = Path
+
+  private val simplifier = symbols.simplifier(inox.solvers.PurityOptions.assumeChecked)
+
+  private var doNotUnfold: Set[Identifier] = Set.empty
+  private def canUnfold(id: Identifier): Boolean = !doNotUnfold.contains(id)
+
+  final private[this] implicit class PathOps(val path: Path) {
+    def contains(cond: Expr): Boolean = {
+      if (cond.getType != BooleanType()) {
+        reporter.error(s"$cond should have type Boolean, found: ${cond.getType})")
+        reporter.error(explainTyping(cond)(PrinterOptions(printUniqueIds = false, symbols = Some(symbols))))
+        assert(cond.getType == BooleanType())
+      }
+
+      simplifier.transform(path implies cond) match {
+        case BooleanLiteral(res) => res
+        case res => solver.solveVALID(res).getOrElse(false)
+      }
+    }
+  }
+
+  private[this] implicit val debugSection = partialeval.DebugSectionPartialEval
+
+  private[this] lazy val semantics = program.getSemantics
+  private[this] lazy val solver = semantics.getSolver(context).withTimeout(150.millis).toAPI
+  private[this] lazy val groundEvaluator = semantics.getEvaluator(context)
+
+  private[this] val maxUnfoldingSteps: Int = 50
+  private[this] var unfoldingStepsLeft: Map[Identifier, Int] = Map().withDefault(_ => maxUnfoldingSteps)
+
+  override def initEnv: Path = Path.empty
+
+  private val cache = new LruCache[Expr, (Path, Expr)](1000)
+
+  override protected def rec(expr: Expr, path: Path): Expr = {
+    if (context.interruptManager.isInterrupted) {
+      return expr
+    }
+
+    val cached = cache.get(expr).filter(_._1 == path).map(_._2)
+    if (cached.isDefined) {
+      return cached.get
+    }
+
+    val res = expr match {
+      case b: BooleanLiteral => b
+      case c: Choose => c
+
+      case Require(pred, body) => rec(pred, path) match {
+        case BooleanLiteral(true) =>
+          rec(body, path withCond pred)
+        case BooleanLiteral(false) =>
+          Require(BooleanLiteral(false), body)
+        case rp =>
+          Require(rp, rec(body, path withCond pred))
+      }
+
+      case Assert(pred, error, body) => rec(pred, path) match {
+        case BooleanLiteral(true) => rec(body, path withCond pred)
+        case BooleanLiteral(false) => Assert(pred, error, body)
+        case rp => rec(body, path withCond pred)
+      }
+
+      case Assume(pred, body) => rec(pred, path) match {
+        case BooleanLiteral(true) => rec(body, path withCond pred)
+        case BooleanLiteral(false) => Assume(pred, body)
+        case rp => rec(body, path withCond pred)
+      }
+
+      case Ensuring(body, pred) =>
+        rec(Ensuring(body, pred).toAssert, path)
+
+      case Annotated(body, flags) =>
+        rec(body, path)
+
+      case Let(vd, v, b) =>
+        rec(replaceFromSymbols(Map(vd -> rec(v, path)), b), path)
+
+      case m @ MatchExpr(scrut, cases) =>
+        reduceMatch(m, path)
+
+      case fi @ FunctionInvocation(id, tps, args) if canUnfold(fi.id) && !fi.tfd.fd.flags.contains(Extern) =>
+        val rargs = args.map(rec(_, path))
+
+        unfold(fi, rargs, path) match {
+          case Some(unfolded) => rec(unfolded, path)
+          case None => FunctionInvocation(id, tps, rargs)
+        }
+
+      case Application(e, es) => rec(e, path) match {
+        case l: Lambda =>
+          val res = es.map(rec(_, path))
+          rec(l.withParamSubst(res, l.body), path)
+
+        case Assume(pred, l: Lambda) =>
+          val res = es.map(rec(_, path))
+          rec(assume(pred, application(l, res)), path)
+
+        case re =>
+          application(re, es.map(rec(_, path)))
+      }
+
+      case Lambda(args, body) => Lambda(args, body)
+
+      case Implies(l, r) => rec(l, path) match {
+        case BooleanLiteral(false) => BooleanLiteral(true)
+        case le => rec(or(not(le), r), path)
+      }
+
+      case And(e +: es) => rec(e, path) match {
+        case BooleanLiteral(true) => rec(andJoin(es), path withCond e)
+        case BooleanLiteral(false) => BooleanLiteral(false)
+        case re =>
+          val res = rec(andJoin(es), path withCond re)
+          if (res == BooleanLiteral(false)) BooleanLiteral(false)
+          else and(re, res)
+      }
+
+      case Or(e +: es) => rec(e, path) match {
+        case BooleanLiteral(true) => BooleanLiteral(true)
+        case BooleanLiteral(false) => rec(orJoin(es), path)
+        case re =>
+          val res = rec(orJoin(es), path withCond not(re))
+          if (res == BooleanLiteral(true)) {
+            BooleanLiteral(true)
+          } else {
+            or(re, res)
+          }
+      }
+
+      case IfExpr(c, t, e) => rec(c, path) match {
+        case BooleanLiteral(true) => rec(t, path withCond c)
+        case BooleanLiteral(false) => rec(e, path withCond not(c))
+        case rc =>
+          val rt = rec(t, path withCond rc)
+          val re = rec(e, path withCond not(rc))
+          if (rt == re) {
+            rt
+          } else {
+            ifExpr(rc, rt, re)
+          }
+      }
+
+      case IsConstructor(ADT(id1, _, _), id2) =>
+        BooleanLiteral(id1 == id2)
+
+      case IsConstructor(e, id) =>
+        val re = rec(e, path)
+        isConstructor(re, id, path) match {
+          case Some(b) => BooleanLiteral(b)
+          case None => IsConstructor(re, id)
+        }
+
+      case s @ ADTSelector(expr, sel) => rec(expr, path) match {
+        case r @ ADT(adt, _, args) =>
+          rec(args(s.selectorIndex), path)
+
+        case other =>
+          adtSelector(other, sel)
+      }
+
+      case sel @ TupleSelect(t, idx) => rec(t, path) match {
+        case Tuple(exprs) =>
+          rec(exprs(sel.index - 1), path)
+
+        case other =>
+          TupleSelect(other, idx)
+      }
+
+      case FiniteMap(pairs, default, keyType, valueType) =>
+        finiteMap(pairs.map(recPair(_, path)), rec(default, path), keyType, valueType)
+
+      case MapApply(map, key) => (rec(map, path), rec(key, path)) match {
+        case (FiniteMap(pairs, default, _, _), key) =>
+          pairs.toMap.getOrElse(key, default)
+
+        case (map, key) => MapApply(map, key)
+      }
+
+      case MapUpdated(map, key, value) => (rec(map, path), rec(key, path), rec(value, path)) match {
+        case (map @ FiniteMap(pairs, default, from, to), key, value) =>
+          finiteMap(pairs.toMap.updated(key, value).toSeq, default, from, to)
+
+        case (map, key, value) => MapUpdated(map, key, value)
+      }
+
+      case BagAdd(bag, elem) => (rec(bag, path), rec(elem, path)) match {
+        case (FiniteBag(els, tpe), evElem) =>
+          val (matching, rest) = els.partition(_._1 == evElem)
+          val mul = matching.lastOption.map {
+            case (_, IntegerLiteral(i)) => IntegerLiteral(i + 1)
+            case (_, e) => Plus(e, IntegerLiteral(1))
+          }.getOrElse(IntegerLiteral(1))
+
+          finiteBag(rest :+ (evElem -> mul), tpe)
+
+        case (le, re) => BagAdd(le, re)
+      }
+
+      case MultiplicityInBag(elem, bag) => (rec(elem, path), rec(bag, path)) match {
+        case (evElem, FiniteBag(els, tpe)) =>
+          els.collect { case (k,v) if k == evElem => v }.lastOption.getOrElse(IntegerLiteral(0))
+        case (le, re) => MultiplicityInBag(le, re)
+      }
+
+      case BagIntersection(b1, b2) => (rec(b1, path), rec(b2, path)) match {
+        case (FiniteBag(els1, tpe), FiniteBag(els2, _)) =>
+          val map2 = els2.toMap
+          finiteBag(els1.flatMap { case (k, v) =>
+            val i = (v, map2.getOrElse(k, IntegerLiteral(0))) match {
+              case (IntegerLiteral(i1), IntegerLiteral(i2)) => Some(i1 min i2)
+              case (le, re) => None
+            }
+
+            i.filter(_ > 0).map(i => k -> IntegerLiteral(i))
+          }, tpe)
+
+        case (le, re) => BagIntersection(le, re)
+      }
+
+      case BagUnion(b1, b2) => (rec(b1, path), rec(b2, path)) match {
+        case (FiniteBag(els1, tpe), FiniteBag(els2, _)) =>
+          val (map1, map2) = (els1.toMap, els2.toMap)
+          finiteBag((map1.keys ++ map2.keys).toSet.map { (k: Expr) =>
+            k -> ((map1.getOrElse(k, IntegerLiteral(0)), map2.getOrElse(k, IntegerLiteral(0))) match {
+              case (IntegerLiteral(i1), IntegerLiteral(i2)) => IntegerLiteral(i1 + i2)
+              case (le, re) => Plus(le, re)
+            })
+          }.toSeq, tpe)
+
+        case (le, re) => BagUnion(le, re)
+      }
+
+      case BagDifference(b1, b2) => (rec(b1, path), rec(b2, path)) match {
+        case (FiniteBag(els1, tpe), FiniteBag(els2, _)) =>
+          val map2 = els2.toMap
+          finiteBag(els1.flatMap { case (k, v) =>
+            val i = (v, map2.getOrElse(k, IntegerLiteral(0))) match {
+              case (IntegerLiteral(i1), IntegerLiteral(i2)) => Some(i1 - i2)
+              case (le, re) => None
+            }
+
+            i.filter(_ > 0).map(i => k -> IntegerLiteral(i))
+          }, tpe)
+
+        case (le, re) => BagDifference(le, re)
+      }
+
+      case FiniteBag(els, base) =>
+        finiteBag(els.map { case (k, v) => (rec(k, path), rec(v, path)) }, base)
+
+      case SetAdd(s1, elem) =>
+        (rec(s1, path), rec(elem, path)) match {
+          case (FiniteSet(els1, tpe), evElem) => finiteSet(els1 :+ evElem, tpe)
+          case (le, re) => SetAdd(le, re)
+        }
+
+      case SetUnion(s1,s2) =>
+        (rec(s1, path), rec(s2, path)) match {
+          case (FiniteSet(els1, tpe), FiniteSet(els2, _)) => finiteSet(els1 ++ els2, tpe)
+          case (le, re) => SetUnion(le, re)
+        }
+
+      case SetIntersection(s1,s2) =>
+        (rec(s1, path), rec(s2, path)) match {
+          case (FiniteSet(els1, tpe), FiniteSet(els2, _)) => finiteSet(els1 intersect els2, tpe)
+          case (le, re) => SetIntersection(le, re)
+        }
+
+      case SetDifference(s1, s2) =>
+        (rec(s1, path), rec(s2, path)) match {
+          case (FiniteSet(els1, tpe), FiniteSet(els2, _)) => finiteSet(els1.toSet -- els2, tpe)
+          case (le, re) => SetDifference(le, re)
+        }
+
+      case ElementOfSet(el,s) => (rec(el, path), rec(s, path)) match {
+        case (e, FiniteSet(els, _)) => BooleanLiteral(els.contains(e))
+          case (le, re) => ElementOfSet(le, re)
+      }
+
+      case SubsetOf(s1, s2) => (rec(s1, path), rec(s2, path)) match {
+        case (FiniteSet(els1, _),FiniteSet(els2, _)) => BooleanLiteral(els1.toSet.subsetOf(els2.toSet))
+          case (le, re) => SubsetOf(le, re)
+      }
+
+      case f @ FiniteSet(els, base) =>
+        finiteSet(els.map(rec(_, path)), base)
+
+      case LargeArray(elems, default, size, base) =>
+        LargeArray(elems.mapValues(rec(_, path)), rec(default, path), size, base)
+
+      case ArraySelect(array, index) => (rec(array, path), rec(index, path)) match {
+        case (FiniteArray(elems, base), Int32Literal(i)) =>
+          if (i < 0 || i >= elems.size) throw PartialEvalError("Index out of bounds @" + expr.getPos)
+          elems(i)
+        case (LargeArray(elems, default, Int32Literal(size), _), Int32Literal(i)) =>
+          if (i < 0 || i >= size) throw PartialEvalError("Index out of bounds @" + expr.getPos)
+          elems.getOrElse(i, default)
+        case (arr, i) =>
+          ArraySelect(arr, i)
+      }
+
+      case ArrayUpdated(array, index, value) => (rec(array, path), rec(index, path), rec(value, path)) match {
+        case (FiniteArray(elems, base), Int32Literal(i), v) =>
+          if (i < 0 || i >= elems.size) throw PartialEvalError("Index out of bounds @" + expr.getPos)
+          FiniteArray(elems.updated(i, v), base)
+        case (LargeArray(elems, default, s @ Int32Literal(size), base), Int32Literal(i), v) =>
+          if (i < 0 || i >= size) throw PartialEvalError("Index out of bounds @" + expr.getPos)
+          LargeArray(elems + (i -> v), default, s, base)
+        case (arr, i, v) =>
+          ArrayUpdated(arr, i, v)
+      }
+
+      case ArrayLength(array) => rec(array, path) match {
+        case FiniteArray(elems, _) => Int32Literal(elems.size)
+        case LargeArray(_, _, s, _) => s
+        case arr => ArrayLength(arr)
+      }
+
+      case e if e.getType == BooleanType() && path.contains(e) =>
+        BooleanLiteral(true)
+
+      case e if e.getType == BooleanType() && path.contains(not(e)) =>
+        BooleanLiteral(false)
+
+      case e => super.rec(e, path)
+    }
+
+    val simpl = simplifyGround(res)(semantics, context)
+    cache(expr) = path -> simpl
+    simpl
+  }
+
+  private def recAndCons(es: Seq[Expr], path: Path, cons: Seq[Expr] => Expr): Expr = {
+    cons(es.map(rec(_, path)))
+  }
+
+  private def recPair(pair: (Expr, Expr), path: Path): (Expr, Expr) = {
+    (rec(pair._1, path), rec(pair._2, path))
+  }
+
+  private def finiteSet(els: Iterable[Expr], tpe: Type): FiniteSet = {
+    FiniteSet(els.toSeq.distinct.sortBy(_.toString), tpe)
+  }
+
+  private def finiteMap(els: Iterable[(Expr, Expr)], default: Expr, from: Type, to: Type): FiniteMap = {
+    FiniteMap(els.toMap.toSeq.filter { case (_, value) => value != default }.sortBy(_._1.toString), default, from, to)
+  }
+
+  private def finiteBag(els: Iterable[(Expr, Expr)], tpe: Type): FiniteBag = {
+    FiniteBag(els.toMap.toSeq.filter { case (_, IntegerLiteral(i)) => i > 0 case _ => false }.sortBy(_._1.toString), tpe)
+  }
+
+  private def isConstructor(e: Expr, id: Identifier, path: Path): Option[Boolean] = {
+    if (path contains IsConstructor(e, id)) {
+      Some(true)
+    } else {
+      val adt @ ADTType(_, tps) = widen(e.getType)
+      val sort = adt.getSort
+      val cons = getConstructor(id, tps)
+      val alts = (sort.constructors.toSet - cons).map(_.id)
+
+      if (alts exists (id => path contains IsConstructor(e, id))) {
+        Some(false)
+      } else if (alts forall (id => path contains Not(IsConstructor(e, id)))) {
+        Some(true)
+      } else {
+        None
+      }
+    }
+  }
+
+  private def unfold(fi: FunctionInvocation, args: Seq[Expr], path: Path): Option[Expr] = {
+    lazy val unfolded = exprOps.freshenLocals(fi.tfd.withParamSubst(args, fi.tfd.fullBody))
+
+    if (unfoldingStepsLeft(fi.id) > 0 && (!isRecursive(fi.id) || isProductiveUnfolding(fi.id, unfolded, path))) {
+      decreaseUnfoldingStepsLeft(fi.id)
+      Some(unfolded)
+    } else {
+      None
+    }
+  }
+
+  private def decreaseUnfoldingStepsLeft(id: Identifier): Unit = {
+    val left = unfoldingStepsLeft(id)
+    unfoldingStepsLeft = unfoldingStepsLeft.updated(id, left - 1)
+  }
+
+  private def preventUnfolding[A](id: Identifier)(action: => A): A = {
+    val alreadyPrevented = doNotUnfold contains id
+    if (!alreadyPrevented) doNotUnfold = doNotUnfold + id
+    val res = action
+    if (!alreadyPrevented) doNotUnfold = doNotUnfold - id
+    res
+  }
+
+  private def isProductiveUnfolding(id: Identifier, expr: Expr, path: Path): Boolean = {
+    def isKnown(expr: Expr): Boolean = expr match {
+      case BooleanLiteral(_) => true
+      case _ => false
+    }
+
+    val invocationPaths = collectWithPC(expr) {
+      case (fi: FunctionInvocation, subPath) if fi.id == id || transitivelyCalls(fi.id, id) => subPath
+    }
+
+    preventUnfolding(id) {
+      invocationPaths.map(p => transform(p.toClause, path)).forall(isKnown)
+    }
+  }
+
+  private def reduceMatch(e: MatchExpr, path: Path): Expr = {
+    val MatchExpr(scrut, cases) = e
+    val rs = transform(scrut, path)
+    val (_, stop, newCases) = cases.foldLeft((path, false, Seq[MatchCase]())) {
+      case (p @ (_, true, _), _) => p
+      case ((soFar, _, newCases), MatchCase(pattern, guard, rhs)) =>
+        transform(conditionForPattern[Path](rs, pattern, includeBinders = false)(pp).fullClause, soFar) match {
+          case BooleanLiteral(false) => (soFar, false, newCases)
+          case rc =>
+            val path = conditionForPattern[Path](rs, pattern, includeBinders = true)(pp)
+            val rg = guard.map(transform(_, soFar merge path)).getOrElse(BooleanLiteral(true))
+            and(rc, rg) match {
+              case BooleanLiteral(false) => (soFar, false, newCases)
+              case BooleanLiteral(true) =>
+                // We know path withCond rg is true here but we need the binders
+                val bindings = conditionForPattern[Path](rs, pattern, includeBinders = true)(pp).bindings
+                val rr = bindings.foldRight(rhs) { case ((i, e), b) => Let(i, e, b) }
+                (soFar, true, newCases :+ MatchCase(WildcardPattern(None).copiedFrom(pattern), None, rr))
+
+              case _ =>
+                val rr = rhs
+                val newGuard = if (rg == BooleanLiteral(true)) None else Some(rg)
+                (
+                  soFar merge (path withCond rg).negate,
+                  false,
+                  newCases :+ MatchCase(pattern, newGuard, rr)
+                )
+            }
+        }
+    }
+
+    newCases match {
+      case Seq() =>
+        Assert(
+          BooleanLiteral(false).copiedFrom(e),
+          Some("No valid case"),
+          Choose(
+            ValDef(FreshIdentifier("res"), e.getType, Seq.empty).copiedFrom(e),
+            BooleanLiteral(true).copiedFrom(e)
+          ).copiedFrom(e)
+        ).copiedFrom(e)
+
+      case Seq(MatchCase(WildcardPattern(None), None, rhs)) if stop => transform(rhs, path)
+      case _ => MatchExpr(rs, newCases).copiedFrom(e)
+    }
+  }
+
+}

--- a/core/src/main/scala/stainless/partialeval/package.scala
+++ b/core/src/main/scala/stainless/partialeval/package.scala
@@ -1,0 +1,62 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+
+import scala.concurrent.duration._
+import scala.language.postfixOps
+
+package object partialeval {
+
+  object DebugSectionPartialEval extends inox.DebugSection("partial-eval")
+
+  object PartialEvaluator {
+
+    private implicit val debugSection = DebugSectionPartialEval
+
+    def apply(p: StainlessProgram, ctx: inox.Context): inox.ast.SymbolTransformer {
+      val s: p.trees.type
+      val t: p.trees.type
+    } = new inox.ast.SymbolTransformer {
+      val s: p.trees.type = p.trees
+      val t: p.trees.type = p.trees
+
+      import ctx._
+      import ctx.{ timers, reporter }
+
+      import p._
+      import p.trees._
+
+      val simplifier = p.symbols.simplifier(inox.solvers.PurityOptions.assumeChecked)
+
+      def partialEval(fd: FunDef, p: StainlessProgram): FunDef =  {
+        import p._, p.trees._
+
+        val evaluator = new PartialEvaluatorWithPC(p, ctx)
+
+        val (Seq(pre, post), body) = exprOps.deconstructSpecs(fd.fullBody)
+        val expr                   = exprOps.reconstructSpecs(Seq(pre), body, fd.fullBody.getType)
+
+        reporter.debug(s" - Partially evaluating function '${fd.id}' at ${fd.getPos}...")
+        reporter.debug(s"   Before: " + expr)
+        val (elapsed, res) = timers.partialeval.runAndGetTime(evaluator.transform(simplifier.transform(expr)))
+        reporter.debug(s"   After: " + res.get)
+        reporter.debug(s"   Time elapsed: " + "%.4f".format(elapsed.millis.toUnit(SECONDS)) + " seconds\n")
+
+        val simpl = simplifier.transform(res.get)
+
+        val newBody = exprOps.reconstructSpecs(Seq(pre, post), Some(simpl), fd.fullBody.getType)
+
+        fd.copy(fullBody = newBody, flags = fd.flags.filterNot(_.name == "partialEval"))
+      }
+
+      def transform(syms: s.Symbols): t.Symbols = {
+        syms.functions.values.toSeq
+          .filter(_.flags exists (_.name == "partialEval"))
+          .sorted(syms.CallGraphOrderings.functionOrdering.reverse)
+          .foldLeft(p) { case (p, fd) => p.withFunctions(Seq(partialEval(fd, p))) }
+          .symbols
+      }
+    }
+  }
+
+}

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -22,7 +22,7 @@ trait InoxEncoder extends ProgramEncoder {
       .withSorts(sourceProgram.symbols.sorts.values.toSeq.map(encoder.transform))
       .withFunctions(sourceProgram.symbols.functions.values.toSeq
         .map(fd => fd.copy(flags = fd.flags.filter {
-          case Derived(_) | IsField(_) | Unchecked | IsUnapply(_, _) => false
+          case Derived(_) | IsField(_) | Unchecked | IsUnapply(_, _) | PartialEval => false
           case _ => true
         }))
         .map { fd =>

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -179,14 +179,15 @@ trait VerificationChecker { self =>
     val s = sf.getNewSolver
 
     try {
-      val cond = simplifyLets(vc.condition)
-      reporter.synchronized {
-        reporter.info(s" - Now solving '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
-        reporter.debug(cond.asString)
-        reporter.debug("Solving with: " + s.name)
-      }
-
       val (time, tryRes) = timers.verification.runAndGetTime {
+        val cond = simplifyLets(vc.condition)
+
+        reporter.synchronized {
+          reporter.info(s" - Now solving '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
+          reporter.debug(cond.asString)
+          reporter.debug("Solving with: " + s.name)
+        }
+
         if (vc.satisfiability) {
           s.assertCnstr(cond)
           s.check(Simple)

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -6,6 +6,9 @@ package verification
 import scala.concurrent.Future
 import scala.language.existentials
 
+import extraction.xlang.{trees => xt}
+import partialeval.PartialEvaluator
+
 /**
  * Strict Arithmetic Mode:
  *
@@ -25,6 +28,12 @@ object VerificationComponent extends SimpleComponent {
     val s: extraction.trees.type = extraction.trees
     val t: extraction.trees.type = extraction.trees
   })
+
+  override def extract(program: Program { val trees: xt.type }, ctx: inox.Context): SelfProgram = {
+    val extracted = super.extract(program, ctx)
+    val partialEvaluator = PartialEvaluator(extracted, ctx)
+    inox.ast.ProgramEncoder(extracted)(partialEvaluator).targetProgram
+  }
 
   implicit val debugSection = DebugSectionVerification
 

--- a/core/src/sphinx/library.rst
+++ b/core/src/sphinx/library.rst
@@ -78,6 +78,9 @@ which instruct Stainless to handle some functions or objects in a specialized wa
 | ``@extern``       | Only extract the contracts of a function, replacing            |
 |                   | its body by a ``choose`` expression.                           |
 +-------------------+----------------------------------------------------------------+
+| ``@partialEval``  | Partially evaluate this function over its formal arguments,    |
+|                   | replacing its body by the resulting expression.                |
++-------------------+----------------------------------------------------------------+
 
 List[T]
 -------

--- a/frontends/benchmarks/verification/invalid/PartialSplit.scala
+++ b/frontends/benchmarks/verification/invalid/PartialSplit.scala
@@ -1,0 +1,83 @@
+
+import stainless.lang._
+import stainless.collection._
+import stainless.annotation._
+
+object split {
+
+  sealed abstract class P
+  case object Alice   extends P;
+  case object Bob     extends P;
+  case object Charlie extends P;
+
+  case class S(who: P, amount: BigInt)
+
+  val spent = List(
+    S(Alice   ,     0),
+    // S(Bob     ,  3000),
+    S(Charlie ,  4000)
+  )
+
+  @partialEval
+  val all = spent.map(_.who)
+
+  @partialEval
+  val pairs = {
+    for {
+      a <- all
+      b <- all
+    } yield (a, b)
+  } filter { case (a, b) => a != b }
+
+  @partialEval val total     = spent.foldLeft(BigInt(0)) { case (acc, S(_, a)) => acc + a }
+  @partialEval val perPerson = total / spent.length
+  @partialEval val diff      = spent map { case S(w, a) => S(w, perPerson - a) }
+  @partialEval val pos       = diff.filter(_.amount >= 0)
+  @partialEval val neg       = diff.filter(_.amount < 0)
+  @partialEval val posTotal  = pos.map(_.amount).foldLeft(BigInt(0))(_ + _)
+  @partialEval val negTotal  = neg.map(_.amount).foldLeft(BigInt(0))(_ + _)
+
+  type Transfers = List[((P, P), BigInt)]
+
+  def posConstraints(transfers: Transfers): Boolean = {
+    val cnstrs = pos map { case S(n, a) =>
+      val out = from(n, transfers).map(_._2).foldLeft(BigInt(0))(_ + _)
+      fuzEq(out, a)
+    }
+    cnstrs.foldLeft(true)(_ && _)
+  }
+
+  def negConstraints(transfers: Transfers): Boolean = {
+    val cnstrs = neg map { case S(n, a) =>
+      val inc = to(n, transfers).map(_._2).foldLeft(BigInt(0))(_ + _)
+      fuzEq(-inc, a)
+    }
+    cnstrs.foldLeft(true)(_ && _)
+  }
+
+  def theorem(transfers: Transfers): Boolean = {
+    val sum = transfers.map(_._2).foldLeft(BigInt(0))(_ + _)
+
+    transfers.length == pairs.length &&
+    pairs.forall { pair => transfers.exists(_._1 == pair) } &&
+    sum == posTotal &&
+    transfers.map(_._1).forall { case (p, q) => p != q } &&
+    transfers.forall { case ((p, q), pqa) =>
+      val qpa = transfers.find(_._1 == (q, p)).map(_._2)
+      qpa.isDefined && (qpa.get == 0 || pqa == 0) && (pqa > 0 || qpa.get > 0)
+    } && posConstraints(transfers) && negConstraints(transfers)
+  } ensuring { !_ }
+
+  def fuzEq(a: BigInt, b: BigInt): Boolean = {
+    a >= b - 50 && a <= b + 50
+  }
+
+  def from(n: P, pps: Transfers): Transfers = {
+    pps.filter { case ((p, _), _) => p == n }
+  }
+
+  def to(n: P, pps: Transfers): Transfers = {
+    pps.filter { case ((_, q), _) => q == n }
+  }
+
+}

--- a/frontends/benchmarks/verification/valid/PartialCompiler.scala
+++ b/frontends/benchmarks/verification/valid/PartialCompiler.scala
@@ -1,0 +1,77 @@
+import stainless.lang._
+import stainless.annotation._
+import stainless.collection._
+import stainless.util.Random
+
+object comp {
+
+  sealed trait Expr
+  case class Var(name: String)     extends Expr
+  case class Num(value: Int)       extends Expr
+  case class Add(l: Expr, r: Expr) extends Expr
+  case class Mul(l: Expr, r: Expr) extends Expr
+  case class Rand(max: Expr)       extends Expr
+
+  type Context = Map[String, Expr]
+
+  @extern
+  def random(max: Int): Int = {
+    42
+  }
+
+  case class Error(msg: String)
+
+  def interpret(expr: Expr, ctx: Context)(fuel: Int): Either[Error, Int] = {
+    require(fuel >= 0)
+    decreases(fuel)
+
+    if (fuel == 0) Left(Error("No more fuel")) else expr match {
+      case Num(value) => Right(value)
+
+      case Var(name) if ctx contains name =>
+        interpret(ctx(name), ctx)(fuel - 1)
+
+      case Var(name) =>
+        Left(Error("Unbound variable: " + name))
+
+      case Add(l, r)  => for {
+        le <- interpret(l, ctx)(fuel - 1)
+        re <- interpret(r, ctx)(fuel - 1)
+      } yield le + re
+
+      case Mul(l, r)  => for {
+        le <- interpret(l, ctx)(fuel - 1)
+        re <- interpret(r, ctx)(fuel - 1)
+      } yield le * re
+
+      case Rand(max) =>
+        interpret(max, ctx)(fuel - 1).map(random(_))
+    }
+  }
+
+  val program: Expr = Mul(Num(10), Add(Var("x"), Rand(Num(42))))
+
+  // @partialEval
+  // def unknown(ctx: Context) = {
+  //   require(ctx.contains("x") && forall((f: Int) => f > 0 ==> interpret(ctx("x"), ctx)(f).isRight))
+  //   interpret(program, ctx)(42)
+  // }
+
+  @partialEval
+  def left_unbound(y: Int) = {
+    val ctx: Context = Map("y" -> Num(y))
+    interpret(program, ctx)(42)                                // Left(Error("Unbound variable: x"))
+  } ensuring { _ == Left[Error, Int](Error("Unbound variable: x")) }
+
+  @partialEval
+  def left_fuel(x: Int) = {
+    val ctx: Context = Map("x" -> Num(x))
+    interpret(program, ctx)(2)                                // Left(Error("No more fuel"))
+  } ensuring { _ == Left[Error, Int](Error("No more fuel")) }
+
+  @partialEval
+  def right(x: Int) = {
+    interpret(program, Map("x" -> Num(x)))(42)                 // Right(10 * (ctx("x") + random(42)))
+  } ensuring { _ == Right[Error, Int](10 * (x + random(42))) }
+
+}

--- a/frontends/benchmarks/verification/valid/PartialFold.scala
+++ b/frontends/benchmarks/verification/valid/PartialFold.scala
@@ -1,0 +1,50 @@
+
+import stainless.lang._
+import stainless.collection._
+import stainless.annotation._
+
+object PartialFold {
+
+//   @partialEval
+//   def sum(xs: List[BigInt]): BigInt = {
+//     require(xs.length == 3)
+
+//     xs.foldLeft(BigInt(0)) { _ + _ }
+//   }
+
+//   def test1 = {
+//     sum(List(1,2,3)) == BigInt(6)
+//   }.holds
+
+  sealed abstract class Tree[A] {
+    def fold[B](node: (B, B) => B)(leaf: A => B): B = this match {
+      case Node(left, right) => node(left.fold(node)(leaf), right.fold(node)(leaf))
+      case Leaf(value) => leaf(value)
+    }
+  }
+  final case class Node[A](left: Tree[A], right: Tree[A]) extends Tree[A]
+  final case class Leaf[A](value: A) extends Tree[A]
+
+  def tree(a: BigInt, b: BigInt, c: BigInt, d: BigInt, e: BigInt): Tree[BigInt] =
+    Node(
+      Node(
+        Leaf(a),
+        Leaf(b)
+      ),
+      Node(
+        Leaf(c),
+        Node(
+          Leaf(d),
+          Leaf(e)
+        )
+      )
+    )
+
+  def id[A](x: A): A = x
+
+  @partialEval
+  def test(a: BigInt, b: BigInt, c: BigInt, d: BigInt, e: BigInt) = {
+    tree(a, b, c, d, e).fold[BigInt](_ + _)(id)
+  } ensuring { _ == a + b + c + d + e }
+
+}

--- a/frontends/benchmarks/verification/valid/PartialKVTrace.scala
+++ b/frontends/benchmarks/verification/valid/PartialKVTrace.scala
@@ -1,0 +1,76 @@
+
+import stainless.lang._
+import stainless.annotation._
+import stainless.collection._
+
+object kv {
+
+  sealed abstract class Label
+  object Label {
+    case class Get(key: String)                extends Label
+    case class Put(key: String, value: String) extends Label
+  }
+
+  sealed abstract class Op
+  case class Pure(value: Option[String])                     extends Op
+  case class Get(key: String, next: Option[String] => Op)    extends Op
+  case class Put(key: String, value: String, next: () => Op) extends Op
+
+  def get(key: String)(next: Option[String] => Op): Op    = Get(key, next)
+  def put(key: String, value: String)(next: () => Op): Op = Put(key, value, next)
+  def pure(value: Option[String]): Op                     = Pure(value)
+
+  def interpret(op: Op)(kv: Map[String, String], trace: List[Label], fuel: BigInt): (Option[String], List[Label]) = {
+    require(fuel >= 0)
+    decreases(fuel)
+
+    op match {
+      case Pure(value) =>
+        (value, trace)
+
+      case Get(key, next) if fuel > 0 =>
+        interpret(next(kv.get(key)))(
+          kv,
+          Label.Get(key) :: trace,
+          fuel - 1
+      )
+
+      case Put(key, value, next) if fuel > 0 =>
+        interpret(next())(
+          kv.updated(key, value),
+          Label.Put(key, value) :: trace,
+          fuel - 1
+       )
+
+      case _ =>
+        (None(), trace)
+    }
+  }
+
+  val program = put("foo", "bar") { () =>
+    put("toto", "tata") { () =>
+      get("foo") { foo =>
+        pure(foo)
+      }
+    }
+  }
+
+  @partialEval
+  def result(map: Map[String, String], init: List[Label], fuel: BigInt) = {
+    require(fuel > 10)
+    interpret(program)(map, init, fuel)
+  } ensuring { res => res match {
+    case (res, trace) => prop(res, trace)
+  }}
+
+  @inline
+  def prop(res: Option[String], trace: List[Label]) = {
+    res == Some("bar") &&
+    trace.take(3) == List(
+      Label.Get("foo"),
+      Label.Put("toto", "tata"),
+      Label.Put("foo", "bar")
+    )
+  }
+
+}

--- a/frontends/library/stainless/annotation/package.scala
+++ b/frontends/library/stainless/annotation/package.scala
@@ -13,24 +13,29 @@ package object annotation {
   /** The annotated function or class' methods are not verified
     * by default (use --functions=... to override this). */
   @ignore
-  class library    extends Annotation
+  class library      extends Annotation
 
   /** Apply the "induct" tactic during verification of the annotated function. */
   @ignore
-  class induct     extends Annotation
+  class induct       extends Annotation
 
   /** Only extract the contracts and replace the annotated function's body with a choose. */
   @ignore
-  class extern     extends Annotation
+  class extern       extends Annotation
+
+  /** The annotated function or class method is partially evaluated
+   *  and its body is replaced by the result of the evaluation. */
+  @ignore
+  class partialEval  extends Annotation
 
   /** Don't unfold the function's body during verification. */
   @ignore
-  class opaque     extends Annotation
+  class opaque       extends Annotation
 
   /** Inline this function, but only once.
     * This might be useful if one wants to eg. inline a recursive function.
     * Note: A recursive function will not be inlined within itself. */
   @ignore
-  class inlineOnce extends Annotation
+  class inlineOnce   extends Annotation
 }
 

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -30,6 +30,7 @@ trait VerificationSuite extends ComponentTestSuite {
     case "verification/valid/IntSetInv" => WithContext(ctx.withOpts(inox.solvers.optAssumeChecked(false)))
     case "verification/valid/IntSetUnit" => WithContext(ctx.withOpts(inox.solvers.optAssumeChecked(false)))
 
+    case "verification/invalid/PartialSplit" => Ignore // too slow/memory hungry for now
     case _ => super.filter(ctx, name)
   }
 
@@ -99,6 +100,10 @@ class SMTCVC4VerificationSuite extends VerificationSuite {
     // These tests are too slow on CVC4 and make the regression unstable
     case "verification/valid/ConcRope" => Ignore
     case "verification/invalid/BadConcRope" => Ignore
+
+    // These tests make CVC4 crash
+    case "verification/valid/PartialCompiler" => Ignore
+    case "verification/valid/PartialKVTrace" => Ignore
     case _ => super.filter(ctx, name)
   }
 }


### PR DESCRIPTION
**Note:** This is a work-in-progress, as the test suite currently fails in quite a few places.

The partial evaluator can be triggered in two ways:

- By adding a `@partialEval` to a function, whose body is then going to be replaced by its partially evaluated version.
- By setting the `--partial-eval` flag when invoking Stainless, which instructs it to partially evaluate verification conditions before they are submitted to Inox.

A `partial-eval` debug section is also included, which can be enabled with the `--debug=partial-eval` flag.