### PR TITLE
[WIP] Extern types

### DIFF
--- a/core/src/main/scala/stainless/extraction/PartialFunctions.scala
+++ b/core/src/main/scala/stainless/extraction/PartialFunctions.scala
@@ -19,7 +19,7 @@ object PartialFunctions extends inox.ast.SymbolTransformer {
     override def transform(e: Expr): Expr = super.transform(e) match {
       case fi @ FunctionInvocation(ast.SymbolIdentifier("stainless.lang.PartialFunction.apply"), _, _) =>
         val FunctionInvocation(_, froms :+ to, Seq(fun)) = fi
-        val ct = ClassType(optPFClass.get.id, Seq(tupleTypeWrap(froms), to))
+        val ct = ClassType(optPFClass.get.id, Seq(tupleTypeWrap(froms), to), Seq())
 
         val (pre, body) = fun match {
           case Lambda(vds, body0) =>

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -116,7 +116,7 @@ trait MethodLifting extends inox.ast.SymbolTransformer { self =>
 
       override def transform(e: s.Expr): t.Expr = e match {
         case s.MethodInvocation(rec, id, tps, args) =>
-          val s.ClassType(_, ctps) = newSymbols.widen(rec.getType(newSymbols))
+          val s.ClassType(_, ctps, _) = newSymbols.widen(rec.getType(newSymbols))
           t.FunctionInvocation(id, (ctps ++ tps) map transform, (rec +: args) map transform).copiedFrom(e)
 
         case _ => super.transform(e)

--- a/core/src/main/scala/stainless/extraction/oo/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/oo/Trees.scala
@@ -83,7 +83,7 @@ trait Trees extends holes.Trees with Definitions { self =>
   }
 
   /** Type associated to instances of [[ClassConstructor]] */
-   case class ClassType(id: Identifier, tps: Seq[Type]) extends Type {
+   case class ClassType(id: Identifier, tps: Seq[Type], flags: Seq[Flag] = Seq.empty) extends Type {
     def lookupClass(implicit s: Symbols): Option[TypedClassDef] = s.lookupClass(id, tps)
     def tcd(implicit s: Symbols): TypedClassDef = s.getClass(id, tps)
 
@@ -177,8 +177,8 @@ trait Printer extends holes.Printer {
         p" extends ${nary(cd.parents, " with ")}"
       }
 
-    case ClassType(id, tps) =>
-      p"${id}${nary(tps, ", ", "[", "]")}"
+    case ClassType(id, tps, flags) =>
+      p"${nary(flags, " ", "", " ")}${id}${nary(tps, ", ", "[", "]")}"
 
     case AnyType() =>
       p"Any"
@@ -271,7 +271,7 @@ trait TreeDeconstructor extends holes.TreeDeconstructor {
   }
 
   override def deconstruct(tpe: s.Type): DeconstructedType = tpe match {
-    case s.ClassType(id, tps) => (Seq(id), tps, Seq(), (ids, tps, _) => t.ClassType(ids.head, tps))
+    case s.ClassType(id, tps, flags) => (Seq(id), tps, flags, (ids, tps, flags) => t.ClassType(ids.head, tps, flags))
     case s.AnyType() => (Seq(), Seq(), Seq(), (_, _, _) => t.AnyType())
     case s.NothingType() => (Seq(), Seq(), Seq(), (_, _, _) => t.NothingType())
     case s.UnionType(tps) => (Seq(), tps, Seq(), (_, tps, _) => t.UnionType(tps))

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -280,7 +280,7 @@ trait TypeEncoding extends inox.ast.SymbolTransformer { self =>
           Map(scope.transform(vd) -> unwrap(nvd.toVariable, scope.transform(vd.tpe))),
           scope.transform(pred))
         ref(t.Lambda(Seq(nvd), t.and(instanceOf(nvd.toVariable, encodeType(vd.tpe)), npred)))
-      case s.ClassType(id, tps) => cls(IntegerLiteral(id.globalId), mkSeq(tps map encodeType))
+      case s.ClassType(id, tps, _) => cls(IntegerLiteral(id.globalId), mkSeq(tps map encodeType))
       case s.ADTType(id, tps) => adt(IntegerLiteral(id.globalId), mkSeq(tps map encodeType))
       case s.ArrayType(base) => arr(encodeType(base))
       case s.SetType(base) => set(encodeType(base))
@@ -758,8 +758,8 @@ trait TypeEncoding extends inox.ast.SymbolTransformer { self =>
           }
 
           override def traverse(tpe: s.Type): Unit = tpe match {
-            case s.ClassType(_, _) => simple = false
-            case s.RefinementType(_, _) => simple = false
+            case _: s.ClassType => simple = false
+            case _: s.RefinementType => simple = false
             case _ => super.traverse(tpe)
           }
 

--- a/core/src/main/scala/stainless/extraction/oo/TypeOps.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeOps.scala
@@ -284,7 +284,7 @@ trait TypeOps extends imperative.TypeOps {
       unificationSolution((tps1 zip tps2).toList ++ tl)
     case (ct: ClassType, _) :: tl if ct.lookupClass.isEmpty => unsolvable
     case (_, ct: ClassType) :: tl if ct.lookupClass.isEmpty => unsolvable
-    case (ClassType(id1, tps1), ClassType(id2, tps2)) :: tl if id1 == id2 =>
+    case (ClassType(id1, tps1, _), ClassType(id2, tps2, _)) :: tl if id1 == id2 =>
       unificationSolution((tps1 zip tps2).toList ++ tl)
     case typeOps.Same(NAryType(ts1, _), NAryType(ts2, _)) :: tl if ts1.size == ts2.size =>
       unificationSolution((ts1 zip ts2).toList ++ tl)
@@ -344,7 +344,7 @@ trait TypeOps extends imperative.TypeOps {
       patternIsTyped(patternInType(pat), pat)
 
     case (_, ClassPattern(ob, ct, subs)) => in match {
-      case ct2 @ ClassType(id, tps) if isSubtypeOf(ct, ct2) =>
+      case ct2 @ ClassType(id, tps, _) if isSubtypeOf(ct, ct2) =>
         lookupClass(ct.id).exists { cls =>
           cls.fields.size == subs.size &&
           cls.tparams.size == ct.tps.size &&
@@ -398,11 +398,11 @@ trait TypeOps extends imperative.TypeOps {
         case IntersectionType(tps) => tps.map(rec(_, variance)).reduceLeft(unify(_, _, !variance))
         case FunctionType(from, to) => FunctionType(from.map(rec(_, !variance)), rec(to, variance))
         case TupleType(tps) => TupleType(tps.map(rec(_, variance)))
-        case ct @ ClassType(id, tps) =>
+        case ct @ ClassType(id, tps, flags) =>
           ClassType(id, (ct.tcd.cd.typeArgs zip tps).map { case (tp, tpe) =>
             if (tp.isContravariant) rec(tpe, !variance)
             else rec(tpe, variance)
-          })
+          }, flags)
         case NAryType(tps, recons) => recons(tps.map(rec(_, variance)))
       })
     }

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -19,7 +19,12 @@ trait InoxEncoder extends ProgramEncoder {
     import sourceProgram.symbols._
 
     inox.InoxProgram(t.NoSymbols
-      .withSorts(sourceProgram.symbols.sorts.values.toSeq.map(encoder.transform))
+      .withSorts(sourceProgram.symbols.sorts.values.toSeq
+        .map(sort => sort.copy(flags = sort.flags.filter {
+          case Extern => false
+          case _ => true
+        }))
+        .map(encoder.transform))
       .withFunctions(sourceProgram.symbols.functions.values.toSeq
         .map(fd => fd.copy(flags = fd.flags.filter {
           case Derived(_) | IsField(_) | Unchecked | IsUnapply(_, _) => false
@@ -166,7 +171,7 @@ trait InoxEncoder extends ProgramEncoder {
       case s.Application(caller, args) =>
         val s.FunctionType(from, to) = caller.getType
         t.Application(transform(caller).copiedFrom(e), args map transform).copiedFrom(e)
-        
+
       case _ => super.transform(e)
     }
 

--- a/core/src/main/scala/stainless/utils/DependenciesFinder.scala
+++ b/core/src/main/scala/stainless/utils/DependenciesFinder.scala
@@ -43,7 +43,7 @@ class DependenciesFinder {
     }
 
     override def traverse(tpe: xt.Type): Unit = tpe match {
-      case xt.ClassType(id, _) =>
+      case xt.ClassType(id, _, flags) if !flags.contains(xt.Extern) =>
         deps += id
         super.traverse(tpe)
 

--- a/frontends/benchmarks/verification/valid/ExternTypes.scala
+++ b/frontends/benchmarks/verification/valid/ExternTypes.scala
@@ -1,0 +1,44 @@
+
+import stainless.lang._
+import stainless.annotation._
+
+import scala.collection.concurrent.TrieMap
+
+object ExternTypes {
+
+  case class TrieMapWrapper[K, V](theMap: TrieMap[K, V] @extern) {
+
+    @extern
+    def contains(k: K): Boolean = {
+      theMap contains k
+    }
+
+    @extern
+    def insert(k: K, v: V): TrieMapWrapper[K, V] = {
+      TrieMapWrapper(theMap += (k -> v))
+    } ensuring { _.contains(k) }
+
+    @extern
+    def apply(k: K): V = {
+      require(contains(k))
+      theMap(k)
+    }
+  }
+
+  object TrieMapWrapper {
+    @extern
+    def empty[K, V]: TrieMapWrapper[K, V] = {
+      TrieMapWrapper(TrieMap.empty[K, V])
+    } ensuring { res =>
+      forall((k: K) => !res.contains(k))
+    }
+  }
+
+  def test = {
+    val wrapper = TrieMapWrapper.empty[BigInt, BigInt]
+    assert(!wrapper.contains(1))
+    assert(wrapper.insert(1, 2).contains(1))
+  }
+
+}
+


### PR DESCRIPTION
> **Warning**: This is just a proof-of-concept for now, as only `ClassType`s can be annotated, and their annotations might very well be lost during the pipeline.

While we can already use `@extern` methods to hide
calls to methods defined by existing Scala libraries
which either make use of Scala features we do not support,
or are provided via the classpath, we currently have no way
of wrapping the types exported by such libraries, because
the registry will complain that such types cannot be found
amongst the symbols.

This palliate to this problem, this PR adds support for annotating
types with the `@extern` annotation, which basically tells the
registry to effectively ignore such types from its dependency graph.

Attached is a simple testcase featuring a wrapper for
`scala.collection.concurrent.TrieMap`.