### PR TITLE
Fix dependency computation for adding edges to overrides

### DIFF
--- a/core/src/main/scala/stainless/extraction/methods/DependencyGraph.scala
+++ b/core/src/main/scala/stainless/extraction/methods/DependencyGraph.scala
@@ -59,7 +59,7 @@ trait DependencyGraph extends oo.DependencyGraph with CallGraph {
           case IsMethodOf(cid) =>
             // we look at transitive edges in `res` rather than in `g` in 
             // order to take into account newly added edges
-            for (n <- res.transitivePred(fd.id) & res.transitivePred(cid)) {
+            for (n <- (res.transitivePred(fd.id) + fd.id) & (res.transitivePred(cid) + cid)) {
               res += SimpleEdge(n, oid)
             }
         }


### PR DESCRIPTION
Fixes the crash on the file (see issue #359):

```scala
import stainless.lang._

object TraitVar2 {

  sealed trait Foo {
    var prop: BigInt

    def doStuff(x: BigInt) = {
      prop = x
    }
  }

  case class Bar(var stuff: BigInt) extends Foo {
    def prop: BigInt = stuff + 1
    def prop_=(y: BigInt): Unit = {
      stuff = y * 2
    }
  }

  def theorem(foo: Foo) = {
    require(foo.isInstanceOf[Bar])
    foo.doStuff(2)
    foo.prop == 5
  }.holds

}
```

In this example, we have (among others) the following dependencies:
* `prop_` from `Foo` depends on `Foo`
* `Foo` depends on `Bar`

`addEdgesToOverrides` should then add an edge from the `prop_` of `Foo` to the `prop_` of `Bar`. This was not done properly because the intersection which is ranged by `n` did not include the `prop_` of  `Foo`. This is fixed by adding `fd.id` (and `cid`) before taking the intersection. 
(We needed the reflexive and transitive closure of `pred` instead of just the transitive closure)