### PR TITLE
Assume `@extern` functions mutate their arguments

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -14,6 +14,7 @@ trait EffectsChecker { self: EffectsAnalyzer =>
     def check(fd: FunAbstraction, vds: Set[ValDef]): Unit = {
       checkMutableField(fd)
       checkEffectsLocations(fd)
+      checkPurity(fd)
 
       val bindings = vds ++ fd.params
       exprOps.withoutSpecs(fd.fullBody).foreach { bd =>
@@ -133,6 +134,11 @@ trait EffectsChecker { self: EffectsAnalyzer =>
 
       case _ => ()
     }(fd.fullBody)
+
+    def checkPurity(fd: FunAbstraction): Unit = {
+      if (fd.flags.exists(_.name == "pure") && !effects(fd.fullBody).isEmpty)
+        throw ImperativeEliminationException(fd, s"Function marked @pure cannot have side-effects")
+    }
 
     /* A fresh expression is an expression that is newly created
      * and does not share memory with existing values and variables.

--- a/core/src/main/scala/stainless/extraction/innerfuns/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/innerfuns/Trees.scala
@@ -146,7 +146,7 @@ trait Printer extends inlining.Printer {
   override protected def ppBody(tree: Tree)(implicit ctx: PrinterContext): Unit = tree match {
     case LetRec(defs, body) =>
       defs foreach { case (LocalFunDef(name, tparams, Lambda(args, body))) =>
-        for (f <- name.flags) p"""|${f.asString(ctx.opts)}
+        for (f <- name.flags) p"""|@${f.asString(ctx.opts)}
                                   |"""
         p"def ${name.id}${nary(tparams, ", ", "[", "]")}"
         if (args.nonEmpty) p"(${args})"

--- a/core/src/sphinx/library.rst
+++ b/core/src/sphinx/library.rst
@@ -78,6 +78,10 @@ which instruct Stainless to handle some functions or objects in a specialized wa
 | ``@extern``       | Only extract the contracts of a function, replacing            |
 |                   | its body by a ``choose`` expression.                           |
 +-------------------+----------------------------------------------------------------+
+| ``@pure``         | Specify that this function is pure, which will then            |
+|                   | be checked. If the function is also annotated with             |
+|                   | ``@extern``, it will not be checked, but assumed pure.         |
++-------------------+----------------------------------------------------------------+
 | ``@partialEval``  | Partially evaluate calls to this function.                     |
 |                   | Note: ``stainless.lang.partialEval`` can also be used to       |
 |                   | partially evaluate an expression.                              |

--- a/frontends/benchmarks/extraction/invalid/Purity.scala
+++ b/frontends/benchmarks/extraction/invalid/Purity.scala
@@ -1,0 +1,30 @@
+import stainless.annotation._
+
+object test {
+
+  case class Test(var abc: Int) {
+
+    @pure
+    def ok1(x: Int): Int = x
+
+    // @pure
+    def bad(x: Int): Int = {
+      abc = abc + x
+      x
+    }
+  }
+
+  @pure
+  def hello = {
+    var test: Int = 1
+
+    @pure
+    def world = {
+      test = test + 1
+      test
+    }
+
+    test
+  }
+
+}

--- a/frontends/benchmarks/verification/invalid/ExternMut.scala
+++ b/frontends/benchmarks/verification/invalid/ExternMut.scala
@@ -1,0 +1,29 @@
+
+import stainless.lang._
+import stainless.annotation._
+
+object ExternMut {
+
+  case class Box(var value: BigInt)
+
+  @extern
+  def mutateStuff(box: Box, n: BigInt): Unit = {
+    box.value = box.value * n
+  }
+
+  @extern @pure
+  def dontMutateStuff(box: Box, n: BigInt): Unit = ()
+
+  def isSameImpure = {
+    val box = Box(123)
+    mutateStuff(box, 2)
+    box.value == 123
+  }.holds // invalid
+
+  def isSamePure = {
+    val box = Box(123)
+    dontMutateStuff(box, 2)
+    box.value == 123
+  }.holds // valid
+
+}

--- a/frontends/library/stainless/annotation/package.scala
+++ b/frontends/library/stainless/annotation/package.scala
@@ -27,6 +27,10 @@ package object annotation {
   @ignore
   class opaque       extends Annotation
 
+  /** Specify that the annotated function is pure, which will be checked. */
+  @ignore
+  class pure         extends Annotation
+
   /** Inline this function, but only once.
     * This might be useful if one wants to eg. inline a recursive function.
     * Note: A recursive function will not be inlined within itself. */


### PR DESCRIPTION
Annotate such a function with `@pure` to assume otherwise.

This PR subsumes #250, and should either be merged instead of #250, or should be rebased on top of it once it gets merged.

Closes #244. Closes #245.