### PR TITLE
Check model for invalid ADT invariants in a more careful way

### DIFF
--- a/core/src/main/scala/stainless/verification/DefaultTactic.scala
+++ b/core/src/main/scala/stainless/verification/DefaultTactic.scala
@@ -97,8 +97,9 @@ trait DefaultTactic extends Tactic {
         }
 
       case (a @ ADT(aid, tps, args), path) if a.getConstructor.sort.hasInvariant =>
-        val condition = path implies FunctionInvocation(a.getConstructor.sort.invariant.get.id, tps, Seq(a))
-        VC(condition, id, VCKind.AdtInvariant, false).setPos(a)
+        val invId = a.getConstructor.sort.invariant.get.id
+        val condition = path implies FunctionInvocation(invId, tps, Seq(a))
+        VC(condition, id, VCKind.AdtInvariant(invId), false).setPos(a)
     }(getFunction(id).fullBody)
 
     val invariantSat = sorts.values.find(_.invariant.exists(_.id == id)).map { sort =>

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -3,10 +3,12 @@
 package stainless
 package verification
 
+import inox.Options
 import inox.solvers._
 
 import scala.util.{ Success, Failure }
 import scala.concurrent.Future
+import scala.collection.mutable
 
 object optFailEarly extends inox.FlagOptionDef("fail-early", false)
 object optFailInvalid extends inox.FlagOptionDef("fail-invalid", false)
@@ -17,6 +19,7 @@ object DebugSectionVerification extends inox.DebugSection("verification")
 trait VerificationChecker { self =>
   val program: Program
   val context: inox.Context
+  val semantics: program.Semantics
 
   import context._
   import program._
@@ -25,6 +28,7 @@ trait VerificationChecker { self =>
 
   private lazy val failEarly = options.findOptionOrDefault(optFailEarly)
   private lazy val failInvalid = options.findOptionOrDefault(optFailInvalid)
+  private lazy val checkModels = options.findOptionOrDefault(optCheckModels)
 
   implicit val debugSection = DebugSectionVerification
 
@@ -36,9 +40,27 @@ trait VerificationChecker { self =>
   type VCResult = verification.VCResult[program.Model]
   val VCResult = verification.VCResult
 
-  protected def getFactory: SolverFactory {
+  type TimeoutSolverFactory = SolverFactory {
     val program: self.program.type
     type S <: inox.solvers.combinators.TimeoutSolver { val program: self.program.type }
+  }
+
+  lazy val evaluator = semantics.getEvaluator(context)
+
+  protected def createFactory(opts: Options): TimeoutSolverFactory
+
+  protected val factoryCache: mutable.Map[Options, TimeoutSolverFactory] = mutable.Map()
+  protected def getFactory(opts: inox.Options = options): TimeoutSolverFactory = {
+    factoryCache.getOrElseUpdate(opts, opts.findOption(inox.optTimeout) match {
+      case Some(to) => createFactory(opts).withTimeout(to)
+      case None => createFactory(opts)
+    })
+  }
+
+  /** @see [[checkAdtInvariantModel]] */
+  protected def getFactoryForVC(vc: VC): TimeoutSolverFactory = vc.kind match {
+    case _: VCKind.AdtInvariant => getFactory(Options(Seq(optCheckModels(false))))
+    case _ => getFactory()
   }
 
   protected def defaultStop(res: VCResult): Boolean = {
@@ -48,24 +70,17 @@ trait VerificationChecker { self =>
   }
 
   def verify(vcs: Seq[VC], stopWhen: VCResult => Boolean = defaultStop): Future[Map[VC, VCResult]] = {
-    val sf = options.findOption(inox.optTimeout) match {
-      case Some(to) => getFactory.withTimeout(to)
-      case None => getFactory
-    }
-
     try {
       reporter.debug("Checking Verification Conditions...")
-      checkVCs(vcs, sf, stopWhen)
+      checkVCs(vcs, stopWhen)
     } finally {
-      sf.shutdown()
+      factoryCache.values.foreach(_.shutdown())
     }
   }
 
   private lazy val unknownResult: VCResult = VCResult(VCStatus.Unknown, None, None)
 
-  def checkVCs(vcs: Seq[VC],
-               sf: SolverFactory { val program: self.program.type },
-               stopWhen: VCResult => Boolean = defaultStop): Future[Map[VC, VCResult]] = {
+  def checkVCs(vcs: Seq[VC], stopWhen: VCResult => Boolean = defaultStop): Future[Map[VC, VCResult]] = {
     @volatile var stop = false
 
     val initMap: Map[VC, VCResult] = vcs.map(vc => vc -> unknownResult).toMap
@@ -73,6 +88,7 @@ trait VerificationChecker { self =>
     import MainHelpers._
     val results = Future.traverse(vcs)(vc => Future {
       if (stop) None else {
+        val sf = getFactoryForVC(vc)
         val res = checkVC(vc, sf)
 
         val shouldStop = stopWhen(res)
@@ -89,6 +105,75 @@ trait VerificationChecker { self =>
     }).map(_.flatten)
 
     results.map(initMap ++ _)
+  }
+
+  /** Check whether the model for the ADT invariant specified by the given (invalid) VC is
+   *  valid, ie. whether evalutating the invariant with the given model actually returns `false`.
+   *
+   *  One needs to be careful, because simply evaluating the invariant over the model
+   *  returned by Inox fails with a 'adt invariant' violation. While this is expected,
+   *  we cannot know whether it was the invariant that we are interested in at this point
+   *  or some other invariant that failed.
+   *
+   *  Instead, we need to put the constructed ADT value in the model when evaluating the
+   *  condition, in order for the evaluator to not attempt to re-construct it.
+   *
+   *  As such, we instead need to:
+   *  - evaluate the ADT's arguments to figure out whether those are valid.
+   *  - rebuild the ADT over its evaluated arguments, and add it to the model under a fresh name.
+   *  - rewrite the invariant's invocation to be applied to this new variable instead.
+   *  - evaluate the resulting condition under the new model.
+   */
+  protected def checkAdtInvariantModel(vc: VC, invId: Identifier, model: Model): VCStatus = {
+    import inox.evaluators.EvaluationResults._
+
+    val evaledModelVars = model.vars.mapValues(v => evaluator.eval(v))
+    val failed = evaledModelVars.values.find(_.result.isEmpty)
+    failed foreach {
+      case RuntimeError(msg) =>
+        reporter.warning(s"- Argument to ADT constructor leads to runtime error: $msg")
+      case EvaluatorError(msg) =>
+        reporter.warning(s"- Argument to ADT constructor leads to evaluation error: $msg")
+      case _ =>
+        reporter.internalError(s"Expected evaluation of argument to have failed")
+    }
+
+    if (failed.isDefined) return VCStatus.Unknown
+
+    val invs = exprOps.collect[FunctionInvocation] {
+      case fi: FunctionInvocation if fi.id == invId => Set(fi)
+      case _ => Set()
+    } (vc.condition)
+
+    val inv @ FunctionInvocation(`invId`, invTps, Seq(adt @ ADT(adtId, tps, args))) = invs.head
+
+    val evaledArgs = evaledModelVars.mapValues(_.result.get)
+    val newArgs = args map (arg => exprOps.replaceFromSymbols(evaledArgs, arg))
+
+    val newAdt = ADT(adtId, tps, newArgs)
+
+    val adtVar = Variable(FreshIdentifier("adt"), adt.getType(symbols), Seq())
+    val newInv = FunctionInvocation(invId, invTps, Seq(adtVar))
+    val newModel = inox.Model(program, context)(model.vars + (adtVar.toVal -> newAdt), model.chooses)
+    val newCondition = exprOps.replace(Map(inv -> newInv), vc.condition)
+
+    evaluator.eval(newCondition, newModel) match {
+      case Successful(BooleanLiteral(false)) =>
+        reporter.debug("- Model validated.")
+        VCStatus.Invalid(VCStatus.CounterExample(model))
+
+      case Successful(_) =>
+        reporter.debug("- Invalid model.")
+        VCStatus.Unknown
+
+      case RuntimeError(msg) =>
+        reporter.warning(s"- Model leads to runtime error: $msg")
+        VCStatus.Unknown
+
+      case EvaluatorError(msg) =>
+        reporter.warning(s"- Model leads to evaluation error: $msg")
+        VCStatus.Unknown
+    }
   }
 
   protected def checkVC(vc: VC, sf: SolverFactory { val program: self.program.type }): VCResult = {
@@ -129,6 +214,11 @@ trait VerificationChecker { self =>
 
           case Unsat if !vc.satisfiability =>
             VCResult(VCStatus.Valid, s.getResultSolver, Some(time))
+
+          case SatWithModel(model) if checkModels && vc.kind.isInstanceOf[VCKind.AdtInvariant] =>
+            val VCKind.AdtInvariant(invId) = vc.kind
+            val status = checkAdtInvariantModel(vc, invId, model)
+            VCResult(status, s.getResultSolver, Some(time))
 
           case SatWithModel(model) if !vc.satisfiability =>
             VCResult(VCStatus.Invalid(VCStatus.CounterExample(model)), s.getResultSolver, Some(time))
@@ -183,8 +273,9 @@ object VerificationChecker {
     class Checker extends VerificationChecker {
       val program: p.type = p
       val context = ctx
+      val semantics = program.getSemantics
 
-      protected def getFactory = solvers.SolverFactory(p, ctx)
+      protected def createFactory(opts: Options) = solvers.SolverFactory(p, ctx.withOpts(opts.options: _*))
     }
 
     val checker = if (ctx.options.findOptionOrDefault(optVCCache)) {

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -33,9 +33,9 @@ object VCKind {
   case object CastError       extends VCKind("cast correctness", "cast")
   case object PostTactic      extends VCKind("postcondition tactic", "tact.")
   case object Choose          extends VCKind("choose satisfiability", "choose")
-  case object AdtInvariant    extends VCKind("adt invariant", "adt inv.")
   case object InvariantSat    extends VCKind("invariant satisfiability", "inv. sat")
-  case class  AssertErr(err: String)  extends VCKind("body assertion: " + err, "assert.")
+  case class  AdtInvariant(inv: Identifier) extends VCKind("adt invariant", "adt inv.")
+  case class  AssertErr(err: String) extends VCKind("body assertion: " + err, "assert.")
 }
 
 sealed abstract class VCStatus[+Model](val name: String) {

--- a/frontends/benchmarks/verification/invalid/ADTInvariantCheck.scala
+++ b/frontends/benchmarks/verification/invalid/ADTInvariantCheck.scala
@@ -1,0 +1,32 @@
+import stainless.lang._
+
+object ADTInvariantCheck {
+
+  case class Foo(x: BigInt) {
+    require(x != 0)
+  }
+
+  def fooFailed1(x: BigInt) = Foo(x)
+  def fooFailed2 = Foo(0)
+  def fooFailed3(x: BigInt) = {
+    require(x <= 0)
+    if (x < 10) Foo(x) else Foo(x - 10)
+  }
+
+  def fooOk1 = Foo(1)
+  def fooOk2(x: BigInt) = {
+    require(x > 0)
+    Foo(x)
+  }
+
+  case class Bar(arg1: BigInt, arg2: Option[BigInt]) {
+    require(arg1 > 0 || arg2.isDefined)
+  }
+
+  def barFailed1: Bar = Bar(-1, None())
+
+  def barOk1: Bar = Bar(-1, Some(1))
+  def barOk2: Bar = Bar(12, None())
+
+}
+


### PR DESCRIPTION
Previously, the following testcase would correctly report an
invalid ADT invariant for `fail` without `--check-models`,
but when setting the latter option, it would be reported as
unknown because the model would to a runtime error,
ie. `Model leads to runtime error: ADT invariant violation for Foo(0)`.

```scala
object test {
  case class Foo(x: BigInt) {
    require(x != 0)
  }

  def fail = Foo(0)
}
```

Fixes #237