### PR TITLE
Cleanup leftover `old` nodes

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
@@ -44,6 +44,9 @@ trait ImperativeCleanup extends inox.ast.SymbolTransformer { self =>
               t.Let(r, transform(rhs),
                 recons(l.toVariable, r.toVariable)).copiedFrom(expr)).copiedFrom(expr)
 
+          // Cleanup leftover `old` nodes if they were used on a reference which is not actually mutated.
+          case s.Old(e) => transform(e)
+
           case _ => super.transform(expr)
         }
 

--- a/frontends/benchmarks/imperative/valid/NoMutation.scala
+++ b/frontends/benchmarks/imperative/valid/NoMutation.scala
@@ -1,0 +1,13 @@
+import stainless.lang._
+
+object test {
+  case class Test(var value: Int)
+
+  def stuff(x: Test): Unit = ()
+
+  def test(x: Test) = {
+    stuff(x)
+    x.value
+  } ensuring { _ == old(x).value }
+
+}


### PR DESCRIPTION
Some `old` nodes are left behind after `ImperativeCodeElimination`
when they are used over a reference that is not mutated.

Close #215.