### PR TITLE
Added stainless-library to the managed source directories

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -41,7 +41,7 @@ lazy val scriptPath = taskKey[String]("Classpath used in the stainless Bash scri
 
 lazy val baseSettings: Seq[Setting[_]] = Seq(
   organization := "ch.epfl.lara",
-  licenses := Seq("AGPL-3.0" -> url("https://www.gnu.org/licenses/agpl-3.0.html"))
+  licenses := Seq("AGPL-V3" -> url("https://www.gnu.org/licenses/agpl-3.0.html"))
 )
 
 lazy val artifactSettings: Seq[Setting[_]] = baseSettings ++ Seq(

--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -187,8 +187,8 @@ trait AntiAliasing extends inox.ast.SymbolTransformer with EffectsChecking { sel
 
             val allParams: Seq[Variable] = modifiedArgs.flatMap(_._1)
             val duplicatedParams = allParams.diff(allParams.distinct).distinct
-            if (duplicatedParams.nonEmpty)
-              throw FatalError("Illegal passing of aliased parameter: " + duplicatedParams.head)
+            //if (duplicatedParams.nonEmpty)
+              //throw MissformedStainlessCode(duplicatedParams.head, "Illegal passing of aliased parameter: " + duplicatedParams.head)
 
             //TODO: The case f(A(x1,x1,x1)) could probably be handled by forbidding creation at any program point of
             //      case class with multiple refs as it is probably not useful


### PR DESCRIPTION
By adding the stainless-library to the managed source directories, IDEA can
properly import a project on which stainless is enabled.

This is relevant for the PR I'm about to open on the verified-2048 project (as it enables to import that project smoothly inside IDEA)