### PR TITLE
Assertions for operations on unsigned bitvectors

### DIFF
--- a/core/src/main/scala/stainless/codegen/runtime/GenericValues.scala
+++ b/core/src/main/scala/stainless/codegen/runtime/GenericValues.scala
@@ -11,7 +11,7 @@ object GenericValues {
   private[this] var gvToI = ScalaMap[ast.Trees#GenericValue, Int]()
   private[this] var iTogv = ScalaMap[Int, ast.Trees#GenericValue]()
 
-  def register(gv: ast.Trees#GenericValue): Int = {
+  def register(gv: ast.Trees#GenericValue): Int = synchronized {
     if (gvToI contains gv) {
       gvToI(gv)
     } else {
@@ -22,7 +22,7 @@ object GenericValues {
     }
   }
 
-  def get(i: Int): java.lang.Object = {
+  def get(i: Int): java.lang.Object = synchronized {
     iTogv(i)
   }
 }


### PR DESCRIPTION
* `a + b`: check that `a + b >= a`
* `a - b`: check that `b <= a`
* `a * b`: check that `a = 0` or `(a * b) / a = b`
* `a / b`: check that `b != 0` (that should be enough for unsigned division?)