### PR TITLE
Infer precondition of partial functions yielded by inexhaustive pattern matches

### DIFF
--- a/core/src/main/scala/stainless/extraction/PartialFunctions.scala
+++ b/core/src/main/scala/stainless/extraction/PartialFunctions.scala
@@ -24,15 +24,21 @@ object PartialFunctions extends inox.ast.SymbolTransformer {
         val (pre, body) = fun match {
           case Lambda(vds, body0) =>
             val (preOpt, bareBody) = body0 match {
+              // Call to another function: Lift the function's definition
               case fi2: FunctionInvocation =>
                 (exprOps.preconditionOf(fi2.inlined(symbols)), fi2)
+
+              // scala.PartialFunction: Infer pattern match condition
+              case m: MatchExpr =>
+                (inferPrecondition(m), m)
+
               case _ =>
                 (exprOps.preconditionOf(body0), exprOps.withPrecondition(body0, None))
             }
 
             val modifiedBody = preOpt match {
               case None => bareBody
-              case Some(pre) => Assume(pre, bareBody)
+              case Some(pre) => Assume(pre, bareBody).setPos(bareBody)
             }
 
             val (vd, funArgs) = vds match {
@@ -44,8 +50,8 @@ object PartialFunctions extends inox.ast.SymbolTransformer {
             }
 
             val subst = (vds zip funArgs).toMap
-            val pre = Lambda(Seq(vd), exprOps.replaceFromSymbols(subst, preOpt getOrElse BooleanLiteral(true)))
-            val body = Lambda(Seq(vd), exprOps.replaceFromSymbols(subst, modifiedBody))
+            val pre = Lambda(Seq(vd), exprOps.replaceFromSymbols(subst, preOpt getOrElse BooleanLiteral(true))).setPos(fi)
+            val body = Lambda(Seq(vd), exprOps.replaceFromSymbols(subst, modifiedBody)).setPos(modifiedBody)
             (pre, body)
 
           case x =>
@@ -55,9 +61,31 @@ object PartialFunctions extends inox.ast.SymbolTransformer {
               "unapply syntactic sugar for partial function creation.")
         }
 
-        ClassConstructor(ct, Seq(pre, body))
+        ClassConstructor(ct, Seq(pre, body)).setPos(fi)
 
       case other => other
     }
+
+    /** Infer the partial function's precondition, by replacing every
+     *  right-hand side of the pattern match with `true`.
+     *  If there is only a single case, and it is a wildcard,
+     *  we don't need to infer any precondition.
+     */
+    def inferPrecondition(body: MatchExpr): Option[Expr] = {
+      val MatchExpr(scrut, cases) = body
+      val rewrittenCases = cases map { c =>
+        c.copy(rhs = BooleanLiteral(true).copiedFrom(c))
+      }
+
+      rewrittenCases match {
+        case Seq(MatchCase(_: WildcardPattern, None, _)) =>
+          None
+
+        case cases =>
+          val fallback = MatchCase(WildcardPattern(None), None, BooleanLiteral(false)).copiedFrom(body)
+          Some(MatchExpr(scrut, cases :+ fallback).copiedFrom(body))
+      }
+    }
+
   })
 }

--- a/frontends/benchmarks/verification/valid/TestPartialFunction3.scala
+++ b/frontends/benchmarks/verification/valid/TestPartialFunction3.scala
@@ -1,0 +1,47 @@
+
+import stainless.lang._
+
+object partialfunctionext {
+
+  def test1 = PartialFunction[Option[String], Int] {
+    case Some(str) => 42
+  }
+
+  def test2 = PartialFunction[Option[String], Int] {
+    case Some(str) => 42
+    case None() => 0
+  }
+
+  def test3 = PartialFunction[Option[String], Int] {
+    case _ => 42
+  }
+
+  def foo(y: BigInt): Boolean = {
+    require(y != 0)
+
+    val f = PartialFunction[BigInt, BigInt] {
+      case x if x != 0 => (2 * x) / x
+    }
+
+    assert(!f.pre(0))
+    assert(f.pre(1))
+    f(y) == 2
+  }.holds
+
+  def bar(pf: BigInt ~> BigInt, y: BigInt): BigInt = {
+    require(pf.pre(y))
+    pf(y)
+  }
+
+  def baz(y: BigInt): Boolean = {
+    require(y > 0)
+
+    val res = bar(PartialFunction[BigInt, BigInt] {
+      case n if n > 0 => n
+      case n if n == 0 => n + 1
+    }, y)
+
+    res > 0
+  }.holds
+
+}

--- a/frontends/library/stainless/lang/PartialFunction.scala
+++ b/frontends/library/stainless/lang/PartialFunction.scala
@@ -13,7 +13,7 @@ import annotation._
  * cannot be expressed in Stainless.)
  */
 @library
-case class ~>[A,B] private[stainless] (pre: A => Boolean, private val f: A => B) {
+case class ~>[A, B] private[stainless](pre: A => Boolean, private val f: A => B) {
   def apply(a: A): B = {
     require(pre(a))
     f(a)
@@ -21,7 +21,7 @@ case class ~>[A,B] private[stainless] (pre: A => Boolean, private val f: A => B)
 }
 
 @library
-case class ~>>[A,B](private val f: A ~> B, post: B => Boolean) {
+case class ~>>[A, B](private val f: A ~> B, post: B => Boolean) {
   require(forall((x: A) => pre(x) ==> post(f(x))))
 
   val pre = f.pre
@@ -48,18 +48,19 @@ object PartialFunction {
    *    )
    */
   @extern
-  def apply[A,B](f: A => B): A ~> B = {
+  def apply[A, B](f: A => B): A ~> B = {
     ~>(x => scala.util.Try(f(x)).isSuccess, f)
   }
 
   @extern
-  def apply[A,B,C](f: (A,B) => C): (A,B) ~> C = {
+  def apply[A, B, C](f: (A, B) => C): (A, B) ~> C = {
     ~>(p => scala.util.Try(f.tupled(p)).isSuccess, f.tupled)
   }
 
   @extern
-  def apply[A,B,C,D](f: (A,B,C) => D): (A,B,C) ~> D = {
+  def apply[A, B, C, D](f: (A, B, C) => D): (A, B, C) ~> D = {
     ~>(p => scala.util.Try(f.tupled(p)).isSuccess, f.tupled)
   }
+
 }
 

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -93,6 +93,7 @@ class SMTCVC4VerificationSuite extends VerificationSuite {
     // Requires non-linear resonning, unsupported by CVC4
     case "verification/valid/Overrides" => Ignore
     case "verification/valid/TestPartialFunction" => Ignore
+    case "verification/valid/TestPartialFunction3" => Ignore
     case "verification/invalid/Existentials" => Ignore
     // These tests are too slow on CVC4 and make the regression unstable
     case "verification/valid/ConcRope" => Ignore


### PR DESCRIPTION
eg.

```scala
def test1 = PartialFunction[Option[String], Int] {
  case Some(str) => 42
}
```

gets precondition:

```scala
x$ match {
  case Some(str) => true
  case _ => false
}
```
