### PR TITLE
Create one post-condition per path in the function and use assertions to prove post-conditions

### DIFF
--- a/frontends/common/src/test/scala/stainless/verification/InliningSuite.scala
+++ b/frontends/common/src/test/scala/stainless/verification/InliningSuite.scala
@@ -57,6 +57,6 @@ class InliningSuite extends FunSuite with InputUtils {
   test("Precondition of inlined functions should be checked") {
     val fun2 = program.lookup[FunDef]("Test.fun2")
     val vcs = VerificationGenerator.gen(program, ctx)(Seq(fun2.id))
-    assert(vcs.size == 3)
+    assert(vcs.size == 4)
   }
 }


### PR DESCRIPTION
This PR adds two features:
1) Multiple post-condition VCs are created for one function, one per path of the function. This is done thanks to the `ensuring` function, which perhaps needs to be extended to other expressions of the language.
2) Assertions that are along a path are kept when generating VCs for post-conditions, thanks to the call to `CollectorWithPC`.

