### PR TITLE
Use TransformerContext in CacheKey computations

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -25,7 +25,10 @@ trait MainHelpers extends inox.MainHelpers {
   override protected def getOptions = super.getOptions - inox.solvers.optAssumeChecked ++ Map(
     optFunctions -> Description(General, "Only consider functions f1,f2,..."),
     extraction.utils.optDebugObjects -> Description(General, "Only print debug output for functions/adts named o1,o2,..."),
-    extraction.utils.optDebugPhases -> Description(General, "Only print debug output for phases whose name contain p1 or p2 or ..."),
+    extraction.utils.optDebugPhases -> Description(General, {
+      "Only print debug output for phases p1,p2,...\nAvailable: " +
+      extraction.phases.map { case (name, desc) => f"\n  $name%-26s : $desc" }.mkString("")
+    }),
     evaluators.optCodeGen -> Description(Evaluators, "Use code generating evaluator"),
     codegen.optInstrumentFields -> Description(Evaluators, "Instrument ADT field access during code generation"),
     codegen.optSmallArrays -> Description(Evaluators, "Assume all arrays fit into memory during code generation"),

--- a/core/src/main/scala/stainless/extraction/ExtractionCaches.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionCaches.scala
@@ -50,9 +50,6 @@ trait ExtractionCaches { self: ExtractionContext =>
     def apply(fd: s.FunDef): CacheKey = new FunctionKey(fd)
   }
 
-  final def funKeys(fds: Set[s.FunDef]): CacheKey =
-    SetKey(fds.map(FunctionKey(_)))
-
   private final class SortKey private(private val sort: s.ADTSort) extends CacheKey {
     override def dependencies = Set(sort.id)
 
@@ -79,9 +76,6 @@ trait ExtractionCaches { self: ExtractionContext =>
     def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = apply(symbols.sorts(id))
     def apply(sort: s.ADTSort): CacheKey = new SortKey(sort)
   }
-
-  final def sortKeys(sorts: Set[s.ADTSort]): CacheKey =
-    SetKey(sorts.map(SortKey(_)))
 
   /** Returns a [[SimpleKey]] given some identifier and the symbols from which
     * it was taken.
@@ -132,8 +126,12 @@ trait ExtractionCaches { self: ExtractionContext =>
 
   object SetKey {
     def apply(keys: Set[CacheKey]): SetKey = new SetKey(keys)
-    def apply(ids: Set[Identifier])(implicit syms: s.Symbols): SetKey = 
+    def apply(ids: Set[Identifier])(implicit syms: s.Symbols): SetKey =
       SetKey(ids.map(getSimpleKey))
+    def apply[T: Keyable](elems: Set[T]): SetKey = {
+      val gen = implicitly[Keyable[T]]
+      SetKey(elems.map(gen.apply))
+    }
   }
 
 

--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -16,11 +16,15 @@ trait AntiAliasing
 
   // Function rewriting depends on the effects analysis which relies on all dependencies
   // of the function, so we use a dependency cache here.
-  override protected final val funCache = new DependencyCache[s.FunDef, FunctionResult]
+  override protected final val funCache = new ExtractionCache[s.FunDef, FunctionResult]((fd, context) => 
+    getDependencyKey(fd.id)(context.symbols)
+  )
 
   // Function types are rewritten by the transformer depending on the result of the
   // effects analysis, so we again use a dependency cache here.
-  override protected final val sortCache = new DependencyCache[s.ADTSort, SortResult]
+  override protected final val sortCache = new ExtractionCache[s.ADTSort, SortResult]((sort, context) => 
+    getDependencyKey(sort.id)(context.symbols)
+  )
 
   override protected type FunctionResult = Option[FunDef]
   override protected def registerFunctions(symbols: t.Symbols, functions: Seq[Option[t.FunDef]]): t.Symbols =

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -16,6 +16,7 @@ trait ImperativeCodeElimination
 
   override protected type TransformerContext = s.Symbols
   override protected def getContext(symbols: s.Symbols) = symbols
+  
   override protected def extractFunction(symbols: s.Symbols, fd: s.FunDef): t.FunDef = {
     import symbols._
     import exprOps._

--- a/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
@@ -11,12 +11,12 @@ trait FunctionInlining extends CachingPhase with IdentitySorts { self =>
 
   // The function inlining transformation depends on all (transitive) callees
   // that will require inlining.
-  override protected final val funCache = new CustomCache[s.FunDef, FunctionResult]({
-    (fd, symbols) => new DependencyKey(fd.id, symbols.dependencies(fd.id)
+  override protected final val funCache = new ExtractionCache[s.FunDef, FunctionResult]({(fd, symbols) => 
+    FunctionKey(fd) + funKeys(
+      symbols.dependencies(fd.id)
       .flatMap(id => symbols.lookupFunction(id))
       .filter(_.flags exists { case Inline | InlineOnce => true case _ => false })
-      .map(_.id)
-    )(symbols)
+    )
   })
 
   override protected type FunctionResult = Option[t.FunDef]

--- a/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
@@ -12,10 +12,10 @@ trait FunctionInlining extends CachingPhase with IdentitySorts { self =>
   // The function inlining transformation depends on all (transitive) callees
   // that will require inlining.
   override protected final val funCache = new ExtractionCache[s.FunDef, FunctionResult]({(fd, symbols) => 
-    FunctionKey(fd) + funKeys(
+    FunctionKey(fd) + SetKey(
       symbols.dependencies(fd.id)
-      .flatMap(id => symbols.lookupFunction(id))
-      .filter(_.flags exists { case Inline | InlineOnce => true case _ => false })
+        .flatMap(id => symbols.lookupFunction(id))
+        .filter(_.flags exists { case Inline | InlineOnce => true case _ => false })
     )
   })
 

--- a/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MethodLifting.scala
@@ -21,7 +21,7 @@ trait MethodLifting extends oo.ExtractionContext with oo.ExtractionCaches { self
   // the set of direct overrides is significantly more expensive and shouldn't improve
   // the cache hit rate that much.
   private[this] final val funCache = new ExtractionCache[s.FunDef, t.FunDef]({ (fd, symbols) =>
-    SetKey(fd.flags
+    FunctionKey(fd) + SetKey(fd.flags
       .collectFirst { case s.IsMethodOf(id) => symbols.getClass(id) }.toSeq
       .flatMap { cd =>
         val descendants = cd.descendants(symbols)
@@ -37,7 +37,7 @@ trait MethodLifting extends oo.ExtractionContext with oo.ExtractionCaches { self
             if (isInvariant) ofd.flags contains s.IsInvariant
             else symbolOf(ofd) == symbolOf(fd) // casts are sound after checking `IsMethodOf`
           }.map(FunctionKey(_): CacheKey).toSet
-      }.toSet) + FunctionKey(fd)
+      }.toSet)
   })
 
   // The class cache must consider all direct overrides of a potential invariant function
@@ -52,7 +52,7 @@ trait MethodLifting extends oo.ExtractionContext with oo.ExtractionCaches { self
         (fd.flags exists { case s.IsMethodOf(id) => ids(id) case _ => false })
       }.map(FunctionKey(_)).toSet
 
-      SetKey(invariants) + ClassKey(cd)
+      ClassKey(cd) + SetKey(invariants)
   })
 
   private case class Override(cid: Identifier, fid: Option[Identifier], children: Seq[Override])

--- a/core/src/main/scala/stainless/extraction/methods/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/methods/Trees.scala
@@ -32,7 +32,7 @@ trait Trees extends throwing.Trees { self =>
 
   /** $encodingof `receiver.id[tps](args)` */
   case class MethodInvocation(receiver: Expr, id: Identifier, tps: Seq[Type], args: Seq[Expr]) extends Expr with CachingTyped {
-    protected def computeType(implicit s: Symbols): Type = widen(receiver.getType) match {
+    protected def computeType(implicit s: Symbols): Type = widenTypeParameter(receiver) match {
       case ct: ClassType =>
         val optTfd = s.lookupFunction(id)
           .filter(fd => tps.size == fd.tparams.size && args.size == fd.params.size)

--- a/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/oo/AdtSpecialization.scala
@@ -123,10 +123,10 @@ trait AdtSpecialization
   private[this] def descendantKey(id: Identifier)(implicit symbols: s.Symbols): CacheKey =
     SetKey(
       (symbols.dependencies(id) + id)
-      .flatMap(id => Set(id) ++ symbols.lookupClass(id).toSeq.flatMap { cd =>
-        val rootCd = symbols.getClass(root(cd.id))
-        Set(rootCd.id) ++ rootCd.descendants.map(_.id)
-      })
+        .flatMap(id => Set(id) ++ symbols.lookupClass(id).toSeq.flatMap { cd =>
+          val rootCd = symbols.getClass(root(cd.id))
+          Set(rootCd.id) ++ rootCd.descendants.map(_.id)
+        })
     )
 
   // The function cache must consider the descendants of all classes on which the

--- a/core/src/main/scala/stainless/extraction/oo/ExtractionCaches.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ExtractionCaches.scala
@@ -34,9 +34,6 @@ trait ExtractionCaches extends extraction.ExtractionCaches { self: oo.Extraction
     def apply(sort: s.ClassDef): CacheKey = new ClassKey(sort)
   }
 
-  final def classKeys(cds: Set[s.ClassDef]): CacheKey =
-    SetKey(cds.map(ClassKey(_)))
-
   override protected def getSimpleKey(id: Identifier)(implicit symbols: s.Symbols): CacheKey =
     symbols.lookupClass(id).map(ClassKey(_)).getOrElse(super.getSimpleKey(id))
 }

--- a/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ExtractionPipeline.scala
@@ -8,7 +8,9 @@ trait ExtractionPipeline extends extraction.ExtractionPipeline {
   val s: Trees
 }
 
-trait CachingPhase extends ExtractionPipeline with extraction.CachingPhase with ExtractionCaches { self =>
+trait ExtractionContext extends ExtractionPipeline with extraction.ExtractionContext
+
+trait CachingPhase extends ExtractionContext with extraction.CachingPhase with ExtractionCaches { self =>
   protected type ClassResult
   protected val classCache: ExtractionCache[s.ClassDef, ClassResult]
 
@@ -19,7 +21,7 @@ trait CachingPhase extends ExtractionPipeline with extraction.CachingPhase with 
     registerClasses(
       super.extractSymbols(context, symbols),
       symbols.classes.values.map { cd =>
-        classCache.cached(cd, symbols)(extractClass(context, cd))
+        classCache.cached(cd, context)(extractClass(context, cd))
       }.toSeq
     )
   }
@@ -34,10 +36,6 @@ trait SimpleClasses extends CachingPhase {
 
 trait SimplyCachedClasses extends CachingPhase {
   override protected final val classCache: ExtractionCache[s.ClassDef, ClassResult] = new SimpleCache[s.ClassDef, ClassResult]
-}
-
-trait DependentlyCachedClasses extends CachingPhase {
-  override protected final val classCache: ExtractionCache[s.ClassDef, ClassResult] = new DependencyCache[s.ClassDef, ClassResult]
 }
 
 trait IdentityClasses extends SimpleClasses with SimplyCachedClasses { self =>

--- a/core/src/main/scala/stainless/extraction/oo/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/oo/Trees.scala
@@ -99,7 +99,7 @@ trait Trees extends imperative.Trees with Definitions { self =>
   /** $encodingof `_ :> lo <: hi` */
   case class TypeBounds(lo: Type, hi: Type) extends Type
 
-  private def widenTypeParameter(tpe: Typed)(implicit s: Symbols): Type = tpe.getType match {
+  protected def widenTypeParameter(tpe: Typed)(implicit s: Symbols): Type = tpe.getType match {
     case tp: TypeParameter => widenTypeParameter(tp.upperBound)
     case tpe => tpe
   }

--- a/core/src/main/scala/stainless/extraction/oo/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/oo/Trees.scala
@@ -44,7 +44,7 @@ trait Trees extends imperative.Trees with Definitions { self =>
   /** $encodingof `expr.asInstanceOf[tpe]` */
   case class AsInstanceOf(expr: Expr, tpe: Type) extends Expr with CachingTyped {
     override protected def computeType(implicit s: Symbols): Type = {
-      if (s.typesCompatible(expr.getType, tpe)) tpe else Untyped
+      if (s.typesCompatible(expr.getType, tpe)) tpe.getType else Untyped
     }
   }
 

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -494,14 +494,15 @@ trait TypeEncoding
   // which the `instanceOf` call well be recursively performed, so the cache key consists of
   // - the class definition
   // - the children class definitions
-  private[this] val classInstanceCache = new CustomCache[s.ClassDef, t.FunDef]({ (cd, symbols) =>
-    new DependencyKey(cd.id, cd.children(symbols).map(_.id).toSet)(symbols)
-  })
+  private[this] val classInstanceCache = 
+    new ExtractionCache[s.ClassDef, t.FunDef]({ 
+      (cd, context) => ClassKey(cd) + classKeys(cd.children(context.symbols).toSet)
+    })
 
   private[this] def classInstance(id: Identifier)(implicit context: TransformerContext): t.FunDef = {
     import context.symbols
     val cd = symbols.getClass(id)
-    classInstanceCache.cached(cd, symbols) {
+    classInstanceCache.cached(cd, context) {
       mkFunDef(instanceID(id), t.Unchecked, t.Synthetic)() { _ =>
         (("x" :: ref) +: cd.typeArgs.map(_.id.name :: (ref =>: BooleanType())), BooleanType(), {
           case x +: tps =>
@@ -534,14 +535,16 @@ trait TypeEncoding
   // - the class definition
   // - the descendant class definitions
   // - the synthetic OptionSort definitions
-  private[this] val classUnapplyCache = new CustomCache[s.ClassDef, t.FunDef]({ (cd, symbols) =>
-    new DependencyKey(cd.id, cd.descendants(symbols).map(_.id).toSet)(symbols) + OptionSort.key(symbols)
-  })
+  private[this] val classUnapplyCache = 
+    new ExtractionCache[s.ClassDef, t.FunDef]({ (cd, context) =>
+      val symbols = context.symbols
+      ClassKey(cd) + classKeys(cd.descendants(symbols).toSet) + OptionSort.key(symbols)
+    })
 
   private[this] def classUnapply(id: Identifier)(implicit context: TransformerContext): t.FunDef = {
     import context.symbols
     val cd = symbols.getClass(id)
-    classUnapplyCache.cached(cd, symbols) {
+    classUnapplyCache.cached(cd, context) {
       import OptionSort._
       mkFunDef(unapplyID(cd.id), t.Unchecked, t.Synthetic, t.IsUnapply(isEmpty, get))() { _ =>
         val cons = constructors(cd)
@@ -566,11 +569,12 @@ trait TypeEncoding
    * ==================================== */
 
   // The unapply function only depends on the synthetic OptionSort
-  private[this] val unapplyAnyCache = new CustomCache[s.Symbols, t.FunDef](
-    (_, symbols) => OptionSort.key(symbols)
+  private[this] val unapplyAnyCache = new ExtractionCache[s.Symbols, t.FunDef](
+    (_, context) => OptionSort.key(context.symbols)
   )
 
-  private[this] def unapplyAny(implicit symbols: s.Symbols): t.FunDef = unapplyAnyCache.cached(symbols, symbols) {
+  private[this] def unapplyAny(implicit context: TransformerContext): t.FunDef = unapplyAnyCache.cached(context.symbols, context) {
+    implicit val symbols = context.symbols
     import OptionSort.{value => _, _}
     mkFunDef(FreshIdentifier("InstanceOf"), t.Unchecked, t.Synthetic, t.IsUnapply(isEmpty, get))("A", "B") {
       case Seq(a, b) => (
@@ -598,7 +602,7 @@ trait TypeEncoding
   private[this] def sortInstance(id: Identifier)(implicit context: TransformerContext): t.FunDef = {
     import context.{symbols, emptyScope => scope}
     val sort = symbols.getSort(id)
-    sortInstanceCache.cached(sort, symbols) {
+    sortInstanceCache.cached(sort, context) {
       val in = sort.typeArgs.map(_.freshen)
       val tin = in.map(tp => scope.transform(tp).asInstanceOf[t.TypeParameter])
 
@@ -630,7 +634,7 @@ trait TypeEncoding
   private[this] def sortConvert(id: Identifier)(implicit context: TransformerContext): t.FunDef = {
     import context.{symbols, emptyScope => scope}
     val sort = symbols.getSort(id)
-    sortConvertCache.cached(sort, symbols) {
+    sortConvertCache.cached(sort, context) {
       val (in, out) = (sort.typeArgs.map(_.freshen), sort.typeArgs.map(_.freshen))
       val tin = in.map(tp => scope.transform(tp).asInstanceOf[t.TypeParameter])
       val tout = out.map(tp => scope.transform(tp).asInstanceOf[t.TypeParameter])
@@ -1167,7 +1171,7 @@ trait TypeEncoding
     def functions: Seq[t.FunDef] =
       symbols.classes.keys.toSeq.flatMap(id => Seq(classInstance(id)(this), classUnapply(id)(this))) ++
       symbols.sorts.keys.flatMap(id => Seq(sortInstance(id)(this), sortConvert(id)(this))) ++
-      OptionSort.functions :+ unapplyAny
+      OptionSort.functions :+ unapplyAny(this)
 
     def sorts: Seq[t.ADTSort] =
       OptionSort.sorts :+ refSort
@@ -1229,7 +1233,9 @@ trait TypeEncoding
 
   // The computation of which type parameters must be rewritten considers all
   // dependencies, so we use a dependency cache for function transformations
-  override protected val funCache = new DependencyCache[s.FunDef, FunctionResult]
+  override protected val funCache = new ExtractionCache[s.FunDef, FunctionResult]((fd, context) => 
+    getDependencyKey(fd.id)(context.symbols)
+  )
 
   // Sort transformations are straightforward and can be simply cached
   override protected val sortCache = new SimpleCache[s.ADTSort, SortResult]

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -494,10 +494,9 @@ trait TypeEncoding
   // which the `instanceOf` call well be recursively performed, so the cache key consists of
   // - the class definition
   // - the children class definitions
-  private[this] val classInstanceCache = 
-    new ExtractionCache[s.ClassDef, t.FunDef]({ 
-      (cd, context) => ClassKey(cd) + classKeys(cd.children(context.symbols).toSet)
-    })
+  private[this] val classInstanceCache = new ExtractionCache[s.ClassDef, t.FunDef]({
+    (cd, context) => ClassKey(cd) + SetKey(cd.children(context.symbols).toSet)
+  })
 
   private[this] def classInstance(id: Identifier)(implicit context: TransformerContext): t.FunDef = {
     import context.symbols
@@ -535,11 +534,9 @@ trait TypeEncoding
   // - the class definition
   // - the descendant class definitions
   // - the synthetic OptionSort definitions
-  private[this] val classUnapplyCache = 
-    new ExtractionCache[s.ClassDef, t.FunDef]({ (cd, context) =>
-      val symbols = context.symbols
-      ClassKey(cd) + classKeys(cd.descendants(symbols).toSet) + OptionSort.key(symbols)
-    })
+  private[this] val classUnapplyCache = new ExtractionCache[s.ClassDef, t.FunDef]({ (cd, context) =>
+    ClassKey(cd) + SetKey(cd.descendants(context.symbols).toSet) + OptionSort.key(context.symbols)
+  })
 
   private[this] def classUnapply(id: Identifier)(implicit context: TransformerContext): t.FunDef = {
     import context.symbols
@@ -1233,9 +1230,9 @@ trait TypeEncoding
 
   // The computation of which type parameters must be rewritten considers all
   // dependencies, so we use a dependency cache for function transformations
-  override protected val funCache = new ExtractionCache[s.FunDef, FunctionResult]((fd, context) => 
-    getDependencyKey(fd.id)(context.symbols)
-  )
+  override protected val funCache = new ExtractionCache[s.FunDef, FunctionResult]({
+    (fd, context) => getDependencyKey(fd.id)(context.symbols)
+  })
 
   // Sort transformations are straightforward and can be simply cached
   override protected val sortCache = new SimpleCache[s.ADTSort, SortResult]

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -25,6 +25,25 @@ import scala.language.existentials
   */
 package object extraction {
 
+  val phases: Seq[(String, String)] = Seq(
+    "PartialFunctions"          -> "Lift partial function preconditions",
+    "Laws"                      -> "Rewrite laws as abstract functions with contracts",
+    "SuperCalls"                -> "Resolve super-function calls",
+    "MethodLifting"             -> "Lift methods into dispatching functions",
+    "FieldAccessors"            -> "Inline field accessors of concrete classes",
+    "AdtSpecialization"         -> "Specialize classes into ADTs (when possible)",
+    "RefinementLifting"         -> "Lift simple refinements to contracts",
+    "TypeEncoding"              -> "Encode non-ADT types",
+    "AntiAliasing"              -> "Rewrite field and array mutations",
+    "ImperativeCodeElimination" -> "Eliminate while loops and assignments",
+    "ImperativeCleanup"         -> "Cleanup after imperative transformations",
+    "FunctionClosure"           -> "Lift inner functions",
+    "FunctionInlining"          -> "Transitively inline marked functions",
+    "PartialEvaluation"         -> "Partially evaluate marked function calls"
+  )
+
+  val phaseNames: Set[String] = phases.map(_._1).toSet
+
   /** Unifies all stainless tree definitions */
   trait Trees extends ast.Trees with termination.Trees { self =>
     override def getDeconstructor(that: inox.ast.Trees): inox.ast.TreeDeconstructor { val s: self.type; val t: that.type } = that match {

--- a/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
@@ -14,9 +14,14 @@ object optDebugObjects extends inox.OptionDef[Seq[String]] {
 }
 
 object optDebugPhases extends inox.OptionDef[Seq[String]] {
+  import inox.OptionParsers._
+
   val name = "debug-phases"
   val default = Seq[String]()
-  val parser = inox.OptionParsers.seqParser(inox.OptionParsers.stringParser)
+  val parser: OptionParser[Seq[String]] = { s =>
+    seqParser(stringParser)(s).filter(_.forall(phaseNames contains _))
+  }
+
   val usageRhs = "p1,p2,..."
 }
 

--- a/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
@@ -52,7 +52,7 @@ trait DebugPipeline extends ExtractionPipeline with PositionChecker { self =>
 
     val symbolsToPrint = if (debugTrees) symbols.debugString(objects)(printerOpts) else ""
     if (!symbolsToPrint.isEmpty) {
-      context.reporter.debug("\n\n\n\nSymbols before " + name + "\n")
+      context.reporter.debug(s"\n\n\n\nSymbols before $name\n")
       context.reporter.debug(symbolsToPrint)
     }
 
@@ -63,9 +63,16 @@ trait DebugPipeline extends ExtractionPipeline with PositionChecker { self =>
 
     val resToPrint = if (debugTrees) res.debugString(objects)(tPrinterOpts) else ""
     if (!symbolsToPrint.isEmpty || !resToPrint.isEmpty) {
-      context.reporter.debug("\n\nSymbols after " + name +  "\n")
-      context.reporter.debug(resToPrint)
-      context.reporter.debug("\n\n")
+      if (resToPrint != symbolsToPrint) {
+        context.reporter.debug(s"\n\nSymbols after $name\n")
+        context.reporter.debug(resToPrint)
+        context.reporter.debug("\n\n")
+        // ensure well-formedness after each extraction step
+        context.reporter.debug(s"Ensuring well-formedness after phase $name")
+        res.ensureWellFormed
+      } else {
+        context.reporter.debug(s"Not printing symbols after $name as they did not change\n\n")
+      }
     }
 
     if (debugPos) {

--- a/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
+++ b/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
@@ -4,7 +4,7 @@ package stainless
 package extraction
 package utils
 
-trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
+trait SyntheticSorts extends ExtractionCaches { self: CachingPhase =>
 
   protected object OptionSort {
     import t._
@@ -31,7 +31,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
 
       val cache = new SimpleCache[s.ADTSort, t.FunDef]
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
-        case Some(sort) => cache.cached(sort, symbols) {
+        case Some(sort) => cache.cached(sort) {
           createFunction(sort.id, sort.constructors.find(_.fields.isEmpty).get.id)
         }
         case None => syntheticFunction
@@ -55,7 +55,7 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
 
       val cache = new SimpleCache[s.ADTSort, t.FunDef]
       (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
-        case Some(sort) => cache.cached(sort, symbols) {
+        case Some(sort) => cache.cached(sort) {
           val some = sort.constructors.find(_.fields.nonEmpty).get
           createFunction(sort.id, some.id, some.fields.head.id)
         }
@@ -93,9 +93,9 @@ trait SyntheticSorts extends ExtractionCaches { self: ExtractionPipeline =>
       })
 
     def key(implicit symbols: s.Symbols): CacheKey = new SeqKey(
-      symbols.lookup.get[s.ADTSort]("stainless.lang.Option").map(SortKey(_, symbols)).toSeq ++
-      symbols.lookup.get[s.FunDef]("stainless.lang.Option.isEmpty").map(FunctionKey(_, symbols)) ++
-      symbols.lookup.get[s.FunDef]("stainless.lang.Option.get").map(FunctionKey(_, symbols))
+      symbols.lookup.get[s.ADTSort]("stainless.lang.Option").map(SortKey(_)).toSeq ++
+      symbols.lookup.get[s.FunDef]("stainless.lang.Option.isEmpty").map(FunctionKey(_)) ++
+      symbols.lookup.get[s.FunDef]("stainless.lang.Option.get").map(FunctionKey(_))
     )
   }
 }

--- a/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
@@ -16,6 +16,7 @@ trait PartialFunctions
   import s._
 
   override protected def getContext(symbols: Symbols) = new TransformerContext(symbols)
+
   protected class TransformerContext(symbols: s.Symbols) extends oo.TreeTransformer {
     override final val s: self.s.type = self.s
     override final val t: self.t.type = self.t

--- a/core/src/main/scala/stainless/extraction/xlang/package.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/package.scala
@@ -28,9 +28,10 @@ package object xlang {
       override val t: methods.trees.type = methods.trees
       override val context = ctx
 
-      override protected type TransformerContext = identity.type
-      override protected def getContext(symbols: s.Symbols) = identity
-      protected final object identity extends oo.TreeTransformer {
+      override protected type TransformerContext = Identity
+      override protected def getContext(symbols: s.Symbols) = new Identity(symbols)
+
+      protected final class Identity(val symbols: s.Symbols) extends oo.TreeTransformer {
         override val s: self.s.type = self.s
         override val t: self.t.type = self.t
 

--- a/core/src/main/scala/stainless/extraction/xlang/package.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/package.scala
@@ -28,10 +28,10 @@ package object xlang {
       override val t: methods.trees.type = methods.trees
       override val context = ctx
 
-      override protected type TransformerContext = Identity
-      override protected def getContext(symbols: s.Symbols) = new Identity(symbols)
+      override protected type TransformerContext = identity.type
+      override protected def getContext(symbols: s.Symbols) = identity
 
-      protected final class Identity(val symbols: s.Symbols) extends oo.TreeTransformer {
+      protected final object identity extends oo.TreeTransformer {
         override val s: self.s.type = self.s
         override val t: self.t.type = self.t
 

--- a/core/src/main/scala/stainless/verification/PartialEvaluation.scala
+++ b/core/src/main/scala/stainless/verification/PartialEvaluation.scala
@@ -10,8 +10,7 @@ object DebugSectionPartialEval extends inox.DebugSection("partial-eval")
 trait PartialEvaluation
   extends extraction.CachingPhase
      with extraction.IdentitySorts
-     with extraction.SimpleFunctions
-     with extraction.DependentlyCachedFunctions { self =>
+     with extraction.SimpleFunctions { self =>
 
   val s: extraction.Trees
   val t: s.type
@@ -22,6 +21,10 @@ trait PartialEvaluation
   implicit val debugSection = DebugSectionPartialEval
 
   protected val semantics: inox.SemanticsProvider { val trees: s.type }
+
+  override protected final val funCache = new ExtractionCache[s.FunDef, FunctionResult]((fd, context) => 
+    getDependencyKey(fd.id)(context.symbols)
+  )
 
   override protected def getContext(symbols: s.Symbols) = new TransformerContext(symbols)
 

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -44,7 +44,8 @@ class VerificationRun(override val pipeline: StainlessPipeline)
 
   override def parse(json: Json): Report = VerificationReport.parse(json)
 
-  override protected def createPipeline = pipeline andThen lowering andThen PartialEvaluation(extraction.trees)
+  override protected def createPipeline = pipeline andThen lowering andThen
+    extraction.utils.DebugPipeline("PartialEvaluation", PartialEvaluation(extraction.trees))
 
   implicit val debugSection = DebugSectionVerification
 

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -37,7 +37,7 @@ class RegistryTestSuite extends FunSuite {
 
   private val DEBUG = false
   private val testSuiteContext =
-    if (DEBUG) stainless.TestContext.debug(utils.DebugSectionRegistry)
+    if (DEBUG) stainless.TestContext.debug(Set(utils.DebugSectionRegistry))
     else stainless.TestContext.empty
 
   /** Expectation on classes and functions identifier name (ignoring ids). */

--- a/frontends/common/src/test/scala/stainless/TestContext.scala
+++ b/frontends/common/src/test/scala/stainless/TestContext.scala
@@ -25,13 +25,13 @@ object TestContext {
    *
    * The returned context has a DefaultReporter.
    **/
-  def debug(sec: DebugSection, options: Options): Context = {
-    val reporter = new inox.DefaultReporter(Set(sec))
+  def debug(sections: Set[DebugSection], options: Options): Context = {
+    val reporter = new inox.DefaultReporter(sections)
     val ctx = apply(options)
     Context(reporter, ctx.interruptManager, ctx.options, ctx.timers)
   }
 
-  def debug(sec: DebugSection): Context = debug(sec, Options.empty)
+  def debug(sections: Set[DebugSection]): Context = debug(sections, Options.empty)
 
   def empty: Context = apply(Options.empty)
 


### PR DESCRIPTION
Following discussions with @samarion, this pull request changes a bit the caches API

* The `ExtractionCache`'s used by `CachingPhase` now use the `TransformerContext` instead of `s.Symbols` for `CacheKey` computations
* Replace `DependencyKey` by a more generic `SetKey`
* Fix some cache issues (thanks @romac for the report of the cache issue in `Laws`)
* Fix minor bug in `Trees` (thanks @samarion)

Edit: As we discussed, `MethodLifting` needs to be adapted to the new cache API and key computation must be done in the `TransformerContext`, but I leave this for another time