### PR TITLE
Setup MutabilityAnalysis phase for classes

### DIFF
--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -344,16 +344,14 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
     *
     * @see [[extraction.DebugPipeline]]
     */
-  def debugString(objs: Option[Set[String]])(implicit pOpts: PrinterOptions): String = {
-    wrapWith("Functions", objectsToString(functions.values, objs)) ++
-    wrapWith("Sorts", objectsToString(sorts.values, objs))
+  def debugString(filter: String => Boolean = (x: String) => true)(implicit pOpts: PrinterOptions): String = {
+    wrapWith("Functions", objectsToString(functions.values, filter)) ++
+    wrapWith("Sorts", objectsToString(sorts.values, filter))
   }
 
-  protected def objectsToString(m: Iterable[Definition], objs: Option[Set[String]])(implicit pOpts: PrinterOptions): String = {
-    m.collect {
-      case d if objs.isEmpty || objs.exists(_.exists { r => d.id.name matches r }) =>
-        d.asString(pOpts)
-    } mkString "\n\n"
+  protected final def objectsToString(m: Iterable[Definition], filter: String => Boolean)
+                                     (implicit pOpts: PrinterOptions): String = {
+    m.collect { case d if filter(d.id.name) => d.asString(pOpts) } mkString "\n\n"
   }
 
   protected def wrapWith(header: String, s: String) = {

--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -344,13 +344,16 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
     *
     * @see [[extraction.DebugPipeline]]
     */
-  def debugString(objs: Set[String])(implicit pOpts: PrinterOptions): String = {
+  def debugString(objs: Option[Set[String]])(implicit pOpts: PrinterOptions): String = {
     wrapWith("Functions", objectsToString(functions.values, objs)) ++
     wrapWith("Sorts", objectsToString(sorts.values, objs))
   }
 
-  protected def objectsToString(m: Iterable[Definition], objs: Set[String])(implicit pOpts: PrinterOptions): String = {
-    m.collect { case d if objs.isEmpty || objs.contains(d.id.name) => d.asString(pOpts) } mkString "\n\n"
+  protected def objectsToString(m: Iterable[Definition], objs: Option[Set[String]])(implicit pOpts: PrinterOptions): String = {
+    m.collect {
+      case d if objs.isEmpty || objs.exists(_.exists { r => d.id.name matches r }) =>
+        d.asString(pOpts)
+    } mkString "\n\n"
   }
 
   protected def wrapWith(header: String, s: String) = {

--- a/core/src/main/scala/stainless/extraction/ExtractionCaches.scala
+++ b/core/src/main/scala/stainless/extraction/ExtractionCaches.scala
@@ -46,7 +46,7 @@ trait ExtractionCaches { self: ExtractionContext =>
   }
 
   protected implicit object FunctionKey extends Keyable[s.FunDef] {
-    def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = apply(symbols.functions(id))
+    def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = apply(symbols.getFunction(id))
     def apply(fd: s.FunDef): CacheKey = new FunctionKey(fd)
   }
 
@@ -73,7 +73,7 @@ trait ExtractionCaches { self: ExtractionContext =>
   }
 
   protected implicit object SortKey extends Keyable[s.ADTSort] {
-    def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = apply(symbols.sorts(id))
+    def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = apply(symbols.getSort(id))
     def apply(sort: s.ADTSort): CacheKey = new SortKey(sort)
   }
 

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -374,12 +374,7 @@ trait EffectsAnalyzer extends CachingPhase {
       case tp: TypeParameter => tp.flags contains IsMutable
       case arr: ArrayType => true
       case adt: ADTType if seen(adt) => false
-      case adt @ ADTType(id, tps) =>
-        val sort = symbols.getSort(id)
-        val mutableSort = sort.constructors.exists(_.fields.exists {
-          vd => (vd.flags contains IsVar) || rec(vd.tpe, seen + ADTType(id, sort.typeArgs))
-        })
-        mutableSort || adt.getSort.constructors.exists(_.fields.exists(vd => rec(vd.tpe, seen + adt)))
+      case adt @ ADTType(id, tps) => symbols.getSort(id).flags.contains(IsMutable)
       case _: FunctionType => false
       case NAryType(tps, _) => tps.exists(rec(_, seen))
     }

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -369,17 +369,12 @@ trait EffectsAnalyzer extends CachingPhase {
     * def and use the same instance of EffectsAnalysis. It is fine to add
     * new ClassDef types on the fly, granted that they use fresh identifiers.
     */
-  def isMutableType(tpe: Type)(implicit symbols: Symbols): Boolean = {
-    def rec(tpe: Type, seen: Set[ADTType]): Boolean = tpe match {
-      case tp: TypeParameter => tp.flags contains IsMutable
-      case arr: ArrayType => true
-      case adt: ADTType if seen(adt) => false
-      case adt @ ADTType(id, tps) => symbols.getSort(id).flags.contains(IsMutable)
-      case _: FunctionType => false
-      case NAryType(tps, _) => tps.exists(rec(_, seen))
-    }
-
-    rec(tpe, Set())
+  def isMutableType(tpe: Type)(implicit symbols: Symbols): Boolean = tpe match {
+    case tp: TypeParameter => tp.flags contains IsMutable
+    case arr: ArrayType => true
+    case ADTType(id, _) => symbols.getSort(id).flags.contains(IsMutable)
+    case _: FunctionType => false
+    case NAryType(tps, _) => tps.exists(isMutableType)
   }
 
   /** Effects at the level of types for a function

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -18,7 +18,7 @@ trait EffectsChecker { self: EffectsAnalyzer =>
     import analysis._
 
     def isMutableSynthetic(id: Identifier): Boolean = {
-      val fd = symbols.functions(id)
+      val fd = symbols.getFunction(id)
       fd.flags.contains(Synthetic) &&
       fd.params.exists(vd => isMutableType(vd.tpe)) &&
       !exprOps.withoutSpecs(fd.fullBody).forall(isExpressionFresh)
@@ -77,7 +77,7 @@ trait EffectsChecker { self: EffectsAnalyzer =>
               throw ImperativeEliminationException(fi, s"Cannot call '${fi.id}' on a class with mutable fields")
 
             case fi @ FunctionInvocation(id, tps, args) =>
-              val fd = symbols.functions(id)
+              val fd = symbols.getFunction(id)
               for ((tpe, tp) <- tps zip fd.tparams if (isMutableType(tpe) && !tp.flags.contains(IsMutable))) {
                 throw ImperativeEliminationException(e,
                   s"Cannot instantiate a non-mutable type parameter $tp in $fd with the mutable type $tpe")

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
@@ -90,6 +90,10 @@ trait ImperativeCleanup
 
     super.extractFunction(context, fd.copy(flags = fd.flags filterNot context.isImperativeFlag))
   }
+
+  override protected def extractSort(context: TransformerContext, sort: s.ADTSort): t.ADTSort = {
+    super.extractSort(context, sort.copy(flags = sort.flags filterNot context.isImperativeFlag))
+  }
 }
 
 object ImperativeCleanup {

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -125,6 +125,7 @@ trait Trees extends innerfuns.Trees with Definitions { self =>
 
   override def extractFlag(name: String, args: Seq[Expr]): Flag = (name, args) match {
     case ("pure", Seq()) => IsPure
+    case ("mutable", Seq()) => IsMutable
     case _ => super.extractFlag(name, args)
   }
 

--- a/core/src/main/scala/stainless/extraction/methods/DependencyGraph.scala
+++ b/core/src/main/scala/stainless/extraction/methods/DependencyGraph.scala
@@ -55,7 +55,7 @@ trait DependencyGraph extends oo.DependencyGraph with CallGraph {
     var res = g
     for (fd <- symbols.functions.values) {
       for (oid <- overrides(fd)) {
-        symbols.functions(oid).flags.collectFirst {
+        symbols.getFunction(oid).flags.collectFirst {
           case IsMethodOf(cid) =>
             // we look at transitive edges in `res` rather than in `g` in 
             // order to take into account newly added edges
@@ -113,7 +113,7 @@ trait DependencyGraph extends oo.DependencyGraph with CallGraph {
         laws(cd) foreach { law => g += SimpleEdge(law, cd.id) }
       }
 
-      for (fid <- cd.methods(symbols) if symbols.functions(fid).isAccessor) {
+      for (fid <- cd.methods(symbols) if symbols.getFunction(fid).isAccessor) {
         g += SimpleEdge(cd.id, fid)
       }
     }

--- a/core/src/main/scala/stainless/extraction/methods/DependencyGraph.scala
+++ b/core/src/main/scala/stainless/extraction/methods/DependencyGraph.scala
@@ -112,6 +112,10 @@ trait DependencyGraph extends oo.DependencyGraph with CallGraph {
       if (!(cd.flags contains IsAbstract)) {
         laws(cd) foreach { law => g += SimpleEdge(law, cd.id) }
       }
+
+      for (fid <- cd.methods(symbols) if symbols.functions(fid).isAccessor) {
+        g += SimpleEdge(cd.id, fid)
+      }
     }
 
     for (fd <- symbols.functions.values; id <- overrides(fd)) {

--- a/core/src/main/scala/stainless/extraction/methods/FieldAccessors.scala
+++ b/core/src/main/scala/stainless/extraction/methods/FieldAccessors.scala
@@ -24,7 +24,7 @@ trait FieldAccessors extends oo.CachingPhase
     override final val t: self.t.type = self.t
 
     def isConcreteAccessor(id: Identifier): Boolean = {
-      isConcreteAccessor(symbols.functions(id))
+      isConcreteAccessor(symbols.getFunction(id))
     }
 
     def isConcreteAccessor(fd: s.FunDef): Boolean = {

--- a/core/src/main/scala/stainless/extraction/methods/MutabilityAnalysis.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MutabilityAnalysis.scala
@@ -1,0 +1,100 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package extraction
+package methods
+
+import scala.language.existentials
+
+/** Add `IsMutable` flag to classes that are mutable.
+  *
+  * Compute a fixpoint of all classes that are mutable by taking into account:
+  * - setters
+  * - getters to mutable types
+  * - ancestors that are mutable
+  * - descendants that are mutable
+  * - classes that are already marked mutable
+  */
+
+trait MutabilityAnalysis extends oo.ExtractionPipeline
+  with IdentityFunctions
+  with IdentitySorts
+  with oo.SimpleClasses
+  { self =>
+
+
+  /* ====================================
+   *       Context and caches setup
+   * ==================================== */
+
+  val s: Trees
+  val t: s.type
+  import s._
+  import s.exprOps._
+
+  protected class TransformerContext(implicit symbols: Symbols) {
+
+    // This function is used in the fixpoint below to gather ClassType's that
+    // contain a getter whose return type is mutable.
+    // For a given call to `isMutableType`, the set `mutableClasses` is fixed,
+    // but may grow while computing the fixpoint below.
+    def isMutableType(tpe: Type, mutableClasses: Set[Identifier]): Boolean = {
+      def rec(tpe: Type, seen: Set[ClassType]): Boolean = tpe match {
+        case tp: TypeParameter => tp.flags contains IsMutable
+        case arr: ArrayType => true
+        case ct@ClassType(cid, tps) if mutableClasses(cid) => true
+        case ct@ClassType(cid, tps) if seen(ct) => false
+        case ct@ClassType(cid, tps) =>
+          symbols.getClass(cid).methods.exists{ fid =>
+            val fd = symbols.functions(fid)
+            fd.isGetter && rec(fd.returnType, seen + ct)
+          }
+        case _: FunctionType => false
+        case NAryType(tps, _) => tps.exists(rec(_, seen))
+      }
+
+      rec(tpe, Set())
+    }
+
+    val classes = symbols.classes.values.toSet
+    val markedClasses = classes.filter(_.flags.contains(IsMutable))
+    val classesWithSetters = classes.filter(_.methods.exists(fid => symbols.functions(fid).isSetter))
+
+    val mutableClasses = inox.utils.fixpoint[Set[ClassDef]](mutableClasses =>
+      mutableClasses.flatMap(cd => cd.ancestors.map(_.cd) ++ cd.descendants) ++
+      classes.filter(cd => isMutableType(cd.typed.toType, mutableClasses.map(_.id))) ++
+      mutableClasses
+    )(markedClasses ++ classesWithSetters)
+
+    def isMutable(cd: ClassDef) = mutableClasses(cd)
+  }
+
+  override protected def getContext(symbols: Symbols) = new TransformerContext()(symbols)
+
+  override protected final val classCache = new ExtractionCache[ClassDef, ClassResult](
+    (cd, context) => ClassKey(cd) + ValueKey(context.isMutable(cd))
+  )
+
+
+  /* ====================================
+   *         Extraction of classes
+   * ==================================== */
+
+  override protected def extractClass(context: TransformerContext, cd: ClassDef): ClassResult = {
+    if (context.isMutable(cd))
+      cd.copy(flags = cd.flags.filterNot(_ == IsMutable) :+ IsMutable).copiedFrom(cd)
+    else
+      cd
+  }
+}
+
+object MutabilityAnalysis {
+  def apply(tt: Trees)(implicit ctx: inox.Context): ExtractionPipeline {
+    val s: tt.type
+    val t: tt.type
+  } = new MutabilityAnalysis {
+    override val s: tt.type = tt
+    override val t: tt.type = tt
+    override val context = ctx
+  }
+}

--- a/core/src/main/scala/stainless/extraction/methods/MutabilityAnalysis.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MutabilityAnalysis.scala
@@ -48,7 +48,7 @@ trait MutabilityAnalysis extends oo.ExtractionPipeline
         // field still has a getter
         case ClassType(cid, tps) =>
           symbols.getClass(cid).methods.exists{ fid =>
-            val fd = symbols.functions(fid)
+            val fd = symbols.getFunction(fid)
             fd.isGetter && rec(fd.returnType, seen + cid)
           }
         case _: FunctionType => false
@@ -60,7 +60,7 @@ trait MutabilityAnalysis extends oo.ExtractionPipeline
 
     val classes = symbols.classes.values.toSet
     val markedClasses = classes.filter(_.flags.contains(IsMutable))
-    val classesWithSetters = classes.filter(_.methods.exists(fid => symbols.functions(fid).isSetter))
+    val classesWithSetters = classes.filter(_.methods.exists(fid => symbols.getFunction(fid).isSetter))
 
     val mutableClasses = inox.utils.fixpoint[Set[ClassDef]](mutableClasses =>
       mutableClasses.flatMap(cd => cd.ancestors.map(_.cd) ++ cd.descendants) ++

--- a/core/src/main/scala/stainless/extraction/methods/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/methods/Trees.scala
@@ -142,6 +142,8 @@ trait Trees extends throwing.Trees { self =>
   case class IsMethodOf(id: Identifier) extends Flag("method", Seq(id))
 
   implicit class ClassDefWrapper(cd: ClassDef) {
+    def isSealed: Boolean = cd.flags contains IsSealed
+
     def methods(implicit s: Symbols): Seq[SymbolIdentifier] = {
       s.functions.values.filter(_.flags contains IsMethodOf(cd.id)).map(_.id.asInstanceOf[SymbolIdentifier]).toSeq
     }

--- a/core/src/main/scala/stainless/extraction/methods/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/methods/Trees.scala
@@ -151,6 +151,22 @@ trait Trees extends throwing.Trees { self =>
     }
   }
 
+  implicit class FunDefWrapper(fd: FunDef) {
+    def isAccessor: Boolean =
+      fd.flags exists { case IsAccessor(_) => true case _ => false }
+
+    def isField: Boolean =
+      fd.flags exists { case IsField(_) => true case _ => false }
+
+    def isSetter: Boolean =
+      (isAccessor || isField) && fd.id.name.endsWith("_=") && fd.params.size == 1
+
+    def isGetter: Boolean = (isAccessor || isField) && fd.params.size == 0
+
+    def isAbstract: Boolean = fd.flags contains IsAbstract
+    def isInvariant: Boolean = fd.flags contains IsInvariant
+  }
+
   override def getDeconstructor(that: inox.ast.Trees): inox.ast.TreeDeconstructor { val s: self.type; val t: that.type } = that match {
     case tree: Trees => new TreeDeconstructor {
       protected val s: self.type = self

--- a/core/src/main/scala/stainless/extraction/methods/package.scala
+++ b/core/src/main/scala/stainless/extraction/methods/package.scala
@@ -17,6 +17,13 @@ package object methods {
     object printer extends Printer { val trees: methods.trees.type = methods.trees }
   }
 
+  class MethodsException(tree: inox.ast.Trees#Tree, msg: String)
+    extends MissformedStainlessCode(tree, msg)
+
+  object MethodsException {
+    def apply(tree: inox.ast.Trees#Tree, msg: String) = new MethodsException(tree, msg)
+  }
+
   def extractor(implicit ctx: inox.Context) =
     utils.DebugPipeline("Laws", Laws(trees)) andThen
     utils.DebugPipeline("SuperCalls", SuperCalls(trees)) andThen

--- a/core/src/main/scala/stainless/extraction/methods/package.scala
+++ b/core/src/main/scala/stainless/extraction/methods/package.scala
@@ -20,6 +20,7 @@ package object methods {
   def extractor(implicit ctx: inox.Context) =
     utils.DebugPipeline("Laws", Laws(trees)) andThen
     utils.DebugPipeline("SuperCalls", SuperCalls(trees)) andThen
+    utils.DebugPipeline("MutabilityAnalysis", MutabilityAnalysis(trees)) andThen
     utils.DebugPipeline("MethodLifting", MethodLifting(trees, trees)) andThen
     utils.DebugPipeline("FieldAccessors", FieldAccessors(trees, throwing.trees))
 }

--- a/core/src/main/scala/stainless/extraction/oo/ExtractionCaches.scala
+++ b/core/src/main/scala/stainless/extraction/oo/ExtractionCaches.scala
@@ -30,7 +30,7 @@ trait ExtractionCaches extends extraction.ExtractionCaches { self: oo.Extraction
   }
 
   protected implicit object ClassKey extends Keyable[s.ClassDef] {
-    def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = ClassKey(symbols.classes(id))
+    def apply(id: Identifier)(implicit symbols: s.Symbols): CacheKey = ClassKey(symbols.getClass(id))
     def apply(sort: s.ClassDef): CacheKey = new ClassKey(sort)
   }
 

--- a/core/src/main/scala/stainless/extraction/oo/SymbolOps.scala
+++ b/core/src/main/scala/stainless/extraction/oo/SymbolOps.scala
@@ -47,7 +47,7 @@ trait SymbolOps extends imperative.SymbolOps { self: TypeOps =>
     case _ => IsInstanceOf(expr, tpe).copiedFrom(expr)
   }
 
-  override def debugString(objs: Set[String])(implicit pOpts: PrinterOptions): String = {
+  override def debugString(objs: Option[Set[String]])(implicit pOpts: PrinterOptions): String = {
     super.debugString(objs) ++ wrapWith("Classes", objectsToString(classes.values, objs))
   }
 

--- a/core/src/main/scala/stainless/extraction/oo/SymbolOps.scala
+++ b/core/src/main/scala/stainless/extraction/oo/SymbolOps.scala
@@ -47,8 +47,8 @@ trait SymbolOps extends imperative.SymbolOps { self: TypeOps =>
     case _ => IsInstanceOf(expr, tpe).copiedFrom(expr)
   }
 
-  override def debugString(objs: Option[Set[String]])(implicit pOpts: PrinterOptions): String = {
-    super.debugString(objs) ++ wrapWith("Classes", objectsToString(classes.values, objs))
+  override def debugString(filter: String => Boolean)(implicit pOpts: PrinterOptions): String = {
+    super.debugString(filter) ++ wrapWith("Classes", objectsToString(classes.values, filter))
   }
 
 }

--- a/core/src/main/scala/stainless/extraction/oo/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/oo/Trees.scala
@@ -175,6 +175,11 @@ trait Printer extends imperative.Printer {
   override def ppBody(tree: Tree)(implicit ctx: PrinterContext): Unit = tree match {
 
     case cd: ClassDef =>
+      for (an <- cd.flags) {
+        p"""|@${an.asString(ctx.opts)}
+            |"""
+      }
+
       p"class ${cd.id}"
       p"${nary(cd.tparams, ", ", "[", "]")}"
       if (cd.fields.nonEmpty) p"(${cd.fields})"

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -29,6 +29,7 @@ package object extraction {
     "PartialFunctions"          -> "Lift partial function preconditions",
     "Laws"                      -> "Rewrite laws as abstract functions with contracts",
     "SuperCalls"                -> "Resolve super-function calls",
+    "MutabilityAnalysis"        -> "Add mutable flag to classes that are mutable",
     "MethodLifting"             -> "Lift methods into dispatching functions",
     "FieldAccessors"            -> "Inline field accessors of concrete classes",
     "AdtSpecialization"         -> "Specialize classes into ADTs (when possible)",

--- a/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
@@ -71,12 +71,15 @@ trait DebugPipeline extends ExtractionPipeline with PositionChecker { self =>
         context.reporter.debug(s"\n\nSymbols after $name\n")
         context.reporter.debug(resToPrint)
         context.reporter.debug("\n\n")
-        // ensure well-formedness after each extraction step
-        context.reporter.debug(s"Ensuring well-formedness after phase $name")
-        res.ensureWellFormed
       } else {
         context.reporter.debug(s"Not printing symbols after $name as they did not change\n\n")
       }
+    }
+
+    if (debugTrees) {
+      // ensure well-formedness after each extraction step
+      context.reporter.debug(s"Ensuring well-formedness after phase $name")
+      res.ensureWellFormed
     }
 
     if (debugPos) {

--- a/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
+++ b/core/src/main/scala/stainless/extraction/utils/DebugPipeline.scala
@@ -32,13 +32,12 @@ trait DebugPipeline extends ExtractionPipeline with PositionChecker { self =>
   override val t: underlying.t.type = underlying.t
   override val context = underlying.context
 
-  private[this] val phases = context.options.findOption(optDebugPhases)
-  private[this] val objects = context.options.findOption(optDebugObjects).getOrElse(Seq()).toSet
+  private[this] val phases = context.options.findOption(optDebugPhases).map(_.toSet)
+  private[this] val objects = context.options.findOption(optDebugObjects).map(_.toSet)
 
   // We print debug output for this phase only if the user didn't specify
-  // any phase with --debug-phases, or gave the name of (or a string
-  // contained in) this phase
-  private[this] val debug = phases.isEmpty || phases.exists(_ contains name)
+  // any phase with --debug-phases, or gave the name of this phase
+  private[this] val debug = phases.isEmpty || phases.exists(_.contains(name))
 
   // Moreover, we only print when the corresponding debug sections are active
   private[this] val debugTrees: Boolean = debug && context.reporter.debugSections.contains(DebugSectionTrees)

--- a/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
@@ -97,7 +97,7 @@ trait TreeSanitizer {
             ct.getField(id) match {
               case Some(field) if field.flags contains Ignore =>
                 throw MissformedStainlessCode(e, s"Cannot access ignored field `${id.asString}` from non-extern context.")
-              case None if symbols.functions.contains(id) && symbols.functions(id).flags.contains(Ignore) =>
+              case None if symbols.lookupFunction(id).exists(_.flags contains Ignore) =>
                 throw MissformedStainlessCode(e, s"Cannot access ignored field `${id.asString}` from non-extern context.")
               case _ =>
                 super.traverse(e)

--- a/frontends/benchmarks/extraction/invalid/ExtendNonMutable.scala
+++ b/frontends/benchmarks/extraction/invalid/ExtendNonMutable.scala
@@ -1,0 +1,6 @@
+// A should be annotated with @mutable
+trait A
+
+case class B(var x: BigInt) extends A {
+  def f() = ()
+}

--- a/frontends/benchmarks/extraction/invalid/NonMutableFunTypeParameter.scala
+++ b/frontends/benchmarks/extraction/invalid/NonMutableFunTypeParameter.scala
@@ -1,0 +1,11 @@
+import stainless.annotation._
+
+object NonMutableFunTypeParameter {
+  def f[T](t: T) = t
+
+  @mutable
+  trait A
+
+  // cannot instantiate f[T] with mutable type A
+  def g(a: A) = f(a)
+}

--- a/frontends/benchmarks/extraction/invalid/NonMutableTypeParameter.scala
+++ b/frontends/benchmarks/extraction/invalid/NonMutableTypeParameter.scala
@@ -1,0 +1,6 @@
+import stainless.annotation._
+
+trait NonMutableTypeParameters[X,Y]
+trait MutableTypeParameter[@mutable X] extends NonMutableTypeParameters[X, X] {
+  def f() = ()
+}

--- a/frontends/benchmarks/extraction/valid/MutableTypeParameter.scala
+++ b/frontends/benchmarks/extraction/valid/MutableTypeParameter.scala
@@ -1,0 +1,6 @@
+import stainless.annotation._
+
+trait MutableTypeParameters[@mutable X,Y]
+trait NonMutableTypeParameter[X] extends MutableTypeParameters[X, X] {
+  def f() = ()
+}

--- a/frontends/benchmarks/imperative/invalid/SimpleImperative.scala
+++ b/frontends/benchmarks/imperative/invalid/SimpleImperative.scala
@@ -1,7 +1,8 @@
 import stainless.lang._
+import stainless.annotation._
 
 object SimpleImperative {
-  abstract class A {
+  @mutable abstract class A {
     def f(): Unit 
   }
 

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -568,8 +568,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
         case _ => None
       }
 
-      val flags = annotationsOf(sym, true)
-
+      val flags = annotationsOf(sym, ignoreOwner = true)
       val tp = xt.TypeParameter(getIdentifier(sym), flags ++ variance.toSeq ++ bounds).setPos(sym.pos)
       (dctx.copy(tparams = dctx.tparams + (sym -> tp)), tparams :+ tp)
     }._2

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -388,7 +388,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
       val pos = inox.utils.Position.between(invariants.map(_.getPos).min, invariants.map(_.getPos).max)
       new xt.FunDef(invId, Seq.empty, Seq.empty, xt.BooleanType().setPos(pos),
         if (invariants.size == 1) invariants.head else xt.And(invariants).setPos(pos),
-        (Seq(xt.IsInvariant) ++ annots).distinct
+        (Seq(xt.IsInvariant) ++ annots.filterNot(_ == xt.IsMutable)).distinct
       ).setPos(pos)
     }
 
@@ -440,7 +440,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     val returnType = stainlessType(sym.info.finalResultType)(nctx, sym.pos)
     val isAbstract = rhs == tpd.EmptyTree
 
-    var flags = annotationsOf(sym) ++
+    var flags = annotationsOf(sym).filterNot(_ == xt.IsMutable) ++
       (if ((sym is Implicit) && (sym is Synthetic)) Seq(xt.Inline, xt.Synthetic) else Seq()) ++
       (if (sym is Inline) Seq(xt.Inline) else Seq()) ++
       (if (sym is Private) Seq(xt.Private) else Seq()) ++
@@ -512,7 +512,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
       )
     }
 
-    val flags = annotationsOf(sym) ++
+    val flags = annotationsOf(sym).filterNot(_ == xt.IsMutable) ++
       (if (sym is Private) Seq(xt.Private) else Seq()) ++
       (if (sym is Synthetic) Seq(xt.Synthetic) else Seq()) ++
       Seq(xt.IsAccessor(Some(field)))
@@ -531,7 +531,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     val args = vparams.map(vd => xt.ValDef(getIdentifier(vd.symbol), xt.IntegerType()).setPos(vd.pos))
     val returnType = if (args.isEmpty) xt.IntegerType() else xt.UnitType()
 
-    val flags = annotationsOf(sym) ++
+    val flags = annotationsOf(sym).filterNot(_ == xt.IsMutable) ++
       (if (sym is Private) Seq(xt.Private) else Seq()) ++
       Seq(xt.Extern, xt.IsAccessor(Some(getIdentifier(sym.underlyingSymbol))))
 

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -568,7 +568,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
         case _ => None
       }
 
-      val flags = annotationsOf(sym)
+      val flags = annotationsOf(sym, true)
 
       val tp = xt.TypeParameter(getIdentifier(sym), flags ++ variance.toSeq ++ bounds).setPos(sym.pos)
       (dctx.copy(tparams = dctx.tparams + (sym -> tp)), tparams :+ tp)

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -568,7 +568,9 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
         case _ => None
       }
 
-      val tp = xt.TypeParameter(getIdentifier(sym), variance.toSeq ++ bounds).setPos(sym.pos)
+      val flags = annotationsOf(sym)
+
+      val tp = xt.TypeParameter(getIdentifier(sym), flags ++ variance.toSeq ++ bounds).setPos(sym.pos)
       (dctx.copy(tparams = dctx.tparams + (sym -> tp)), tparams :+ tp)
     }._2
   }

--- a/frontends/library/stainless/annotation.scala
+++ b/frontends/library/stainless/annotation.scala
@@ -48,6 +48,13 @@ class partialEval extends Annotation
 @ignore
 class law          extends Annotation
 
+/** Used to mark non-sealed classes that must be considered mutable.
+  * Can also be used to mark a type parameter T to announce that it can be
+  * instantiated with mutable types
+  */
+@ignore
+class mutable          extends Annotation
+
 /**
  * Code annotated with @ghost is removed after stainless extraction.
  *

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -570,7 +570,9 @@ trait CodeExtraction extends ASTExtractors {
         case _ => None
       }
 
-      val tp = xt.TypeParameter(getIdentifier(sym), variance.toSeq ++ bounds).setPos(sym.pos)
+      val flags = annotationsOf(sym)
+
+      val tp = xt.TypeParameter(getIdentifier(sym), flags ++ variance.toSeq ++ bounds).setPos(sym.pos)
       (dctx.copy(tparams = dctx.tparams + (sym -> tp)), tparams :+ tp)
     }._2
   }

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -570,8 +570,7 @@ trait CodeExtraction extends ASTExtractors {
         case _ => None
       }
 
-      val flags = annotationsOf(sym, true)
-
+      val flags = annotationsOf(sym, ignoreOwner = true)
       val tp = xt.TypeParameter(getIdentifier(sym), flags ++ variance.toSeq ++ bounds).setPos(sym.pos)
       (dctx.copy(tparams = dctx.tparams + (sym -> tp)), tparams :+ tp)
     }._2

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -391,7 +391,7 @@ trait CodeExtraction extends ASTExtractors {
       val pos = inox.utils.Position.between(invariants.map(_.getPos).min, invariants.map(_.getPos).max)
       new xt.FunDef(id, Seq.empty, Seq.empty, xt.BooleanType().setPos(pos),
         if (invariants.size == 1) invariants.head else xt.And(invariants).setPos(pos),
-        (Seq(xt.IsInvariant) ++ annots).distinct
+        (Seq(xt.IsInvariant) ++ annots.filterNot(_ == xt.IsMutable)).distinct
       ).setPos(pos)
     })
 
@@ -470,7 +470,7 @@ trait CodeExtraction extends ASTExtractors {
     val id = getIdentifier(sym)
     val isAbstract = rhs == EmptyTree
 
-    var flags = annotationsOf(sym) ++
+    var flags = annotationsOf(sym).filterNot(_ == xt.IsMutable) ++
       (if (sym.isImplicit && sym.isSynthetic) Seq(xt.Inline, xt.Synthetic) else Seq()) ++
       (if (sym.isPrivate) Seq(xt.Private) else Seq()) ++
       (if (sym.isVal || sym.isLazy) Seq(xt.IsField(sym.isLazy)) else Seq()) ++
@@ -533,7 +533,7 @@ trait CodeExtraction extends ASTExtractors {
     val args = vparams.map(vd => xt.ValDef(getIdentifier(vd.symbol), xt.IntegerType()).setPos(vd.pos))
     val returnType = if (args.isEmpty) xt.IntegerType() else xt.UnitType()
 
-    val flags = annotationsOf(sym) ++
+    val flags = annotationsOf(sym).filterNot(_ == xt.IsMutable) ++
       (if (sym.isPrivate) Seq(xt.Private) else Seq()) ++
       Seq(xt.Extern, xt.IsAccessor(Some(getIdentifier(sym.accessedOrSelf))))
 

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -570,7 +570,7 @@ trait CodeExtraction extends ASTExtractors {
         case _ => None
       }
 
-      val flags = annotationsOf(sym)
+      val flags = annotationsOf(sym, true)
 
       val tp = xt.TypeParameter(getIdentifier(sym), flags ++ variance.toSeq ++ bounds).setPos(sym.pos)
       (dctx.copy(tparams = dctx.tparams + (sym -> tp)), tparams :+ tp)


### PR DESCRIPTION
This phase adds a flag `IsMutable` to classes that are mutable. Mutable classes are computed thanks to the following fixpoint. A class is mutable if it has:
  * a setter, or
  * a getter to a mutable type, or
  * a mutable ancestor, or
  * a mutable descendant, or
  * a `@mutable` annotation.

In addition, there is now code that checks that:
  * a mutable class cannot extend a non-sealed class not marked as `@mutable`.
  * non-mutability of type parameters has to be respected when extending classes.
  * non-mutability of type parameters has to be respected when doing `FunctionInvocation`'s

This PR also adds dependency edges from classes to their accessors, so that state is never lost in dependency computations.

Thanks @samarion for the help!