### PR TITLE
Fix documentation links

### DIFF
--- a/core/src/sphinx/gettingstarted.rst
+++ b/core/src/sphinx/gettingstarted.rst
@@ -5,7 +5,9 @@ Getting Started
 
 Stainless is currently only available as a command line tool,
 which exposes most of the functionality. See the
-:doc:`installation documentation <installation>`
+`installation documentation`_.
+
+.. _installation documentation: installation.rst
 for more information.
 
 Stainless compilation will generate two scripts for you, namely
@@ -24,7 +26,9 @@ To see the main options, use
   $ ./stainless --help
 
 in your command line shell while in the top-level Stainless directory.
-You may also wish to consult the :doc:`available command-line options <options>`.
+You may also wish to consult the `available command-line options`_.
+
+.. _available command-line options: options.rst
 
 You can try some of the examples from ``frontends/benchmarks``
 distributed with Stainless:

--- a/core/src/sphinx/imperative.rst
+++ b/core/src/sphinx/imperative.rst
@@ -3,12 +3,14 @@
 Imperative
 ==========
 
-To complement the core :doc:`Pure Scala <purescala>` language, Stainless
+To complement the core `Pure Scala`_ language, Stainless
 proposes a few extensions to that core language.
 
 On the technical side, these extensions do not have specific treatment in the
-back-end of Stainless. Instead, they are desugared into :doc:`Pure Scala <purescala>`
+back-end of Stainless. Instead, they are desugared into `Pure Scala`_
 constructs during a preprocessing phase in the Stainless front-end.
+
+.. _Pure Scala: purescala.rst
 
 Imperative Code
 ---------------

--- a/core/src/sphinx/installation.rst
+++ b/core/src/sphinx/installation.rst
@@ -22,8 +22,7 @@ sbt
 ---
 Setting up a sbt build file to use stainless it's a simple 4-steps procedure:
 
-1. Start by installing an external solver (see Section
-   ":ref:`smt-solvers`").
+1. Start by installing an external solver (see Section `External Solvers`_").
 
 2. Add the ``sbt-stainless`` plugin together with the required resolver to your ``project/plugins.sbt``
 
@@ -115,8 +114,6 @@ Compilation will automatically generate the following two bash scripts:
 1. ``frontends/scalac/target/universal/stage/bin/stainless-scalac.bat`` that will use the ``scalac`` compiler as frontend,
 2. ``frontends/stainless-dotty/target/universal/stage/bin/stainless-dotty.bat`` that uses the ``dotc`` compiler as frontend (experimental).
 
-
-.. _smt-solvers:
 
 External Solvers
 ----------------

--- a/core/src/sphinx/intro.rst
+++ b/core/src/sphinx/intro.rst
@@ -21,7 +21,7 @@ Stainless attempts to strike a delicate balance between the
 convenience of use on the one hand and the simplicity of
 reasoning on the other hand. Stainless supports verification
 of Scala programs by applying a succession of semantic-preserving
-transformations to the :doc:`Pure Scala <purescala>` fragment until
+transformations to the `Pure Scala`_ fragment until
 it fits into the fragment supported by
 `Inox <https://github.com/epfl-lara/inox>`_.
 The Pure Scala fragment is at the core of
@@ -37,7 +37,7 @@ are designed to work well with automated reasoning and Stainless's
 language fragment.
 
 In addition to this pure fragment, Stainless supports certain
-:doc:`imperative <imperative>` features.
+`Imperative`_ features.
 Features thus introduced are handled by
 a translation into Pure Scala concepts. They are often more
 than just syntactic sugar, because some of them require
@@ -49,9 +49,12 @@ e.g. concurrency with a shared mutable heap, though it might
 support more manageable forms of concurrency in the future.
 
 If you would like to use Stainless now, check the
-:doc:`gettingstarted`
-section and try our :doc:`Tutorial <tutorial>`.
+`Getting started`_
+section and try our `Tutorial`_.
 To learn more about the functionality that Stainless provides, read on below.
+
+.. _Getting started: gettingstarted.rst
+.. _Tutorial: tutorial.rst
 
 Software Verification
 ---------------------
@@ -92,7 +95,7 @@ Stainless will also verify for each call site that the precondition of the invok
 function cannot be violated.
 
 Stainless supports verification of a significant part of the Scala language, described in
-:doc:`purescala` and :doc:`imperative`.
+`Pure Scala`_ and `Imperative`_.
 
 Program Termination
 -------------------
@@ -133,3 +136,5 @@ can be shown terminating as follows:
 
 It is also possible to add a pre-condition (``require(...)``) *before* ``decreases``.
 
+.. _Pure Scala: purescala.rst
+.. _Imperative: imperative.rst

--- a/core/src/sphinx/library.rst
+++ b/core/src/sphinx/library.rst
@@ -289,7 +289,9 @@ Methods of these classes are mapped to specialized trees within SMT solvers.
 For code generation, we rely on Java Sets and Maps.
 
 The API of these classes is a subset of the Scala API and can be found
-in the :doc:`purescala` section.
+in the `Pure Scala`_ section.
+
+.. _Pure Scala: purescala.rst
 
 Additionally, the following functions for Sets are provided in the
 ``stainless.collection`` package:

--- a/core/src/sphinx/options.rst
+++ b/core/src/sphinx/options.rst
@@ -22,7 +22,9 @@ By default, ``--verification`` is chosen.
 
 * ``--verification``
 
-  Proves or disproves function contracts, as explained in the :doc:`verification` section.
+  Proves or disproves function contracts, as explained in the `verification`_ section.
+
+  .. _verification: verification.rst
 
 * ``--termination``
 

--- a/core/src/sphinx/tutorial.rst
+++ b/core/src/sphinx/tutorial.rst
@@ -10,8 +10,10 @@ This tutorial shows how to:
   * define lists as algebraic data types
   * use sets and recursive function to specify data structures
 
-See :doc:`gettingstarted` about how to setup the command line
+See `Getting Started`_ about how to setup the command line
 tool.
+
+.. _`Getting Started`: gettingstarted.rst
 
 Warm-up: Max
 ------------
@@ -182,8 +184,10 @@ Defining Lists and Their Properties
 We next consider sorting an unbounded number of elements.
 For this purpose, we define a data structure for lists of
 integers.  Stainless has a built-in data type of parametric
-lists, see :doc:`library`, but here we define
+lists, see `library`_, but here we define
 our own variant instead.
+
+.. _library: library.rst
 
 Lists
 ^^^^^

--- a/core/src/sphinx/verification.rst
+++ b/core/src/sphinx/verification.rst
@@ -9,10 +9,13 @@ specifications as annotations and attempt to prove --- or disprove --- their
 validity.
 
 One of the core modules of Stainless is a verifier for the subset of Scala described
-in the sections :doc:`purescala` and :doc:`imperative`. In this
+in the sections `Pure Scala`_ and `Imperative`_. In this
 section, we describe the specification language that can be used to declare
 properties of programs, as well as the safety properties automatically checked
 by Stainless. We also discuss how Stainless can be used to prove mathematical theorems.
+
+.. _Pure Scala: purescala.rst
+.. _Imperative: imperative.rst
 
 Verification conditions
 -----------------------


### PR DESCRIPTION
Some links in the documentation in `core/src/sphinx/*` were broken and did not follow the `.rst` spec. This pull request aims to fix those links in a consistent manner.