### PR TITLE
Remove dependency from non-sealed classes to their subclasses

### DIFF
--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -86,7 +86,7 @@ trait ComponentRun { self =>
   private[this] final val extractionFilter = createFilter
 
   /** Sends the symbols through the extraction pipeline. */
-  def extract(symbols: extraction.xlang.trees.Symbols): trees.Symbols = extractionPipeline extract symbols
+  def extract(symbols: extraction.xlang.trees.Symbols): trees.Symbols = extractionPipeline extractWithDebug symbols
 
   /** Sends the program's symbols through the extraction pipeline. */
   def extract(program: inox.Program { val trees: extraction.xlang.trees.type }): inox.Program {
@@ -96,6 +96,7 @@ trait ComponentRun { self =>
   /** Passes the provided symbols through the extraction pipeline and processes all
     * functions derived from the provided identifier. */
   def apply(id: Identifier, symbols: extraction.xlang.trees.Symbols): Future[Analysis] = try {
+
     val exSymbols = extract(symbols)
 
     val toCheck = inox.utils.fixpoint { (ids: Set[Identifier]) =>

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -40,6 +40,13 @@ object optDebugObjects extends inox.OptionDef[Seq[String]] {
   val usageRhs = "o1,o2,..."
 }
 
+object optDebugPhases extends inox.OptionDef[Seq[String]] {
+  val name = "debug-phases"
+  val default = Seq[String]()
+  val parser = inox.OptionParsers.seqParser(inox.OptionParsers.stringParser)
+  val usageRhs = "p1,p2,..."
+}
+
 trait ComponentRun { self =>
   val component: Component
   val trees: ast.Trees

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -33,6 +33,13 @@ object optFunctions extends inox.OptionDef[Seq[String]] {
   val usageRhs = "f1,f2,..."
 }
 
+object optDebugObjects extends inox.OptionDef[Seq[String]] {
+  val name = "debug-objects"
+  val default = Seq[String]()
+  val parser = inox.OptionParsers.seqParser(inox.OptionParsers.stringParser)
+  val usageRhs = "o1,o2,..."
+}
+
 trait ComponentRun { self =>
   val component: Component
   val trees: ast.Trees

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -23,7 +23,8 @@ trait MainHelpers extends inox.MainHelpers {
   case object Termination extends Category
 
   override protected def getOptions = super.getOptions - inox.solvers.optAssumeChecked ++ Map(
-    optFunctions -> Description(General, "Only consider functions s1,s2,..."),
+    optFunctions -> Description(General, "Only consider functions f1,f2,..."),
+    optDebugObjects -> Description(General, "Only print debug output for functions/adts named o1,o2,..."),
     evaluators.optCodeGen -> Description(Evaluators, "Use code generating evaluator"),
     codegen.optInstrumentFields -> Description(Evaluators, "Instrument ADT field access during code generation"),
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -25,6 +25,7 @@ trait MainHelpers extends inox.MainHelpers {
   override protected def getOptions = super.getOptions - inox.solvers.optAssumeChecked ++ Map(
     optFunctions -> Description(General, "Only consider functions f1,f2,..."),
     optDebugObjects -> Description(General, "Only print debug output for functions/adts named o1,o2,..."),
+    optDebugPhases -> Description(General, "Only print debug output for phases whose name contain p1 or p2 or ..."),
     evaluators.optCodeGen -> Description(Evaluators, "Use code generating evaluator"),
     codegen.optInstrumentFields -> Description(Evaluators, "Instrument ADT field access during code generation"),
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -55,6 +55,7 @@ trait MainHelpers extends inox.MainHelpers {
     verification.DebugSectionPartialEval,
     termination.DebugSectionTermination,
     DebugSectionExtraction,
+    extraction.utils.DebugSectionPositions,
     frontend.DebugSectionFrontend,
     utils.DebugSectionRegistry
   )

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -32,8 +32,8 @@ trait ExtractionPipeline { self =>
           context.reporter.debug(res.asString(t.PrinterOptions.fromContext(context)))
           context.reporter.debug("\n\n")
         }
-      } else {
-        // output only the functions given by --functions=f1,f2,...
+      } else if (symbols.functions.exists { case (id,_) => funs.get.contains(id.name) }) {
+        // output only the functions given by --functions=f1,f2,..., if there are any in the symbols
         context.reporter.synchronized {
           context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
           context.reporter.debug(symbols.functions.filter { case (id,_) => funs.get.contains(id.name) }

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -9,7 +9,8 @@ trait ExtractionPipeline { self =>
 
   val phaseName: String
   // This boolean is `true` for extraction pipelines that should be printed for debugging
-  // It is set to `true` for the basic building blocks of the pipeline
+  // It is set to `true` for the basic building blocks of the pipeline, and set 
+  // to `false` when combining components using ̀`andThen`.
   val debugTransformation: Boolean
 
   implicit val context: inox.Context
@@ -18,7 +19,7 @@ trait ExtractionPipeline { self =>
   def extract(symbols: s.Symbols): t.Symbols
 
   // make a String representation for a table of Symbols `s`, only keeping 
-  // functions and classes who names appear in `objs`
+  // functions and classes whose names appear in `objs`
   def symbolsToString(tt: ast.Trees)(s: tt.Symbols, objs: Set[String]): String = {
     val printerOpts = tt.PrinterOptions.fromContext(context)
     val printerOpts2 = oo.trees.PrinterOptions.fromContext(context)

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -35,9 +35,9 @@ trait ExtractionPipeline { self =>
       if (!symbolsToPrint.functions.isEmpty || !symbolsToPrint.sorts.isEmpty ||
           !resToPrint.functions.isEmpty || !resToPrint.sorts.isEmpty) {
         context.reporter.synchronized {
-          context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
+          context.reporter.debug("\n\n\n\nSymbols before " + this + "\n")
           context.reporter.debug(symbolsToPrint.asString(printerOpts))
-          context.reporter.debug("\n\nSymbols after extraction " + this +  "\n")
+          context.reporter.debug("\n\nSymbols after " + this +  "\n")
           context.reporter.debug(resToPrint.asString(t.PrinterOptions.fromContext(context)))
           context.reporter.debug("\n\n")
         }

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -264,7 +264,9 @@ trait CachingPhase extends ExtractionPipeline with ExtractionCaches { self =>
   private[this] final val funCache = ExtractionCache[s.FunDef, FunctionResult]()
 
   protected type SortResult
-  private[this] final val sortCache = ExtractionCache[s.ADTSort, SortResult]()
+  private[this] final val sortCache = new ExtractionCache[Set[Identifier], s.ADTSort, SortResult](
+    (sd, syms) => sd.constructors.map(_.id).toSet + sd.id
+  )
 
   protected type TransformerContext
   protected def getContext(symbols: s.Symbols): TransformerContext

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -226,28 +226,29 @@ trait ExtractionCaches { self: ExtractionPipeline =>
     def apply(d: s.Definition)(implicit symbols: s.Symbols): CacheKey = apply(d.id)
   }
 
-  private[this] val caches = new scala.collection.mutable.ListBuffer[ExtractionCache[_, _]]
+  private[this] val caches = new scala.collection.mutable.ListBuffer[ExtractionCache[_, _, _]]
 
-  protected class ExtractionCache[Key, T](keyOf: (Identifier, s.Symbols) => Key) {
-    private[this] final val cache = new utils.ConcurrentCache[(Identifier, Key), T]
+  protected class ExtractionCache[Key, X <: s.Definition, Y](keyOf: (X, s.Symbols) => Key) {
+    private[this] final val cache = new utils.ConcurrentCache[(X, Key), Y]
 
-    def cached(id: Identifier, symbols: s.Symbols)(builder: => T): T = cache.cached(id -> keyOf(id, symbols))(builder)
+    def cached(id: X, symbols: s.Symbols)(builder: => Y): Y = cache.cached(id -> keyOf(id, symbols))(builder)
 
-    def contains(id: Identifier, symbols: s.Symbols): Boolean = cache contains (id -> keyOf(id, symbols))
-    def update(id: Identifier, symbols: s.Symbols, value: T) = cache.update(id -> keyOf(id, symbols), value)
-    def get(id: Identifier, symbols: s.Symbols): Option[T] = cache.get(id -> keyOf(id, symbols))
-    def apply(id: Identifier, symbols: s.Symbols): T = cache(id -> keyOf(id, symbols))
+    def contains(id: X, symbols: s.Symbols): Boolean = cache contains (id -> keyOf(id, symbols))
+    def update(id: X, symbols: s.Symbols, value: Y) = cache.update(id -> keyOf(id, symbols), value)
+    def get(id: X, symbols: s.Symbols): Option[Y] = cache.get(id -> keyOf(id, symbols))
+    def apply(id: X, symbols: s.Symbols): Y = cache(id -> keyOf(id, symbols))
 
     private[ExtractionCaches] def invalidate(id: Identifier): Unit =
-      cache.retain(key => key._1 != id)
-      // cache.retain(key => key._1 != id && !(key.dependencies contains id))
+      cache.retain(key => key._1.id != id)
+      // FIXME: key._1.dependencies is not accepted by the compiler
+      // cache.retain(key => key._1.id != id && !(key._1.dependencies contains id)) 
 
     self.synchronized(caches += this)
   }
 
   object ExtractionCache {
-    def apply[Key, T]() = {
-      new ExtractionCache[CacheKey, T]((id, sym) => CacheKey(id)(sym))
+    def apply[X <: s.Definition, Y]() = {
+      new ExtractionCache[CacheKey, X, Y]((x, sym) => CacheKey(x)(sym))
     }
   }
 
@@ -281,11 +282,11 @@ trait CachingPhase extends ExtractionPipeline with ExtractionCaches { self =>
 
   protected def extractSymbols(context: TransformerContext, symbols: s.Symbols): t.Symbols = {
     val functions = symbols.functions.values.map { fd =>
-      funCache.cached(fd.id, symbols)(extractFunction(context, fd))
+      funCache.cached(fd, symbols)(extractFunction(context, fd))
     }.toSeq
 
     val sorts = symbols.sorts.values.map { sort =>
-      sortCache.cached(sort.id, symbols)(extractSort(context, sort))
+      sortCache.cached(sort, symbols)(extractSort(context, sort))
     }.toSeq
 
     registerSorts(registerFunctions(t.NoSymbols, functions), sorts)

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -61,7 +61,7 @@ trait ExtractionPipeline { self =>
     val objs = context.options.findOption(optDebugObjects).getOrElse(Seq()).toSet
     val debug: Boolean = 
       debugTransformation && 
-      (phases.isEmpty || (phases.isDefined && phases.get.exists(phaseName.contains _))
+      (phases.isEmpty || (phases.isDefined && phases.get.exists(phaseName.contains _)))
 
     context.reporter.synchronized {
       val symbolsToPrint = symbolsToString(s)(symbols, objs)

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -22,12 +22,29 @@ trait ExtractionPipeline { self =>
     implicit val debugSection = inox.ast.DebugSectionTrees
     val res = extract(symbols)
     if (debugTransformation) {
-      context.reporter.synchronized {
-        context.reporter.debug("\n\n\n\nSymbols before extraction " + this)
-        context.reporter.debug(symbols.asString(printerOpts))
-        context.reporter.debug("\n\nSymbols after extraction " + this)
-        context.reporter.debug(res.asString(t.PrinterOptions.fromContext(context)))
-        context.reporter.debug("\n\n")
+      val funs = context.options.findOption(optFunctions)
+      if (funs.isEmpty) {
+        // output all the symbols
+        context.reporter.synchronized {
+          context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
+          context.reporter.debug(symbols.asString(printerOpts))
+          context.reporter.debug("\n\nSymbols after extraction " + this +  "\n")
+          context.reporter.debug(res.asString(t.PrinterOptions.fromContext(context)))
+          context.reporter.debug("\n\n")
+        }
+      } else {
+        // output only the functions given by --functions=f1,f2,...
+        context.reporter.synchronized {
+          context.reporter.debug("\n\n\n\nSymbols before extraction " + this + "\n")
+          context.reporter.debug(symbols.functions.filter { case (id,_) => funs.get.contains(id.name) }
+                                        .map(_._2.asString(printerOpts))
+                                        .mkString("\n\n"))
+          context.reporter.debug("\n\nSymbols after extraction " + this +  "\n")
+          context.reporter.debug(res.functions.filter { case (id,_) => funs.get.contains(id.name) }
+                                        .map(_._2.asString(t.PrinterOptions.fromContext(context)))
+                                        .mkString("\n\n"))
+          context.reporter.debug("\n\n")
+        }
       }
     }
     res

--- a/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionPipeline.scala
@@ -188,7 +188,7 @@ trait ExtractionCaches { self: ExtractionPipeline =>
   }
 
   protected object CacheKey {
-    private def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = {
+    def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = {
       new CacheKey(id, symbols.dependencies(id).flatMap { did =>
         val optKey = symbols.lookupFunction(id).map { fd =>
           if (fd.flags contains s.Uncached) {
@@ -228,20 +228,27 @@ trait ExtractionCaches { self: ExtractionPipeline =>
 
   private[this] val caches = new scala.collection.mutable.ListBuffer[ExtractionCache[_, _]]
 
-  protected class ExtractionCache[Key <: s.Definition, T] {
-    private[this] final val cache = new utils.ConcurrentCache[CacheKey, T]
+  protected class ExtractionCache[Key, T](keyOf: (Identifier, s.Symbols) => Key) {
+    private[this] final val cache = new utils.ConcurrentCache[(Identifier, Key), T]
 
-    def cached(key: Key, symbols: s.Symbols)(builder: => T): T = cache.cached(CacheKey(key)(symbols))(builder)
+    def cached(id: Identifier, symbols: s.Symbols)(builder: => T): T = cache.cached(id -> keyOf(id, symbols))(builder)
 
-    def contains(key: Key, symbols: s.Symbols): Boolean = cache contains CacheKey(key)(symbols)
-    def update(key: Key, symbols: s.Symbols, value: T) = cache.update(CacheKey(key)(symbols), value)
-    def get(key: Key, symbols: s.Symbols): Option[T] = cache.get(CacheKey(key)(symbols))
-    def apply(key: Key, symbols: s.Symbols): T = cache(CacheKey(key)(symbols))
+    def contains(id: Identifier, symbols: s.Symbols): Boolean = cache contains (id -> keyOf(id, symbols))
+    def update(id: Identifier, symbols: s.Symbols, value: T) = cache.update(id -> keyOf(id, symbols), value)
+    def get(id: Identifier, symbols: s.Symbols): Option[T] = cache.get(id -> keyOf(id, symbols))
+    def apply(id: Identifier, symbols: s.Symbols): T = cache(id -> keyOf(id, symbols))
 
     private[ExtractionCaches] def invalidate(id: Identifier): Unit =
-      cache.retain(key => key.id != id && !(key.dependencies contains id))
+      cache.retain(key => key._1 != id)
+      // cache.retain(key => key._1 != id && !(key.dependencies contains id))
 
     self.synchronized(caches += this)
+  }
+
+  object ExtractionCache {
+    def apply[Key, T]() = {
+      new ExtractionCache[CacheKey, T]((id, sym) => CacheKey(id)(sym))
+    }
   }
 
   override def invalidate(id: Identifier): Unit = {
@@ -253,10 +260,10 @@ trait CachingPhase extends ExtractionPipeline with ExtractionCaches { self =>
   override val debugTransformation = true
 
   protected type FunctionResult
-  private[this] final val funCache = new ExtractionCache[s.FunDef, FunctionResult]
+  private[this] final val funCache = ExtractionCache[s.FunDef, FunctionResult]()
 
   protected type SortResult
-  private[this] final val sortCache = new ExtractionCache[s.ADTSort, SortResult]
+  private[this] final val sortCache = ExtractionCache[s.ADTSort, SortResult]()
 
   protected type TransformerContext
   protected def getContext(symbols: s.Symbols): TransformerContext
@@ -274,11 +281,11 @@ trait CachingPhase extends ExtractionPipeline with ExtractionCaches { self =>
 
   protected def extractSymbols(context: TransformerContext, symbols: s.Symbols): t.Symbols = {
     val functions = symbols.functions.values.map { fd =>
-      funCache.cached(fd, symbols)(extractFunction(context, fd))
+      funCache.cached(fd.id, symbols)(extractFunction(context, fd))
     }.toSeq
 
     val sorts = symbols.sorts.values.map { sort =>
-      sortCache.cached(sort, symbols)(extractSort(context, sort))
+      sortCache.cached(sort.id, symbols)(extractSort(context, sort))
     }.toSeq
 
     registerSorts(registerFunctions(t.NoSymbols, functions), sorts)

--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -13,6 +13,8 @@ trait AntiAliasing
      with EffectsChecker { self =>
   import s._
 
+  override val phaseName = "imperative.AntiAliasing"
+
   override protected type FunctionResult = Option[FunDef]
 
   override protected def registerFunctions(symbols: t.Symbols, functions: Seq[Option[t.FunDef]]): t.Symbols =

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -110,7 +110,7 @@ trait EffectsAnalyzer extends CachingPhase {
 
     def apply(fd: FunDef)(implicit symbols: Symbols): EffectsAnalysis = {
       val fds = (symbols.transitiveCallees(fd) + fd).toSeq.sortBy(_.id)
-      val lookups = fds.map((fd: FunDef) => effectsCache get (fd.id, symbols))
+      val lookups = fds.map((fd: FunDef) => effectsCache get (fd, symbols))
       val newFds = (fds zip lookups).filter(_._2.isEmpty).map(_._1)
       val prevEffects = lookups.flatten.foldLeft(EffectsAnalysis.empty)(_ merge _)
 
@@ -135,7 +135,7 @@ trait EffectsAnalyzer extends CachingPhase {
         } (prevEffects merge baseEffects)
 
         for ((fd, inners) <- inners) {
-          effectsCache(fd.id, symbols) = new EffectsAnalysis(
+          effectsCache(fd, symbols) = new EffectsAnalysis(
             effects.effects.filter { case (fun, _) => fun == Outer(fd) || inners(fun) },
             effects.locals.filter { case (_, fun) => inners(fun) })
         }
@@ -382,7 +382,7 @@ trait EffectsAnalyzer extends CachingPhase {
         val mutableSort = sort.constructors.exists(_.fields.exists {
           vd => (vd.flags contains IsVar) || rec(vd.tpe, seen + ADTType(id, sort.typeArgs))
         })
-        mutableCache(sort.id, symbols) = mutableSort
+        mutableCache(sort, symbols) = mutableSort
         mutableSort || adt.getSort.constructors.exists(_.fields.exists(vd => rec(vd.tpe, seen + adt)))
       case _: FunctionType => false
       case NAryType(tps, _) => tps.exists(rec(_, seen))

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -89,7 +89,10 @@ trait EffectsAnalyzer extends CachingPhase {
     override def toString: String = asString
   }
 
-  private[this] val effectsCache = ExtractionCache[FunDef, EffectsAnalysis]()
+  // This cache is only valid for that exact set of symbols
+  private[this] val effectsCache = new ExtractionCache[Int, FunDef, EffectsAnalysis](
+    (fd, syms) => (fd, syms).hashCode
+  )
 
   protected object EffectsAnalysis {
     def empty: EffectsAnalysis = new EffectsAnalysis(Map.empty, Map.empty)
@@ -362,7 +365,9 @@ trait EffectsAnalyzer extends CachingPhase {
       .flatMap { case (v, effects) => merge(effects.map(_.target)).map(Effect(v, _)) }.toSet
   }
 
-  private[this] val mutableCache = ExtractionCache[ADTSort, Boolean]()
+  private[this] val mutableCache = new ExtractionCache[Set[Identifier], ADTSort, Boolean](
+    (sd, syms) => sd.constructors.map(_.id).toSet + sd.id
+  )
 
   /** Determine if the type is mutable
     *

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
@@ -15,6 +15,8 @@ trait ImperativeCleanup extends SimplePhase { self =>
   val s: Trees
   val t: extraction.Trees
 
+  override val phaseName = "imperative.ImperativeCleanup"
+
   override protected def getContext(symbols: s.Symbols) = new TransformerContext(symbols)
   protected class TransformerContext(val symbols: s.Symbols) extends CheckingTransformer {
     val s: self.s.type = self.s
@@ -48,7 +50,7 @@ trait ImperativeCleanup extends SimplePhase { self =>
             recons(l.toVariable, r.toVariable)).copiedFrom(expr)).copiedFrom(expr)
 
       case s.Variable(id, tpe, flags) =>
-        t.Variable(id, transform(tpe), flags filterNot isImperativeFlag map transform)
+        t.Variable(id, transform(tpe), flags filterNot isImperativeFlag map transform).copiedFrom(expr)
 
       case _ => super.transform(expr)
     }

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -9,6 +9,8 @@ trait ImperativeCodeElimination extends SimpleFunctions with IdentitySorts {
   val t: s.type
   import s._
 
+  override val phaseName = "imperative.ImperativeCodeElimination"
+
   override protected type TransformerContext = s.Symbols
   override protected def getContext(symbols: s.Symbols) = symbols
   override protected def extractFunction(symbols: s.Symbols, fd: s.FunDef): t.FunDef = {

--- a/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
+++ b/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
@@ -8,6 +8,8 @@ trait FunctionClosure extends CachingPhase with IdentitySorts { self =>
   val s: Trees
   val t: ast.Trees
 
+  override val phaseName = "innerfuns.FunctionClosure"
+
   override protected type FunctionResult = Seq[t.FunDef]
   override protected type TransformerContext = s.Symbols
   override protected def getContext(symbols: s.Symbols) = symbols
@@ -61,7 +63,7 @@ trait FunctionClosure extends CachingPhase with IdentitySorts { self =>
       val instBody = inst.transform(withPath(body, reqPC))
 
       val fullBody = exprOps.preMap {
-        case v: Variable => freeMap.get(v.toVal).map(_.toVariable)
+        case v: Variable => freeMap.get(v.toVal).map(_.toVariable.copiedFrom(v))
 
         case let @ Let(id, v, r) if freeMap.isDefinedAt(id) =>
           Some(Let(freeMap(id), v, r).copiedFrom(let))

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -12,6 +12,7 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
   import s._
 
   override val phaseName = "methods.MethodLifting"
+  override val debugTransformation = true
 
   private[this] final val funCache   = new ExtractionCache[s.FunDef, t.FunDef]
   private[this] final val classCache = new ExtractionCache[s.ClassDef, (t.ClassDef, Option[t.FunDef])]
@@ -285,6 +286,5 @@ object MethodLifting {
     override val s: ts.type = ts
     override val t: tt.type = tt
     override val context = ctx
-    override val debugTransformation = true
   }
 }

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -11,6 +11,8 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
   val t: oo.Trees
   import s._
 
+  override val phaseName = "methods.MethodLifting"
+
   private[this] final val funCache   = new ExtractionCache[s.FunDef, t.FunDef]
   private[this] final val classCache = new ExtractionCache[s.ClassDef, (t.ClassDef, Option[t.FunDef])]
 

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -14,8 +14,10 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
   override val phaseName = "methods.MethodLifting"
   override val debugTransformation = true
 
-  private[this] final val funCache   = ExtractionCache[s.FunDef, t.FunDef]()
-  private[this] final val classCache = ExtractionCache[s.ClassDef, (t.ClassDef, Option[t.FunDef])]()
+  // private[this] final val funCache   = ExtractionCache[s.FunDef, t.FunDef]()
+  private[this] final val classCache = new ExtractionCache[Set[Identifier], s.ClassDef, (t.ClassDef, Option[t.FunDef])](
+    (cd, syms) => cd.descendantsIdsWithSelf(syms)
+  )
 
   private sealed trait Override { val cid: Identifier }
   private case class FunOverride(cid: Identifier, fid: Option[Identifier], children: Seq[Override]) extends Override
@@ -61,13 +63,15 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
       val funs = cd.methods(symbols)
         .map(symbols.functions)
         .map { fd =>
-          funCache.cached(fd, symbols)(transformMethod(fd)(symbols))
+          // funCache.cached(fd, symbols)(transformMethod(fd)(symbols))
+          transformMethod(fd)(symbols)
         }
 
       functions ++= funs
 
       val inv = invariant map { inv =>
-        funCache.cached(inv, symbols)(transformMethod(inv)(symbols.withFunctions(Seq(inv))))
+        // funCache.cached(inv, symbols)(transformMethod(inv)(symbols.withFunctions(Seq(inv))))
+        transformMethod(inv)(symbols.withFunctions(Seq(inv)))
       }
 
       val (cls, fun) = classCache.cached(cd, symbols) {
@@ -82,7 +86,8 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
     functions ++= symbols.functions.values
       .filterNot(_.flags exists { case IsMethodOf(_) => true case _ => false })
       .map { fd =>
-        funCache.cached(fd, symbols)(default.transform(fd))
+        // funCache.cached(fd, symbols)(default.transform(fd))
+        default.transform(fd)
       }
 
     t.NoSymbols.withFunctions(functions.toSeq).withClasses(classes.toSeq)

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -285,5 +285,6 @@ object MethodLifting {
     override val s: ts.type = ts
     override val t: tt.type = tt
     override val context = ctx
+    override val debugTransformation = true
   }
 }

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -61,16 +61,16 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
       val funs = cd.methods(symbols)
         .map(symbols.functions)
         .map { fd =>
-          funCache.cached(fd.id, symbols)(transformMethod(fd)(symbols))
+          funCache.cached(fd, symbols)(transformMethod(fd)(symbols))
         }
 
       functions ++= funs
 
       val inv = invariant map { inv =>
-        funCache.cached(inv.id, symbols)(transformMethod(inv)(symbols.withFunctions(Seq(inv))))
+        funCache.cached(inv, symbols)(transformMethod(inv)(symbols.withFunctions(Seq(inv))))
       }
 
-      val (cls, fun) = classCache.cached(cd.id, symbols) {
+      val (cls, fun) = classCache.cached(cd, symbols) {
         val cls = identity.transform(cd.copy(flags = cd.flags ++ invariant.map(fd => HasADTInvariant(fd.id))))
         (cls, inv)
       }
@@ -82,7 +82,7 @@ trait MethodLifting extends ExtractionPipeline with ExtractionCaches { self =>
     functions ++= symbols.functions.values
       .filterNot(_.flags exists { case IsMethodOf(_) => true case _ => false })
       .map { fd =>
-        funCache.cached(fd.id, symbols)(default.transform(fd))
+        funCache.cached(fd, symbols)(default.transform(fd))
       }
 
     t.NoSymbols.withFunctions(functions.toSeq).withClasses(classes.toSeq)

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -19,10 +19,13 @@ trait AdtSpecialization
     symbols.getClass(id).parents.map(ct => root(ct.id)).headOption.getOrElse(id)
   }
 
-  private[this] val candidateCache = ExtractionCache[s.ClassDef, Boolean]()
+  private[this] val candidateCache = new ExtractionCache[Set[Identifier], s.ClassDef, Boolean](
+    (cd, syms) => cd.descendantsIdsWithSelf(syms)
+  )
   private[this] def isCandidate(id: Identifier)(implicit symbols: s.Symbols): Boolean = {
     import s._
     val cd = symbols.getClass(id)
+    
     candidateCache.cached(cd, symbols)(cd.parents match {
       case Nil =>
         def rec(cd: s.ClassDef): Boolean = {
@@ -52,8 +55,12 @@ trait AdtSpecialization
     val sorts: Seq[t.ADTSort]
   )
 
-  private[this] val infoCache = OptionSort.cached(ExtractionCache[s.ClassDef, ClassInfo]())
-  private[this] val constructorCache = ExtractionCache[s.ClassDef, Identifier]()
+  private[this] val infoCache = OptionSort.cached(new ExtractionCache[Set[Identifier], s.ClassDef, ClassInfo](
+    (cd, syms) => cd.descendantsIdsWithSelf(syms)
+  ))
+  private[this] val constructorCache = new ExtractionCache[Set[Identifier], s.ClassDef, Identifier](
+    (cd, syms) => cd.descendantsIdsWithSelf(syms)
+  )
   private[this] def classInfo(id: Identifier)(implicit context: TransformerContext): ClassInfo = {
     import t.dsl._
     import context.{s => _, t => _, _}

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -19,11 +19,11 @@ trait AdtSpecialization
     symbols.getClass(id).parents.map(ct => root(ct.id)).headOption.getOrElse(id)
   }
 
-  private[this] val candidateCache = new ExtractionCache[s.ClassDef, Boolean]
+  private[this] val candidateCache = ExtractionCache[s.ClassDef, Boolean]()
   private[this] def isCandidate(id: Identifier)(implicit symbols: s.Symbols): Boolean = {
     import s._
     val cd = symbols.getClass(id)
-    candidateCache.cached(cd, symbols)(cd.parents match {
+    candidateCache.cached(cd.id, symbols)(cd.parents match {
       case Nil =>
         def rec(cd: s.ClassDef): Boolean = {
           val cs = cd.children
@@ -52,20 +52,20 @@ trait AdtSpecialization
     val sorts: Seq[t.ADTSort]
   )
 
-  private[this] val infoCache = OptionSort.cached(new ExtractionCache[s.ClassDef, ClassInfo])
-  private[this] val constructorCache = new ExtractionCache[s.ClassDef, Identifier]
+  private[this] val infoCache = OptionSort.cached(ExtractionCache[s.ClassDef, ClassInfo]())
+  private[this] val constructorCache = ExtractionCache[s.ClassDef, Identifier]()
   private[this] def classInfo(id: Identifier)(implicit context: TransformerContext): ClassInfo = {
     import t.dsl._
     import context.{s => _, t => _, _}
 
     val cd = context.symbols.getClass(id)
-    infoCache.get.cached(cd, context.symbols) {
+    infoCache.get.cached(cd.id, context.symbols) {
       assert(isCandidate(id))
 
       val classes = cd +: cd.descendants
       val extraConstructors: Seq[Identifier] = classes
         .filter(cd => (cd.flags contains s.IsAbstract) && !(cd.flags contains s.IsSealed))
-        .map(cd => constructorCache.cached(cd, symbols)(FreshIdentifier("Open")))
+        .map(cd => constructorCache.cached(cd.id, symbols)(FreshIdentifier("Open")))
 
       val constructors = classes.filterNot(_.flags contains s.IsAbstract).map(_.id) ++ extraConstructors
 

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -13,6 +13,8 @@ trait AdtSpecialization
   val s: Trees
   val t: Trees
 
+  override val phaseName = "oo.AdtSpecialization"
+
   private[this] def root(id: Identifier)(implicit symbols: s.Symbols): Identifier = {
     symbols.getClass(id).parents.map(ct => root(ct.id)).headOption.getOrElse(id)
   }

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -23,7 +23,7 @@ trait AdtSpecialization
   private[this] def isCandidate(id: Identifier)(implicit symbols: s.Symbols): Boolean = {
     import s._
     val cd = symbols.getClass(id)
-    candidateCache.cached(cd.id, symbols)(cd.parents match {
+    candidateCache.cached(cd, symbols)(cd.parents match {
       case Nil =>
         def rec(cd: s.ClassDef): Boolean = {
           val cs = cd.children
@@ -59,13 +59,13 @@ trait AdtSpecialization
     import context.{s => _, t => _, _}
 
     val cd = context.symbols.getClass(id)
-    infoCache.get.cached(cd.id, context.symbols) {
+    infoCache.get.cached(cd, context.symbols) {
       assert(isCandidate(id))
 
       val classes = cd +: cd.descendants
       val extraConstructors: Seq[Identifier] = classes
         .filter(cd => (cd.flags contains s.IsAbstract) && !(cd.flags contains s.IsSealed))
-        .map(cd => constructorCache.cached(cd.id, symbols)(FreshIdentifier("Open")))
+        .map(cd => constructorCache.cached(cd, symbols)(FreshIdentifier("Open")))
 
       val constructors = classes.filterNot(_.flags contains s.IsAbstract).map(_.id) ++ extraConstructors
 

--- a/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
@@ -29,12 +29,5 @@ trait ClassSymbols { self: Trees =>
       this.sorts,
       this.classes ++ classes.map(cd => cd.id -> cd)
     )
-
-    override def filterObjects(objs: Set[String]) = {
-      NoSymbols.
-        withFunctions(this.functions.values.toSeq.filter { fd => objs.contains(fd.id.name) }).
-        withSorts(this.sorts.values.toSeq.filter { s => objs.contains(s.id.name) }).
-        withClasses(this.classes.values.toSeq.filter { cd => objs.contains(cd.id.name) })
-    }
   }
 }

--- a/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ClassSymbols.scala
@@ -29,5 +29,12 @@ trait ClassSymbols { self: Trees =>
       this.sorts,
       this.classes ++ classes.map(cd => cd.id -> cd)
     )
+
+    override def filterObjects(objs: Set[String]) = {
+      NoSymbols.
+        withFunctions(this.functions.values.toSeq.filter { fd => objs.contains(fd.id.name) }).
+        withSorts(this.sorts.values.toSeq.filter { s => objs.contains(s.id.name) }).
+        withClasses(this.classes.values.toSeq.filter { cd => objs.contains(cd.id.name) })
+    }
   }
 }

--- a/core/src/main/scala/stainless/extraction/oo/Definitions.scala
+++ b/core/src/main/scala/stainless/extraction/oo/Definitions.scala
@@ -41,6 +41,9 @@ trait Definitions extends imperative.Trees { self: Trees =>
     def descendants(implicit s: Symbols): Seq[ClassDef] =
       children.flatMap(cd => cd +: cd.descendants).distinct
 
+    def descendantsIdsWithSelf(implicit s: Symbols): Set[Identifier] =
+      descendants(s).map(_.id).toSet + id
+
     def typeArgs = tparams map (_.tp)
 
     def typed(tps: Seq[Type])(implicit s: Symbols): TypedClassDef = TypedClassDef(this, tps)

--- a/core/src/main/scala/stainless/extraction/oo/DependencyGraph.scala
+++ b/core/src/main/scala/stainless/extraction/oo/DependencyGraph.scala
@@ -67,9 +67,14 @@ trait DependencyGraph extends ast.DependencyGraph {
         .collectFirst { case HasADTInvariant(id) => id }
         .foreach { inv => g += SimpleEdge(cd.id, inv) }
 
-      cd.descendants(symbols) foreach { dd =>
-        g += SimpleEdge(cd.id, dd.id)
+      for (p <- cd.parents) {
+        g += SimpleEdge(cd.id, p.id)
       }
+
+      if (cd.flags.contains(IsSealed))
+        cd.children(symbols) foreach { dd =>
+          g += SimpleEdge(cd.id, dd.id)
+        }
     }
 
     g

--- a/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
@@ -8,7 +8,9 @@ trait CachingPhase extends extraction.CachingPhase { self =>
   val s: Trees
 
   protected type ClassResult
-  private lazy val classCache = ExtractionCache[s.ClassDef, ClassResult]()
+  private lazy val classCache = new ExtractionCache[Set[Identifier], s.ClassDef, ClassResult](
+    (cd, syms) => cd.descendantsIdsWithSelf(syms)
+  )
 
   protected def extractClass(context: TransformerContext, cd: s.ClassDef): ClassResult
   protected def registerClasses(symbols: t.Symbols, classes: Seq[ClassResult]): t.Symbols

--- a/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
@@ -17,7 +17,7 @@ trait CachingPhase extends extraction.CachingPhase { self =>
     registerClasses(
       super.extractSymbols(context, symbols),
       symbols.classes.values.map { cd =>
-        classCache.cached(cd.id, symbols)(extractClass(context, cd))
+        classCache.cached(cd, symbols)(extractClass(context, cd))
       }.toSeq
     )
   }

--- a/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
@@ -8,7 +8,7 @@ trait CachingPhase extends extraction.CachingPhase { self =>
   val s: Trees
 
   protected type ClassResult
-  private lazy val classCache = new ExtractionCache[s.ClassDef, ClassResult]
+  private lazy val classCache = ExtractionCache[s.ClassDef, ClassResult]()
 
   protected def extractClass(context: TransformerContext, cd: s.ClassDef): ClassResult
   protected def registerClasses(symbols: t.Symbols, classes: Seq[ClassResult]): t.Symbols
@@ -17,7 +17,7 @@ trait CachingPhase extends extraction.CachingPhase { self =>
     registerClasses(
       super.extractSymbols(context, symbols),
       symbols.classes.values.map { cd =>
-        classCache.cached(cd, symbols)(extractClass(context, cd))
+        classCache.cached(cd.id, symbols)(extractClass(context, cd))
       }.toSeq
     )
   }

--- a/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
+++ b/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
@@ -10,6 +10,8 @@ trait RefinementLifting extends CachingPhase with SimpleFunctions with SimpleCla
   val s: Trees
   val t: Trees
 
+  override val phaseName = "oo.RefinementLifting"
+
   override protected type SortResult = (t.ADTSort, Option[t.FunDef])
   override protected def registerSorts(symbols: t.Symbols, sorts: Seq[(t.ADTSort, Option[t.FunDef])]): t.Symbols =
     symbols.withSorts(sorts.map(_._1)).withFunctions(sorts.flatMap(_._2))

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -510,7 +510,7 @@ trait TypeEncoding
   private[this] def sortInfo(id: Identifier)(implicit context: TransformerContext): SortInfo = {
     import context.{symbols, emptyScope => scope}
     val sort = symbols.getSort(id)
-    sortCache.cached(sort.id, symbols) {
+    sortCache.cached(sort, symbols) {
       val convertFunction: t.FunDef = {
         val (in, out) = (sort.typeArgs.map(_.freshen), sort.typeArgs.map(_.freshen))
         val tin = in.map(tp => scope.transform(tp).asInstanceOf[t.TypeParameter])
@@ -578,7 +578,7 @@ trait TypeEncoding
   private[this] def classInfo(id: Identifier)(implicit context: TransformerContext): ClassInfo = {
     import context.symbols
     val cd = symbols.getClass(id)
-    classCache.get(symbols).cached(cd.id, symbols) {
+    classCache.get(symbols).cached(cd, symbols) {
       import OptionSort._
 
       val classes = cd +: cd.descendants

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -17,6 +17,8 @@ trait TypeEncoding
   val s: Trees
   val t: Trees
 
+  override val phaseName = "oo.TypeEncoding"
+
   import t._
   import t.dsl._
   import s.TypeParameterWrapper

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -506,7 +506,10 @@ trait TypeEncoding
 
   private class SortInfo(val functions: Seq[t.FunDef])
 
-  private[this] val sortCache = ExtractionCache[s.ADTSort, SortInfo]()
+  private[this] val sortCache = new ExtractionCache[Set[Identifier], s.ADTSort, SortInfo](
+    (sd, syms) => sd.constructors.map(_.id).toSet + sd.id
+  )
+
   private[this] def sortInfo(id: Identifier)(implicit context: TransformerContext): SortInfo = {
     import context.{symbols, emptyScope => scope}
     val sort = symbols.getSort(id)
@@ -574,7 +577,9 @@ trait TypeEncoding
     val sorts: Seq[t.ADTSort]
   )
 
-  private[this] val classCache = OptionSort.cached(ExtractionCache[s.ClassDef, ClassInfo]())
+  private[this] val classCache = OptionSort.cached(new ExtractionCache[Set[Identifier], s.ClassDef, ClassInfo](
+    (cd, syms) => cd.descendantsIdsWithSelf(syms)
+  ))
   private[this] def classInfo(id: Identifier)(implicit context: TransformerContext): ClassInfo = {
     import context.symbols
     val cd = symbols.getClass(id)

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -506,11 +506,11 @@ trait TypeEncoding
 
   private class SortInfo(val functions: Seq[t.FunDef])
 
-  private[this] val sortCache = new ExtractionCache[s.ADTSort, SortInfo]
+  private[this] val sortCache = ExtractionCache[s.ADTSort, SortInfo]()
   private[this] def sortInfo(id: Identifier)(implicit context: TransformerContext): SortInfo = {
     import context.{symbols, emptyScope => scope}
     val sort = symbols.getSort(id)
-    sortCache.cached(sort, symbols) {
+    sortCache.cached(sort.id, symbols) {
       val convertFunction: t.FunDef = {
         val (in, out) = (sort.typeArgs.map(_.freshen), sort.typeArgs.map(_.freshen))
         val tin = in.map(tp => scope.transform(tp).asInstanceOf[t.TypeParameter])
@@ -574,11 +574,11 @@ trait TypeEncoding
     val sorts: Seq[t.ADTSort]
   )
 
-  private[this] val classCache = OptionSort.cached(new ExtractionCache[s.ClassDef, ClassInfo])
+  private[this] val classCache = OptionSort.cached(ExtractionCache[s.ClassDef, ClassInfo]())
   private[this] def classInfo(id: Identifier)(implicit context: TransformerContext): ClassInfo = {
     import context.symbols
     val cd = symbols.getClass(id)
-    classCache.get(symbols).cached(cd, symbols) {
+    classCache.get(symbols).cached(cd.id, symbols) {
       import OptionSort._
 
       val classes = cd +: cd.descendants

--- a/core/src/main/scala/stainless/extraction/oo/package.scala
+++ b/core/src/main/scala/stainless/extraction/oo/package.scala
@@ -23,6 +23,8 @@ package object oo {
       override val t: imperative.trees.type = imperative.trees
     })
 
+    import utils.PositionChecker
+
     AdtSpecialization(trees, trees) andThen
     RefinementLifting(trees, trees) andThen
     TypeEncoding(trees, trees)      andThen

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -73,6 +73,8 @@ package object extraction {
     extends Exception(msg)
 
   def pipeline(implicit ctx: inox.Context): StainlessPipeline = {
+    import utils.PositionChecker
+
     xlang.extractor      andThen
     methods.extractor    andThen
     throwing.extractor   andThen
@@ -98,6 +100,7 @@ package object extraction {
     override val s: extraction.trees.type = extraction.trees
     override val t: to.type = to
     override val context = ctx
+    override val phaseName = "completer"
 
     override def invalidate(id: Identifier): Unit = ()
     override def extract(symbols: s.Symbols): t.Symbols = completeSymbols(symbols)(to)

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -102,6 +102,8 @@ package object extraction {
     override val context = ctx
     override val phaseName = "completer"
 
+    override val debugTransformation = true
+
     override def invalidate(id: Identifier): Unit = ()
     override def extract(symbols: s.Symbols): t.Symbols = completeSymbols(symbols)(to)
   }

--- a/core/src/main/scala/stainless/extraction/throwing/ExceptionLifting.scala
+++ b/core/src/main/scala/stainless/extraction/throwing/ExceptionLifting.scala
@@ -8,6 +8,8 @@ trait ExceptionLifting extends oo.SimplePhase { self =>
   val s: Trees
   val t: oo.Trees
 
+  override val phaseName = "throwing.ExceptionLifting"
+
   override protected type TransformerContext = transformer.type
   override protected def getContext(symbols: s.Symbols) = transformer
   protected object transformer extends oo.TreeTransformer {

--- a/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
+++ b/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
@@ -1,0 +1,44 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package extraction
+package utils
+
+import inox.utils.{Position, NoPosition}
+
+object DebugSectionPositions extends inox.DebugSection("positions")
+
+/** Inspect trees, detecting missing positions. */
+object PositionChecker {
+
+  def apply(phaseName: String)(tr: ast.Trees)(context: inox.Context): tr.TreeTraverser { val trees: tr.type } = new tr.TreeTraverser {
+    val trees: tr.type = tr
+    import trees._
+
+    private implicit val debuSection = DebugSectionPositions
+
+    private var lastKnownPosition: Position = NoPosition
+
+    override def traverse(fd: FunDef): Unit = {
+      if (fd.flags.contains(Synthetic)) return ()
+      traverse(fd.id)
+      fd.tparams.foreach(traverse)
+      fd.params.foreach(traverse)
+      traverse(fd.returnType)
+      traverse(fd.fullBody)
+      fd.flags.foreach(traverse)
+    }
+
+    override def traverse(e: Expr): Unit = {
+      if (!e.getPos.isDefined) {
+        context.reporter.debug(NoPosition, s"Missing position for expression '$e' (of type ${e.getClass}) after phase '$phaseName'. Last known position: $lastKnownPosition")
+      } else {
+        lastKnownPosition = e.getPos
+      }
+
+      super.traverse(e)
+    }
+  }
+
+}
+

--- a/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
+++ b/core/src/main/scala/stainless/extraction/utils/PositionChecker.scala
@@ -15,7 +15,7 @@ object PositionChecker {
 
   private[this] val seen: MutableHashSet[ast.Trees#Expr] = MutableHashSet.empty
 
-  def apply(phaseName: String)(tr: ast.Trees)(context: inox.Context): tr.TreeTraverser { val trees: tr.type } = new tr.TreeTraverser {
+  def apply(phaseName: String)(tr: ast.Trees)(context: inox.Context)(before: Boolean): tr.TreeTraverser { val trees: tr.type } = new tr.TreeTraverser {
     val trees: tr.type = tr
     import trees._
 
@@ -37,7 +37,8 @@ object PositionChecker {
       if (seen contains e) return ()
 
       if (!e.getPos.isDefined) {
-        context.reporter.debug(NoPosition, s"After $phaseName: Missing position for expression '$e' (of type ${e.getClass}). Last known position: $lastKnownPosition")
+        val word = if (before) "Before" else "After"
+        context.reporter.debug(NoPosition, s"$word $phaseName: Missing position for expression '$e' (of type ${e.getClass}). Last known position: $lastKnownPosition")
       } else {
         lastKnownPosition = e.getPos
       }

--- a/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
+++ b/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
@@ -31,7 +31,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
 
       val cache = ExtractionCache[s.ADTSort, t.FunDef]()
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
-        case Some(sort) => cache.cached(sort.id, symbols) {
+        case Some(sort) => cache.cached(sort, symbols) {
           createFunction(sort.id, sort.constructors.find(_.fields.isEmpty).get.id)
         }
         case None => syntheticFunction
@@ -55,7 +55,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
 
       val cache = ExtractionCache[s.ADTSort, t.FunDef]()
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
-        case Some(sort) => cache.cached(sort.id, symbols) {
+        case Some(sort) => cache.cached(sort, symbols) {
           val some = sort.constructors.find(_.fields.nonEmpty).get
           createFunction(sort.id, some.id, some.fields.head.id)
         }

--- a/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
+++ b/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
@@ -29,9 +29,9 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
         syntheticOption.id,
         syntheticOption.constructors.find(_.fields.isEmpty).get.id)
 
-      val cache = new ExtractionCache[s.ADTSort, t.FunDef]
+      val cache = ExtractionCache[s.ADTSort, t.FunDef]()
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
-        case Some(sort) => cache.cached(sort, symbols) {
+        case Some(sort) => cache.cached(sort.id, symbols) {
           createFunction(sort.id, sort.constructors.find(_.fields.isEmpty).get.id)
         }
         case None => syntheticFunction
@@ -53,9 +53,9 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
         createFunction(syntheticOption.id, some.id, some.fields.head.id)
       }
 
-      val cache = new ExtractionCache[s.ADTSort, t.FunDef]
+      val cache = ExtractionCache[s.ADTSort, t.FunDef]()
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
-        case Some(sort) => cache.cached(sort, symbols) {
+        case Some(sort) => cache.cached(sort.id, symbols) {
           val some = sort.constructors.find(_.fields.nonEmpty).get
           createFunction(sort.id, some.id, some.fields.head.id)
         }

--- a/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
+++ b/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
@@ -20,7 +20,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
     private[this] val syntheticIsEmpty: s.Symbols => t.FunDef = {
       def createFunction(option: Identifier, none: Identifier): t.FunDef = {
         val isEmpty = ast.SymbolIdentifier("stainless.lang.Option.isEmpty")
-        mkFunDef(isEmpty, t.Unchecked)("A") {
+        mkFunDef(isEmpty, t.Unchecked, t.Synthetic)("A") {
           case Seq(aT) => (Seq("x" :: T(option)(aT)), t.BooleanType(), { case Seq(v) => v is none })
         }
       }
@@ -41,7 +41,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
     private[this] val syntheticGet: s.Symbols => t.FunDef = {
       def createFunction(option: Identifier, some: Identifier, value: Identifier): t.FunDef = {
         val get = ast.SymbolIdentifier("stainless.lang.Option.get")
-        mkFunDef(get, t.Unchecked)("A") {
+        mkFunDef(get, t.Unchecked, t.Synthetic)("A") {
           case Seq(aT) => (Seq("x" :: T(option)(aT)), aT, {
             case Seq(v) => t.Require(v is some, v.getField(value))
           })

--- a/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
+++ b/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
@@ -29,7 +29,9 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
         syntheticOption.id,
         syntheticOption.constructors.find(_.fields.isEmpty).get.id)
 
-      val cache = ExtractionCache[s.ADTSort, t.FunDef]()
+      val cache = new ExtractionCache[Set[Identifier], s.ADTSort, t.FunDef](
+        (sd, syms) => sd.constructors.map(_.id).toSet + sd.id
+      )
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
         case Some(sort) => cache.cached(sort, symbols) {
           createFunction(sort.id, sort.constructors.find(_.fields.isEmpty).get.id)
@@ -53,7 +55,9 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
         createFunction(syntheticOption.id, some.id, some.fields.head.id)
       }
 
-      val cache = ExtractionCache[s.ADTSort, t.FunDef]()
+      val cache = new ExtractionCache[Set[Identifier], s.ADTSort, t.FunDef](
+        (sd, syms) => sd.constructors.map(_.id).toSet + sd.id
+      )
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
         case Some(sort) => cache.cached(sort, symbols) {
           val some = sort.constructors.find(_.fields.nonEmpty).get

--- a/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
@@ -10,6 +10,8 @@ trait PartialFunctions extends oo.SimplePhase { self =>
   val t: self.s.type
   import s._
 
+  override val phaseName = "xlang.PartialFunctions"
+
   override protected def getContext(symbols: Symbols) = new TransformerContext(symbols)
   protected class TransformerContext(symbols: s.Symbols) extends oo.TreeTransformer {
     override final val s: self.s.type = self.s

--- a/core/src/main/scala/stainless/extraction/xlang/package.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/package.scala
@@ -27,6 +27,7 @@ package object xlang {
       override val s: trees.type = trees
       override val t: methods.trees.type = methods.trees
       override val context = ctx
+      override val phaseName = "xlang"
 
       override protected type TransformerContext = identity.type
       override protected def getContext(symbols: s.Symbols) = identity

--- a/core/src/main/scala/stainless/verification/PartialEvaluation.scala
+++ b/core/src/main/scala/stainless/verification/PartialEvaluation.scala
@@ -15,6 +15,8 @@ trait PartialEvaluation
   val s: extraction.Trees
   val t: s.type
 
+  override val phaseName = "PartialEvaluation"
+
   import context._
   import s._
 


### PR DESCRIPTION
Integrates https://github.com/epfl-lara/stainless/pull/308 https://github.com/epfl-lara/stainless/pull/318 and https://github.com/epfl-lara/stainless/pull/332.

We now add a dependency edge from a class to its parent, and don't add dependency edges from non-sealed classes to their subclasses. The keys for a few caches were changed to include the descendants of a class (or the constructors of a sort).  There might a few more caches to change (e.g. the `classCache` in `MethodLifting` or the caches in `SyntheticSorts`).