### PR TITLE
Fix soundness issue in MethodLifting

### DIFF
--- a/frontends/benchmarks/verification/valid/BigIntMonoidLaws.scala
+++ b/frontends/benchmarks/verification/valid/BigIntMonoidLaws.scala
@@ -5,32 +5,32 @@ import stainless.annotation._
 
 object BigIntMonoidLaws {
 
-  abstract class Monoid {
-    def empty: BigInt
-    def append(x: BigInt, y: BigInt): BigInt
+  abstract class Monoid[A] {
+    def empty: A
+    def append(x: A, y: A): A
 
     @law
-    def law_leftIdentity(x: BigInt) = {
+    def law_leftIdentity(x: A) = {
       append(empty, x) == x
     }
 
     @law
-    def law_rightIdentity(x: BigInt) = {
+    def law_rightIdentity(x: A) = {
       append(x, empty) == x
     }
 
     @law
-    def law_associativity(x: BigInt, y: BigInt, z: BigInt) = {
+    def law_associativity(x: A, y: A, z: A) = {
       append(x, append(y, z)) == append(append(x, y), z)
     }
   }
 
-  case class AdditiveMonoid() extends Monoid {
+  case class AdditiveMonoid() extends Monoid[BigInt] {
     def empty = 0
     def append(x: BigInt, y: BigInt) = x + y
   }
 
-  case class ProductMonoid() extends Monoid {
+  case class ProductMonoid() extends Monoid[BigInt] {
     def empty = 1
     def append(x: BigInt, y: BigInt) = x * y
   }


### PR DESCRIPTION
In a method's dispatcher, we now constrain forwarded arguments to
have the expected type, rather than just casting them to said type.

Not doing leads in some cases to invalid models where some argument's
model is of a totally unrelated type.

It is sound to use `assume` for this, as this is a constraint that
is guaranteed by both Scala's and our type system.