### PR TITLE
Make equations go backwards for better line number reporting

### DIFF
--- a/frontends/benchmarks/verification/invalid/Equations1.scala
+++ b/frontends/benchmarks/verification/invalid/Equations1.scala
@@ -3,9 +3,9 @@ import stainless.annotation._
 import stainless.lang._
 
 object Equations1 {
-  @library
-  def makeEqual(x: BigInt, y: BigInt) = {
-    true
+  @extern
+  def makeEqual(x: BigInt, y: BigInt): Unit = {
+    (??? : Unit)
   } ensuring(_ => x == y)
 
   def f(x: BigInt, y: BigInt) = {

--- a/frontends/benchmarks/verification/invalid/Equations1.scala
+++ b/frontends/benchmarks/verification/invalid/Equations1.scala
@@ -1,0 +1,16 @@
+import stainless.equations._
+import stainless.annotation._
+import stainless.lang._
+
+object Equations1 {
+  @library
+  def makeEqual(x: BigInt, y: BigInt) = {
+    true
+  } ensuring(_ => x == y)
+
+  def f(x: BigInt, y: BigInt) = {
+    x ==:| makeEqual(x,y) |:
+    y ==:| trivial |:
+    x
+  }
+}

--- a/frontends/benchmarks/verification/invalid/Equations2.scala
+++ b/frontends/benchmarks/verification/invalid/Equations2.scala
@@ -1,0 +1,16 @@
+import stainless.equations._
+import stainless.annotation._
+import stainless.lang._
+
+object Equations2 {
+  @library
+  def makeEqual(x: BigInt, y: BigInt) = {
+    true
+  } ensuring(_ => x == y)
+
+  def f(x: BigInt, y: BigInt) = {
+    x ==:| trivial |:
+    y ==:| makeEqual(x,y) |:
+    x
+  }
+}

--- a/frontends/benchmarks/verification/invalid/Equations2.scala
+++ b/frontends/benchmarks/verification/invalid/Equations2.scala
@@ -3,9 +3,9 @@ import stainless.annotation._
 import stainless.lang._
 
 object Equations2 {
-  @library
-  def makeEqual(x: BigInt, y: BigInt) = {
-    true
+  @extern
+  def makeEqual(x: BigInt, y: BigInt): Unit = {
+    (??? : Unit)
   } ensuring(_ => x == y)
 
   def f(x: BigInt, y: BigInt) = {

--- a/frontends/benchmarks/verification/invalid/Equations3.scala
+++ b/frontends/benchmarks/verification/invalid/Equations3.scala
@@ -3,9 +3,9 @@ import stainless.annotation._
 import stainless.lang._
 
 object Equations3 {
-  @library
-  def makeEqual(x: BigInt, y: BigInt) = {
-    true
+  @extern
+  def makeEqual(x: BigInt, y: BigInt): Unit = {
+    (??? : Unit)
   } ensuring(_ => x == y)
 
   def f(x: BigInt, y: BigInt, z: BigInt) = {

--- a/frontends/benchmarks/verification/invalid/Equations3.scala
+++ b/frontends/benchmarks/verification/invalid/Equations3.scala
@@ -1,0 +1,21 @@
+import stainless.equations._
+import stainless.annotation._
+import stainless.lang._
+
+object Equations3 {
+  @library
+  def makeEqual(x: BigInt, y: BigInt) = {
+    true
+  } ensuring(_ => x == y)
+
+  def f(x: BigInt, y: BigInt, z: BigInt) = {
+    (
+      x ==:| makeEqual(x,y) |:
+      y ==:| makeEqual(y,z) |:
+      z
+    ).qed
+
+    assert(x == z) // OK
+    assert(z == y) // Not OK, as we don't want the internals of equations to leak outside
+  }
+}

--- a/frontends/benchmarks/verification/valid/Equations.scala
+++ b/frontends/benchmarks/verification/valid/Equations.scala
@@ -1,0 +1,17 @@
+import stainless.equations._
+import stainless.annotation._
+import stainless.lang._
+
+object Equations {
+  @library
+  def makeEqual(x: BigInt, y: BigInt) = {
+    true
+  } ensuring(_ => x == y)
+
+  def f(x: BigInt, y: BigInt, z: BigInt, t: BigInt) = {
+    x ==:| makeEqual(x,y) |:
+    y ==:| makeEqual(y,z) |:
+    z ==:| makeEqual(z,t) |:
+    t
+  }
+}

--- a/frontends/benchmarks/verification/valid/Equations.scala
+++ b/frontends/benchmarks/verification/valid/Equations.scala
@@ -3,9 +3,9 @@ import stainless.annotation._
 import stainless.lang._
 
 object Equations {
-  @library
-  def makeEqual(x: BigInt, y: BigInt) = {
-    true
+  @extern
+  def makeEqual(x: BigInt, y: BigInt): Unit = {
+    (??? : Unit)
   } ensuring(_ => x == y)
 
   def f(x: BigInt, y: BigInt, z: BigInt, t: BigInt) = {

--- a/frontends/library/stainless/equations/package.scala
+++ b/frontends/library/stainless/equations/package.scala
@@ -21,33 +21,22 @@ package object equations {
   def trivial: Boolean = true
 
   @library @inline
-  implicit def any2EqProof[A](x: => A): EqProof[A] = EqProof(() => x, () => x)
+  implicit def any2EqEvidence[A](x: => A): EqEvidence[A] = EqEvidence(() => x, () => x, () => true)
 
   @library
   case class EqEvidence[A](x: () => A, y: () => A, evidence: () => Boolean) {
     require(x() == y() && evidence())
 
     @inline
-    def |(that: EqProof[A]): EqProof[A] = {
-      require(evidence() ==> (y() == that.x()))
-      EqProof(x, that.y)
-    }
-
-    @inline
-    def |(that: EqEvidence[A]): EqEvidence[A] = {
-      require(evidence() ==> (y() == that.x()))
-      EqEvidence(x, that.y, that.evidence)
-    }
-  }
-
-  @library
-  case class EqProof[A](x: () => A, y: () => A) {
-    require(x() == y())
-
-    @inline
     def ==|(proof: => Boolean): EqEvidence[A] = {
       require(proof)
       EqEvidence(x, y, () => proof)
+    }
+
+    @inline
+    def |:(prev: EqEvidence[A]): EqEvidence[A] = {
+      require(prev.evidence() ==> (prev.y() == x()))
+      EqEvidence(prev.x, y, prev.evidence)
     }
 
     @inline

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -134,5 +134,4 @@ package object lang {
   def print(x: String): Unit = {
     scala.Predef.print(x)
   }
-
 }


### PR DESCRIPTION
This PR makes equations right-associative instead of left-associative to get better positions in reports.
(This assumes missing positions are fixed with https://github.com/epfl-lara/stainless/pull/340)

In this program
```scala
import stainless.equations._

object LineNumbers {
  def f(x: BigInt, y: BigInt, z: BigInt, t: BigInt, b1: Boolean, b2: Boolean, b3: Boolean) = {
    x ==| b1 |
    y ==| b2 |
    z ==| b3 |
    t
  }
}
```
the expression appears to be parsed as:
```scala
    (((x ==| b1) |
    (y ==| b2)) |
    (z ==| b3)) |
    t
```
Since every function invocation of `|` starts at line 5, we get the following report, which can make it difficult to understand which step of proof fails or takes longer than other steps.
```
[  Info  ]   ┌───────────────────┐
[  Info  ] ╔═╡ stainless summary ╞══════════════════════════════════════════════════════════════════════╗
[  Info  ] ║ └───────────────────┘                                                                      ║
[  Info  ] ║ f  body assertion: Inlined precondition of ==|   invalid   nativez3  Test.scala:5:5  0,535 ║
[  Info  ] ║ f  body assertion: Inlined precondition of |     invalid   nativez3  Test.scala:5:5  0,541 ║
[  Info  ] ║ f  body assertion: Inlined precondition of |     invalid   nativez3  Test.scala:5:5  0,116 ║
[  Info  ] ║ f  body assertion: Inlined precondition of |     invalid   nativez3  Test.scala:5:5  0,119 ║
[  Info  ] ║ f  body assertion: Inlined precondition of ==|   invalid   nativez3  Test.scala:6:5  0,531 ║
[  Info  ] ║ f  body assertion: Inlined precondition of ==|   invalid   nativez3  Test.scala:7:5  0,517 ║
[  Info  ] ╟┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄╢
[  Info  ] ║ total: 6    valid: 0    (0 from cache) invalid: 6    unknown: 0    time:   2,359           ║
[  Info  ] ╚════════════════════════════════════════════════════════════════════════════════════════════╝
```


If instead we write `|:` to get right-associativity
```scala
import stainless.equations._

object LineNumbers {
  def f(x: BigInt, y: BigInt, z: BigInt, t: BigInt, b1: Boolean, b2: Boolean, b3: Boolean) = {
    x ==| b1 |:
    y ==| b2 |:
    z ==| b3 |:
    t
  }
}
```
we get:
```
[  Info  ]   ┌───────────────────┐
[  Info  ] ╔═╡ stainless summary ╞══════════════════════════════════════════════════════════════════════╗
[  Info  ] ║ └───────────────────┘                                                                      ║
[  Info  ] ║ f  body assertion: Inlined precondition of ==|   invalid  nativez3  Test.scala:5:17  0,455 ║
[  Info  ] ║ f  body assertion: Inlined precondition of |:    invalid  nativez3  Test.scala:5:26  0,124 ║
[  Info  ] ║ f  body assertion: Inlined precondition of ==|   invalid  nativez3  Test.scala:6:17  0,445 ║
[  Info  ] ║ f  body assertion: Inlined precondition of |:    invalid  nativez3  Test.scala:6:26  0,141 ║
[  Info  ] ║ f  body assertion: Inlined precondition of ==|   invalid  nativez3  Test.scala:7:17  0,445 ║
[  Info  ] ║ f  body assertion: Inlined precondition of |:    invalid  nativez3  Test.scala:7:26  0,460 ║
[  Info  ] ╟┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄╢
[  Info  ] ║ total: 6    valid: 0    (0 from cache) invalid: 6    unknown: 0    time:   2,070           ║
[  Info  ] ╚════════════════════════════════════════════════════════════════════════════════════════════╝
```