### PR TITLE
Turn body of `holds` expressions into postcondition

### DIFF
--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -561,6 +561,20 @@ trait ASTExtractors {
     }
 
     object ExHolds {
+      def unapply(tree: tpd.Tree): Option[(tpd.Tree, Option[tpd.Tree])] = tree match {
+        case ExHoldsOnly(body, Apply(ExSymbol("stainless", "lang", "package$", "because"), Seq(proof))) =>
+          Some((body, Some(proof)))
+        case ExHoldsOnly(body, proof) =>
+          Some((body, Some(proof)))
+        case ExHoldsOnly(body) =>
+          Some((body, None))
+        case ExBecause(ExHoldsOnly(body), proof) =>
+          Some((body, Some(proof)))
+        case _ => None
+      }
+    }
+
+    object ExHoldsOnly {
       def unapplySeq(tree: tpd.Tree): Option[Seq[tpd.Tree]] = tree match {
         case ExCall(Some(rec),
           ExSymbol("stainless", "lang", "package$", "BooleanDecorations", "holds"),

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -206,8 +206,18 @@ trait ASTExtractors {
       }
     }
 
-    /** Matches the `holds` expression at the end of any boolean expression, and returns the boolean expression.*/
+    /** Matches any of the three types of `holds` expression at the end of any boolean expression */
     object ExHoldsExpression {
+      def unapply(tree: Tree): Option[(Tree, Option[Tree])] = tree match {
+        case ExHoldsExpressionOnly(body) => Some((body, None))
+        case ExHoldsWithProofExpression(body, ExMaybeBecauseExpressionWrapper(proof)) => Some((body, Some(proof)))
+        case ExBecauseExpression(ExHoldsExpressionOnly(body), proof) => Some((body, Some(proof)))
+        case _ => None
+       }
+    }
+
+    /** Matches the `holds` expression at the end of any boolean expression, and returns the boolean expression.*/
+    object ExHoldsExpressionOnly {
       def unapply(tree: Select) : Option[Tree] = tree match {
         case Select(
           Apply(ExSelected("stainless", "lang", "package", "BooleanDecorations"), realExpr :: Nil),


### PR DESCRIPTION
As per this commit, the following program

```scala
def foo(x: Int): Boolean = {
  require(x >= 0)
  x == 0 || x > 0
}.holds

def bar(x: Int): Boolean = {
  require(x >= 0)
  x == 0 || x > 0
}.holds because { x != -1 }

def baz(x: Int): Boolean = {
  require(x >= 0)
  x == 0 || x > 0
}.holds(x != -1)
```

gets extracted into

```scala
def foo(x: Int): Boolean = {
  require(x >= 0)
  true
} ensuring { _ => x == 0 || x > 0 }

def bar(x: Int): Boolean = {
  require(x >= 0)
  x != 1
} ensuring { proof => proof && (x == 0 || x > 0) }

def baz(x: Int): Boolean = {
  require(x >= 0)
  x != 1
} ensuring { proof => proof && (x == 0 || x > 0) }
```