### PR TITLE
Freshen local variables in refinement lifting

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
+++ b/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
@@ -99,7 +99,7 @@ trait RefinementLifting
 
         case s.RefinementType(vd, pred) =>
           transform(s.Assert(
-            s.exprOps.replaceFromSymbols(Map(vd -> asInstOf(expr, vd.tpe).copiedFrom(e)), pred),
+            s.exprOps.freshenLocals(s.exprOps.replaceFromSymbols(Map(vd -> asInstOf(expr, vd.tpe).copiedFrom(e)), pred)),
             Some("Cast error"),
             asInstOf(expr, vd.tpe).copiedFrom(e)
           ).copiedFrom(e))


### PR DESCRIPTION
I had a problem before doing this change, but unfortunately I cannot reproduce the issue I got. If we don't freshen, I think this might create conflicts when building a `Path`.