### PR TITLE
Add debug output of symbols before and after each transformation

### DIFF
--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -40,6 +40,13 @@ object optDebugObjects extends inox.OptionDef[Seq[String]] {
   val usageRhs = "o1,o2,..."
 }
 
+object optDebugPhases extends inox.OptionDef[Seq[String]] {
+  val name = "debug-phases"
+  val default = Seq[String]()
+  val parser = inox.OptionParsers.seqParser(inox.OptionParsers.stringParser)
+  val usageRhs = "p1,p2,..."
+}
+
 trait ComponentRun { self =>
   val component: Component
   val trees: ast.Trees

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -33,6 +33,13 @@ object optFunctions extends inox.OptionDef[Seq[String]] {
   val usageRhs = "f1,f2,..."
 }
 
+object optDebugObjects extends inox.OptionDef[Seq[String]] {
+  val name = "debug-objects"
+  val default = Seq[String]()
+  val parser = inox.OptionParsers.seqParser(inox.OptionParsers.stringParser)
+  val usageRhs = "o1,o2,..."
+}
+
 trait ComponentRun { self =>
   val component: Component
   val trees: ast.Trees

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -23,7 +23,8 @@ trait MainHelpers extends inox.MainHelpers {
   case object Termination extends Category
 
   override protected def getOptions = super.getOptions - inox.solvers.optAssumeChecked ++ Map(
-    optFunctions -> Description(General, "Only consider functions s1,s2,..."),
+    optFunctions -> Description(General, "Only consider functions f1,f2,..."),
+    optDebugObjects -> Description(General, "Only print debug output for functions/adts named o1,o2,..."),
     evaluators.optCodeGen -> Description(Evaluators, "Use code generating evaluator"),
     codegen.optInstrumentFields -> Description(Evaluators, "Instrument ADT field access during code generation"),
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -25,6 +25,7 @@ trait MainHelpers extends inox.MainHelpers {
   override protected def getOptions = super.getOptions - inox.solvers.optAssumeChecked ++ Map(
     optFunctions -> Description(General, "Only consider functions f1,f2,..."),
     optDebugObjects -> Description(General, "Only print debug output for functions/adts named o1,o2,..."),
+    optDebugPhases -> Description(General, "Only print debug output for phases whose name contain p1 or p2 or ..."),
     evaluators.optCodeGen -> Description(Evaluators, "Use code generating evaluator"),
     codegen.optInstrumentFields -> Description(Evaluators, "Instrument ADT field access during code generation"),
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -55,6 +55,7 @@ trait MainHelpers extends inox.MainHelpers {
     verification.DebugSectionPartialEval,
     termination.DebugSectionTermination,
     DebugSectionExtraction,
+    extraction.utils.DebugSectionPositions,
     frontend.DebugSectionFrontend,
     utils.DebugSectionRegistry
   )

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -32,8 +32,8 @@ trait ExtractionPipeline { self =>
           context.reporter.debug(res.asString(t.PrinterOptions.fromContext(context)))
           context.reporter.debug("\n\n")
         }
-      } else {
-        // output only the functions given by --functions=f1,f2,...
+      } else if (symbols.functions.exists { case (id,_) => funs.get.contains(id.name) }) {
+        // output only the functions given by --functions=f1,f2,..., if there are any in the symbols
         context.reporter.synchronized {
           context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
           context.reporter.debug(symbols.functions.filter { case (id,_) => funs.get.contains(id.name) }

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -9,7 +9,8 @@ trait ExtractionPipeline { self =>
 
   val phaseName: String
   // This boolean is `true` for extraction pipelines that should be printed for debugging
-  // It is set to `true` for the basic building blocks of the pipeline
+  // It is set to `true` for the basic building blocks of the pipeline, and set 
+  // to `false` when combining components using ̀`andThen`.
   val debugTransformation: Boolean
 
   implicit val context: inox.Context
@@ -18,7 +19,7 @@ trait ExtractionPipeline { self =>
   def extract(symbols: s.Symbols): t.Symbols
 
   // make a String representation for a table of Symbols `s`, only keeping 
-  // functions and classes who names appear in `objs`
+  // functions and classes whose names appear in `objs`
   def symbolsToString(tt: ast.Trees)(s: tt.Symbols, objs: Set[String]): String = {
     val printerOpts = tt.PrinterOptions.fromContext(context)
     val printerOpts2 = oo.trees.PrinterOptions.fromContext(context)

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -35,9 +35,9 @@ trait ExtractionPipeline { self =>
       if (!symbolsToPrint.functions.isEmpty || !symbolsToPrint.sorts.isEmpty ||
           !resToPrint.functions.isEmpty || !resToPrint.sorts.isEmpty) {
         context.reporter.synchronized {
-          context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
+          context.reporter.debug("\n\n\n\nSymbols before " + this + "\n")
           context.reporter.debug(symbolsToPrint.asString(printerOpts))
-          context.reporter.debug("\n\nSymbols after extraction " + this +  "\n")
+          context.reporter.debug("\n\nSymbols after " + this +  "\n")
           context.reporter.debug(resToPrint.asString(t.PrinterOptions.fromContext(context)))
           context.reporter.debug("\n\n")
         }

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -61,7 +61,7 @@ trait ExtractionPipeline { self =>
     val objs = context.options.findOption(optDebugObjects).getOrElse(Seq()).toSet
     val debug: Boolean = 
       debugTransformation && 
-      (phases.isEmpty || (phases.isDefined && phases.get.exists(phaseName.contains _))
+      (phases.isEmpty || (phases.isDefined && phases.get.exists(phaseName.contains _)))
 
     context.reporter.synchronized {
       val symbolsToPrint = symbolsToString(s)(symbols, objs)

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -22,12 +22,29 @@ trait ExtractionPipeline { self =>
     implicit val debugSection = inox.ast.DebugSectionTrees
     val res = extract(symbols)
     if (debugTransformation) {
-      context.reporter.synchronized {
-        context.reporter.debug("\n\n\n\nSymbols before extraction " + this)
-        context.reporter.debug(symbols.asString(printerOpts))
-        context.reporter.debug("\n\nSymbols after extraction " + this)
-        context.reporter.debug(res.asString(t.PrinterOptions.fromContext(context)))
-        context.reporter.debug("\n\n")
+      val funs = context.options.findOption(optFunctions)
+      if (funs.isEmpty) {
+        // output all the symbols
+        context.reporter.synchronized {
+          context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
+          context.reporter.debug(symbols.asString(printerOpts))
+          context.reporter.debug("\n\nSymbols after extraction " + this +  "\n")
+          context.reporter.debug(res.asString(t.PrinterOptions.fromContext(context)))
+          context.reporter.debug("\n\n")
+        }
+      } else {
+        // output only the functions given by --functions=f1,f2,...
+        context.reporter.synchronized {
+          context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
+          context.reporter.debug(symbols.functions.filter { case (id,_) => funs.get.contains(id.name) }
+                                        .map(_._2.asString(printerOpts))
+                                        .mkString("\n\n"))
+          context.reporter.debug("\n\nSymbols after extraction " + this +  "\n")
+          context.reporter.debug(res.functions.filter { case (id,_) => funs.get.contains(id.name) }
+                                        .map(_._2.asString(t.PrinterOptions.fromContext(context)))
+                                        .mkString("\n\n"))
+          context.reporter.debug("\n\n")
+        }
       }
     }
     res

--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -13,6 +13,8 @@ trait AntiAliasing
      with EffectsChecker { self =>
   import s._
 
+  override val phaseName = "imperative.AntiAliasing"
+
   override protected type FunctionResult = Option[FunDef]
 
   override protected def registerFunctions(symbols: t.Symbols, functions: Seq[Option[t.FunDef]]): t.Symbols =

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
@@ -15,6 +15,8 @@ trait ImperativeCleanup extends SimplePhase { self =>
   val s: Trees
   val t: extraction.Trees
 
+  override val phaseName = "imperative.ImperativeCleanup"
+
   override protected def getContext(symbols: s.Symbols) = new TransformerContext(symbols)
   protected class TransformerContext(val symbols: s.Symbols) extends CheckingTransformer {
     val s: self.s.type = self.s
@@ -48,7 +50,7 @@ trait ImperativeCleanup extends SimplePhase { self =>
             recons(l.toVariable, r.toVariable)).copiedFrom(expr)).copiedFrom(expr)
 
       case s.Variable(id, tpe, flags) =>
-        t.Variable(id, transform(tpe), flags filterNot isImperativeFlag map transform)
+        t.Variable(id, transform(tpe), flags filterNot isImperativeFlag map transform).copiedFrom(expr)
 
       case _ => super.transform(expr)
     }

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -9,6 +9,8 @@ trait ImperativeCodeElimination extends SimpleFunctions with IdentitySorts {
   val t: s.type
   import s._
 
+  override val phaseName = "imperative.ImperativeCodeElimination"
+
   override protected type TransformerContext = s.Symbols
   override protected def getContext(symbols: s.Symbols) = symbols
   override protected def extractFunction(symbols: s.Symbols, fd: s.FunDef): t.FunDef = {

--- a/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
+++ b/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
@@ -8,6 +8,8 @@ trait FunctionClosure extends CachingPhase with IdentitySorts { self =>
   val s: Trees
   val t: ast.Trees
 
+  override val phaseName = "innerfuns.FunctionClosure"
+
   override protected type FunctionResult = Seq[t.FunDef]
   override protected type TransformerContext = s.Symbols
   override protected def getContext(symbols: s.Symbols) = symbols
@@ -61,7 +63,7 @@ trait FunctionClosure extends CachingPhase with IdentitySorts { self =>
       val instBody = inst.transform(withPath(body, reqPC))
 
       val fullBody = exprOps.preMap {
-        case v: Variable => freeMap.get(v.toVal).map(_.toVariable)
+        case v: Variable => freeMap.get(v.toVal).map(_.toVariable.copiedFrom(v))
 
         case let @ Let(id, v, r) if freeMap.isDefinedAt(id) =>
           Some(Let(freeMap(id), v, r).copiedFrom(let))

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -12,6 +12,7 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
   import s._
 
   override val phaseName = "methods.MethodLifting"
+  override val debugTransformation = true
 
   private[this] final val funCache   = new ExtractionCache[s.FunDef, t.FunDef]
   private[this] final val classCache = new ExtractionCache[s.ClassDef, (t.ClassDef, Option[t.FunDef])]
@@ -285,6 +286,5 @@ object MethodLifting {
     override val s: ts.type = ts
     override val t: tt.type = tt
     override val context = ctx
-    override val debugTransformation = true
   }
 }

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -11,6 +11,8 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
   val t: oo.Trees
   import s._
 
+  override val phaseName = "methods.MethodLifting"
+
   private[this] final val funCache   = new ExtractionCache[s.FunDef, t.FunDef]
   private[this] final val classCache = new ExtractionCache[s.ClassDef, (t.ClassDef, Option[t.FunDef])]
 

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -285,5 +285,6 @@ object MethodLifting {
     override val s: ts.type = ts
     override val t: tt.type = tt
     override val context = ctx
+    override val debugTransformation = true
   }
 }

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -13,6 +13,8 @@ trait AdtSpecialization
   val s: Trees
   val t: Trees
 
+  override val phaseName = "oo.AdtSpecialization"
+
   private[this] def root(id: Identifier)(implicit symbols: s.Symbols): Identifier = {
     symbols.getClass(id).parents.map(ct => root(ct.id)).headOption.getOrElse(id)
   }

--- a/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
@@ -29,12 +29,5 @@ trait ClassSymbols { self: Trees =>
       this.sorts,
       this.classes ++ classes.map(cd => cd.id -> cd)
     )
-
-    override def filterObjects(objs: Set[String]) = {
-      NoSymbols.
-        withFunctions(this.functions.values.toSeq.filter { fd => objs.contains(fd.id.name) }).
-        withSorts(this.sorts.values.toSeq.filter { s => objs.contains(s.id.name) }).
-        withClasses(this.classes.values.toSeq.filter { cd => objs.contains(cd.id.name) })
-    }
   }
 }

--- a/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
@@ -29,5 +29,12 @@ trait ClassSymbols { self: Trees =>
       this.sorts,
       this.classes ++ classes.map(cd => cd.id -> cd)
     )
+
+    override def filterObjects(objs: Set[String]) = {
+      NoSymbols.
+        withFunctions(this.functions.values.toSeq.filter { fd => objs.contains(fd.id.name) }).
+        withSorts(this.sorts.values.toSeq.filter { s => objs.contains(s.id.name) }).
+        withClasses(this.classes.values.toSeq.filter { cd => objs.contains(cd.id.name) })
+    }
   }
 }

--- a/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
+++ b/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
@@ -10,6 +10,8 @@ trait RefinementLifting extends CachingPhase with SimpleFunctions with SimpleCla
   val s: Trees
   val t: Trees
 
+  override val phaseName = "oo.RefinementLifting"
+
   override protected type SortResult = (t.ADTSort, Option[t.FunDef])
   override protected def registerSorts(symbols: t.Symbols, sorts: Seq[(t.ADTSort, Option[t.FunDef])]): t.Symbols =
     symbols.withSorts(sorts.map(_._1)).withFunctions(sorts.flatMap(_._2))

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -17,6 +17,8 @@ trait TypeEncoding
   val s: Trees
   val t: Trees
 
+  override val phaseName = "oo.TypeEncoding"
+
   import t._
   import t.dsl._
   import s.TypeParameterWrapper

--- a/core/src/main/scala/stainless/extraction/oo/package.scala
+++ b/core/src/main/scala/stainless/extraction/oo/package.scala
@@ -23,6 +23,8 @@ package object oo {
       override val t: imperative.trees.type = imperative.trees
     })
 
+    import utils.PositionChecker
+
     AdtSpecialization(trees, trees) andThen
     RefinementLifting(trees, trees) andThen
     TypeEncoding(trees, trees)      andThen

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -73,6 +73,8 @@ package object extraction {
     extends Exception(msg)
 
   def pipeline(implicit ctx: inox.Context): StainlessPipeline = {
+    import utils.PositionChecker
+
     xlang.extractor      andThen
     methods.extractor    andThen
     throwing.extractor   andThen
@@ -98,6 +100,7 @@ package object extraction {
     override val s: extraction.trees.type = extraction.trees
     override val t: to.type = to
     override val context = ctx
+    override val phaseName = "completer"
 
     override def invalidate(id: Identifier): Unit = ()
     override def extract(symbols: s.Symbols): t.Symbols = completeSymbols(symbols)(to)

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -102,6 +102,8 @@ package object extraction {
     override val context = ctx
     override val phaseName = "completer"
 
+    override val debugTransformation = true
+
     override def invalidate(id: Identifier): Unit = ()
     override def extract(symbols: s.Symbols): t.Symbols = completeSymbols(symbols)(to)
   }

--- a/core/src/main/scala/stainless/extraction/throwing/ExceptionLifting.scala
+++ b/core/src/main/scala/stainless/extraction/throwing/ExceptionLifting.scala
@@ -8,6 +8,8 @@ trait ExceptionLifting extends oo.SimplePhase { self =>
   val s: Trees
   val t: oo.Trees
 
+  override val phaseName = "throwing.ExceptionLifting"
+
   override protected type TransformerContext = transformer.type
   override protected def getContext(symbols: s.Symbols) = transformer
   protected object transformer extends oo.TreeTransformer {

--- a/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
+++ b/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
@@ -1,0 +1,44 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package extraction
+package utils
+
+import inox.utils.{Position, NoPosition}
+
+object DebugSectionPositions extends inox.DebugSection("positions")
+
+/** Inspect trees, detecting missing positions. */
+object PositionChecker {
+
+  def apply(phaseName: String)(tr: ast.Trees)(context: inox.Context): tr.TreeTraverser { val trees: tr.type } = new tr.TreeTraverser {
+    val trees: tr.type = tr
+    import trees._
+
+    private implicit val debuSection = DebugSectionPositions
+
+    private var lastKnownPosition: Position = NoPosition
+
+    override def traverse(fd: FunDef): Unit = {
+      if (fd.flags.contains(Synthetic)) return ()
+      traverse(fd.id)
+      fd.tparams.foreach(traverse)
+      fd.params.foreach(traverse)
+      traverse(fd.returnType)
+      traverse(fd.fullBody)
+      fd.flags.foreach(traverse)
+    }
+
+    override def traverse(e: Expr): Unit = {
+      if (!e.getPos.isDefined) {
+        context.reporter.debug(NoPosition, s"Missing position for expression '$e' (of type ${e.getClass}) after phase '$phaseName'. Last known position: $lastKnownPosition")
+      } else {
+        lastKnownPosition = e.getPos
+      }
+
+      super.traverse(e)
+    }
+  }
+
+}
+

--- a/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
+++ b/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
@@ -15,7 +15,7 @@ object PositionChecker {
 
   private[this] val seen: MutableHashSet[ast.Trees#Expr] = MutableHashSet.empty
 
-  def apply(phaseName: String)(tr: ast.Trees)(context: inox.Context): tr.TreeTraverser { val trees: tr.type } = new tr.TreeTraverser {
+  def apply(phaseName: String)(tr: ast.Trees)(context: inox.Context)(before: Boolean): tr.TreeTraverser { val trees: tr.type } = new tr.TreeTraverser {
     val trees: tr.type = tr
     import trees._
 
@@ -37,7 +37,8 @@ object PositionChecker {
       if (seen contains e) return ()
 
       if (!e.getPos.isDefined) {
-        context.reporter.debug(NoPosition, s"After $phaseName: Missing position for expression '$e' (of type ${e.getClass}). Last known position: $lastKnownPosition")
+        val word = if (before) "Before" else "After"
+        context.reporter.debug(NoPosition, s"$word $phaseName: Missing position for expression '$e' (of type ${e.getClass}). Last known position: $lastKnownPosition")
       } else {
         lastKnownPosition = e.getPos
       }

--- a/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
+++ b/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
@@ -20,7 +20,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
     private[this] val syntheticIsEmpty: s.Symbols => t.FunDef = {
       def createFunction(option: Identifier, none: Identifier): t.FunDef = {
         val isEmpty = ast.SymbolIdentifier("stainless.lang.Option.isEmpty")
-        mkFunDef(isEmpty, t.Unchecked)("A") {
+        mkFunDef(isEmpty, t.Unchecked, t.Synthetic)("A") {
           case Seq(aT) => (Seq("x" :: T(option)(aT)), t.BooleanType(), { case Seq(v) => v is none })
         }
       }
@@ -41,7 +41,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
     private[this] val syntheticGet: s.Symbols => t.FunDef = {
       def createFunction(option: Identifier, some: Identifier, value: Identifier): t.FunDef = {
         val get = ast.SymbolIdentifier("stainless.lang.Option.get")
-        mkFunDef(get, t.Unchecked)("A") {
+        mkFunDef(get, t.Unchecked, t.Synthetic)("A") {
           case Seq(aT) => (Seq("x" :: T(option)(aT)), aT, {
             case Seq(v) => t.Require(v is some, v.getField(value))
           })

--- a/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
@@ -10,6 +10,8 @@ trait PartialFunctions extends oo.SimplePhase { self =>
   val t: self.s.type
   import s._
 
+  override val phaseName = "xlang.PartialFunctions"
+
   override protected def getContext(symbols: Symbols) = new TransformerContext(symbols)
   protected class TransformerContext(symbols: s.Symbols) extends oo.TreeTransformer {
     override final val s: self.s.type = self.s

--- a/core/src/main/scala/stainless/extraction/xlang/package.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/package.scala
@@ -27,6 +27,7 @@ package object xlang {
       override val s: trees.type = trees
       override val t: methods.trees.type = methods.trees
       override val context = ctx
+      override val phaseName = "xlang"
 
       override protected type TransformerContext = identity.type
       override protected def getContext(symbols: s.Symbols) = identity

--- a/core/src/main/scala/stainless/verification/PartialEvaluation.scala
+++ b/core/src/main/scala/stainless/verification/PartialEvaluation.scala
@@ -15,6 +15,8 @@ trait PartialEvaluation
   val s: extraction.Trees
   val t: s.type
 
+  override val phaseName = "PartialEvaluation"
+
   import context._
   import s._
 


### PR DESCRIPTION
This adds debug output (for `--debug=trees`) of the symbols before and after each transformation. `debugTransformation = false` is set to `false` for compound transformations (in `andThen`) to avoid duplication of output.

The output is still a bit hard to read sometimes (maybe because I didn't set `debugTransformation` to `false` somewhere), but it is generally ok. We could add names to each transformations to have a nicer output.

This one is OK:
> Symbols before extraction stainless.extraction.imperative.ImperativeCleanup$$anon$1@1ccfcec5

This one less so:
> Symbols before extraction stainless.extraction.ExtractionPipeline$$anon$3@1212d8a5
