### PR TITLE
Update circe to 0.10.0-M2 which bumps cats to 1.2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -17,6 +17,7 @@ val osArch = System.getProperty("sun.arch.data.model")
 
 val inoxVersion = "1.1.0-243-gd08df9b"
 val dottyVersion = "0.1.1-bin-20170429-10a2ce6-NIGHTLY"
+val circeVersion = "0.10.0-M2"
 
 lazy val nParallel = {
   val p = System.getProperty("parallel")
@@ -50,8 +51,6 @@ lazy val artifactSettings: Seq[Setting[_]] = baseSettings ++ Seq(
   scalaVersion := crossScalaVersions.value.head,
   crossScalaVersions := SupportedScalaVersions
 )
-
-val circeVersion = "0.10.0-M2"
 
 lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
   scalacOptions ++= Seq(

--- a/build.sbt
+++ b/build.sbt
@@ -51,6 +51,8 @@ lazy val artifactSettings: Seq[Setting[_]] = baseSettings ++ Seq(
   crossScalaVersions := SupportedScalaVersions
 )
 
+val circeVersion = "0.10.0-M2"
+
 lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
   scalacOptions ++= Seq(
     "-deprecation",
@@ -76,9 +78,9 @@ lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
     "ch.epfl.lara" %% "inox" % inoxVersion % "test" classifier "tests",
     "ch.epfl.lara" %% "cafebabe" % "1.2",
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
-    "io.circe" %% "circe-core" % "0.8.0",
-    "io.circe" %% "circe-generic" % "0.8.0",
-    "io.circe" %% "circe-parser" % "0.8.0"
+    "io.circe" %% "circe-core" % circeVersion,
+    "io.circe" %% "circe-generic" % circeVersion,
+    "io.circe" %% "circe-parser" % circeVersion
   ),
 
   concurrentRestrictions in Global += Tags.limit(Tags.Test, nParallel),

--- a/core/src/main/scala/stainless/codegen/runtime/GenericValues.scala
+++ b/core/src/main/scala/stainless/codegen/runtime/GenericValues.scala
@@ -11,7 +11,7 @@ object GenericValues {
   private[this] var gvToI = ScalaMap[ast.Trees#GenericValue, Int]()
   private[this] var iTogv = ScalaMap[Int, ast.Trees#GenericValue]()
 
-  def register(gv: ast.Trees#GenericValue): Int = {
+  def register(gv: ast.Trees#GenericValue): Int = synchronized {
     if (gvToI contains gv) {
       gvToI(gv)
     } else {
@@ -22,7 +22,7 @@ object GenericValues {
     }
   }
 
-  def get(i: Int): java.lang.Object = {
+  def get(i: Int): java.lang.Object = synchronized {
     iTogv(i)
   }
 }


### PR DESCRIPTION
This might be useful for people who wants to depend on `stainless-core` while using a recent version of `cats` (like me).