### PR TITLE
Replace reference to case object with a call to a constructor function

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/Definitions.scala
+++ b/core/src/main/scala/stainless/extraction/oo/Definitions.scala
@@ -175,6 +175,7 @@ trait Definitions extends imperative.Trees { self: Trees =>
   case object IsInvariant extends Flag("invariant", Seq.empty)
   case object IsAbstract extends Flag("abstract", Seq.empty)
   case object IsSealed extends Flag("sealed", Seq.empty)
+  case object IsCaseObject extends Flag("caseObject", Seq.empty)
   case class Bounds(lo: Type, hi: Type) extends Flag("bounds", Seq(lo, hi))
   case class Variance(variance: Boolean) extends Flag("variance", Seq.empty)
 

--- a/core/src/main/scala/stainless/extraction/oo/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/oo/Trees.scala
@@ -331,6 +331,7 @@ trait TreeDeconstructor extends holes.TreeDeconstructor {
   }
 
   override def deconstruct(f: s.Flag): DeconstructedFlag = f match {
+    case s.IsCaseObject => (Seq(), Seq(), Seq(), (_, _, _) => t.IsCaseObject)
     case s.IsInvariant => (Seq(), Seq(), Seq(), (_, _, _) => t.IsInvariant)
     case s.IsAbstract => (Seq(), Seq(), Seq() ,(_, _, _) => t.IsAbstract)
     case s.IsSealed => (Seq(), Seq(), Seq(), (_, _, _) => t.IsSealed)

--- a/frontends/benchmarks/verification/invalid/ObjectInvariant.scala
+++ b/frontends/benchmarks/verification/invalid/ObjectInvariant.scala
@@ -1,0 +1,25 @@
+
+object hello {
+
+  abstract class Foo {
+    require(foo != 0)
+    def foo: BigInt
+  }
+
+  case class Hello() extends Foo {
+    def foo = 0
+  }
+
+  case object invalid extends Foo {
+    def foo = 0
+  }
+
+  case object valid extends Foo {
+    def foo = 42
+  }
+
+  def testMethodAccess = {
+    valid.foo
+  }
+
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -238,7 +238,8 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     val annots = annotationsOf(sym)
     val flags = annots ++
       (if ((sym is Abstract) || (sym is Trait)) Some(xt.IsAbstract) else None) ++
-      (if (sym is Sealed) Some(xt.IsSealed) else None)
+      (if (sym is Sealed) Some(xt.IsSealed) else None) ++
+      (if ((sym is ModuleClass) && (sym is Case)) Some(xt.IsCaseObject) else None)
 
     val template = td.rhs.asInstanceOf[tpd.Template]
 

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1095,11 +1095,16 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
       else                xt.BVWideningCast(extractTree(expr), newType)
 
     case ExCall(rec, sym, tps, args) => rec match {
-      // Case object local values are treated differently by dotty (same as scalac) for some
+      // Case object fields and methods are treated differently by dotty (same as scalac) for some
       // reason so we need a special extractor here.
-      case None if (sym.owner is ModuleClass) && (sym.owner is Case) && tps.isEmpty && args.isEmpty =>
+      case None if (sym.owner is ModuleClass) && (sym.owner is Case) =>
         val ct = extractType(sym.owner.thisType)(dctx, tr.pos).asInstanceOf[xt.ClassType]
-        xt.MethodInvocation(xt.This(ct).setPos(tr.pos), getIdentifier(sym), Seq(), Seq())
+        xt.MethodInvocation(
+          xt.ClassConstructor(ct, Seq()).setPos(tr.pos),
+          getIdentifier(sym),
+          tps map extractType,
+          args map extractTree
+        )
 
       case None =>
         dctx.localFuns.get(sym) match {

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -272,7 +272,8 @@ trait CodeExtraction extends ASTExtractors {
     val annots = annotationsOf(sym)
     val flags = annots ++
       (if (sym.isAbstractClass) Some(xt.IsAbstract) else None) ++
-      (if (sym.isSealed) Some(xt.IsSealed) else None)
+      (if (sym.isSealed) Some(xt.IsSealed) else None) ++
+      (if (sym.tpe.typeSymbol.isModuleClass && sym.isCase) Some(xt.IsCaseObject) else None)
 
     val tparamsSyms = sym.tpe match {
       case TypeRef(_, _, tps) => typeParamSymbols(tps)


### PR DESCRIPTION
This enables us to check the ADT invariant for case objects even if no one ever directly references the case object. Previously, this was not the case and could thus potentially lead to runtime errors.

Because the "constructor function" is marked with `@inline`, it will disappear in the resulting program.

This PR also fixes #239.