### PR TITLE
Add `gh-pages` target to documentation Makefile.

### DIFF
--- a/core/src/sphinx/Makefile
+++ b/core/src/sphinx/Makefile
@@ -19,7 +19,16 @@ ALLSPHINXOPTS   = -d $(BUILDDIR)/doctrees $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 # the i18n builder cannot share the environment and doctrees with the others
 I18NSPHINXOPTS  = $(PAPEROPT_$(PAPER)) $(SPHINXOPTS) .
 
-.PHONY: help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+.PHONY: gh-pages help clean html dirhtml singlehtml pickle json htmlhelp qthelp devhelp epub latex latexpdf text man changes linkcheck doctest gettext
+
+gh-pages:
+	$(MAKE) html
+	cd $(BUILDDIR)/html && \
+	touch .nojekyll _static/.nojekyll _images/.nojekyll _sources/.nojekyll && \
+	git init && \
+	git add . && \
+	git commit -am "Update documentation" && \
+	git push -f git@github.com:epfl-lara/stainless.git master:gh-pages
 
 help:
 	@echo "Please use \`make <target>' where <target> is one of"


### PR DESCRIPTION
Running `make gh-pages` from the `core/src/sphinx/` directory will now build the documentation,
and upload it to the `gh-pages` branch of the repository, overwriting anything that was there
beforehand, which is okay since the documentation sources are properly versioned in the `master` branch.