### PR TITLE
Make FieldAccessors funCache use all dependencies

### DIFF
--- a/core/src/main/scala/stainless/extraction/methods/FieldAccessors.scala
+++ b/core/src/main/scala/stainless/extraction/methods/FieldAccessors.scala
@@ -9,7 +9,6 @@ import scala.language.existentials
 trait FieldAccessors extends oo.CachingPhase
   with SimpleSorts
   with oo.SimpleClasses
-  with SimplyCachedFunctions
   with SimplyCachedSorts
   with oo.SimplyCachedClasses { self =>
 
@@ -17,9 +16,13 @@ trait FieldAccessors extends oo.CachingPhase
   val t: oo.Trees
   import s._
 
+  override protected final val funCache = new ExtractionCache[s.FunDef, FunctionResult]((fd, context) =>
+    getDependencyKey(fd.id)(context.symbols)
+  )
+
   override protected def getContext(symbols: Symbols) = new TransformerContext(symbols)
 
-  protected class TransformerContext(symbols: s.Symbols) extends oo.TreeTransformer {
+  protected class TransformerContext(val symbols: s.Symbols) extends oo.TreeTransformer {
     override final val s: self.s.type = self.s
     override final val t: self.t.type = self.t
 

--- a/core/src/main/scala/stainless/extraction/methods/FieldAccessors.scala
+++ b/core/src/main/scala/stainless/extraction/methods/FieldAccessors.scala
@@ -16,10 +16,7 @@ trait FieldAccessors extends oo.CachingPhase
   val t: oo.Trees
   import s._
 
-  private def isConcreteAccessor(fd: FunDef): Boolean = {
-    (fd.flags exists { case IsAccessor(_) => true case _ => false }) &&
-    !(fd.flags contains IsAbstract)
-  }
+  private def isConcreteAccessor(fd: FunDef): Boolean = fd.isAccessor && !fd.isAbstract
 
   override protected def getContext(symbols: Symbols) = new TransformerContext(symbols)
 

--- a/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
+++ b/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
@@ -99,7 +99,7 @@ trait RefinementLifting
 
         case s.RefinementType(vd, pred) =>
           transform(s.Assert(
-            s.exprOps.replaceFromSymbols(Map(vd -> asInstOf(expr, vd.tpe).copiedFrom(e)), pred),
+            s.exprOps.freshenLocals(s.exprOps.replaceFromSymbols(Map(vd -> asInstOf(expr, vd.tpe).copiedFrom(e)), pred)),
             Some("Cast error"),
             asInstOf(expr, vd.tpe).copiedFrom(e)
           ).copiedFrom(e))

--- a/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
@@ -22,11 +22,11 @@ trait TreeSanitizer {
     for {
       cd <- symbols.classes.values
       id <- cd.methods(symbols)
-      if !symbols.getFunction(id).isAccessor
+      if !symbols.getFunction(id).isSetter
       sid <- symbols.firstSuper(id)
-      if symbols.getFunction(sid).isAccessor
+      if symbols.getFunction(sid).isSetter
     } throw MissformedStainlessCode(symbols.getFunction(id),
-      "Cannot override an accessor with a non-accessor method.")
+      "Cannot override a `var` accessor with a non-accessor method.")
   }
 
   /* This detects both multiple `require` and `require` after `decreases`. */

--- a/frontends/benchmarks/imperative/invalid/HiddenEffect.scala
+++ b/frontends/benchmarks/imperative/invalid/HiddenEffect.scala
@@ -1,0 +1,11 @@
+trait HiddenEffect {
+  var x: BigInt
+
+  def f(): BigInt
+
+  def g() = {
+    val x0 = x
+    f()
+    assert(x == x0)
+  }
+}

--- a/frontends/benchmarks/imperative/invalid/ImpureMethods.scala
+++ b/frontends/benchmarks/imperative/invalid/ImpureMethods.scala
@@ -1,0 +1,11 @@
+trait ImpureMethods {
+  var x: BigInt
+
+  def f(): BigInt
+
+  def g() = {
+    val a = f()
+    val b = f()
+    assert(a == b)
+  }
+}

--- a/frontends/benchmarks/imperative/invalid/MutableTrait.scala
+++ b/frontends/benchmarks/imperative/invalid/MutableTrait.scala
@@ -1,0 +1,15 @@
+trait MutableTrait {
+  var x: BigInt
+}
+
+trait B {
+  def f(a: MutableTrait): Unit
+
+  def g(a: MutableTrait): Unit = {
+    val a0 = a
+    f(a)
+    // we cannot ensure that `a` has not changed during the call to `f`
+    // See similar example in verification/valid/ImmutableTrait.scala
+    assert(a == a0)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/VarUpdate.scala
+++ b/frontends/benchmarks/imperative/valid/VarUpdate.scala
@@ -1,0 +1,8 @@
+trait VarUpdate {
+  var x: BigInt
+
+  def f() = {
+    x = 0
+    assert(x == 0)
+  }
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -445,9 +445,11 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
       (if (sym is Inline) Seq(xt.Inline) else Seq()) ++
       (if (sym is Private) Seq(xt.Private) else Seq()) ++
       (if (sym is Final) Seq(xt.Final) else Seq()) ++
-      (if ((sym.isField) || (sym is Lazy)) Seq(xt.IsField(sym is Lazy)) else Seq()) ++
+      (if (!isAbstract && ((sym.isField) || (sym is Lazy))) Seq(xt.IsField(sym is Lazy)) else Seq()) ++
       (if (isDefaultGetter(sym) || isCopyMethod(sym)) Seq(xt.Synthetic, xt.Inline) else Seq()) ++
-      (if (!(sym is Lazy) && (sym is Accessor)) Seq(xt.IsAccessor(Option(getIdentifier(sym.underlyingSymbol)).filterNot(_ => isAbstract))) else Seq())
+      (if ((isAbstract && sym.isField) || (!(sym is Lazy) && (sym is Accessor)))
+        Seq(xt.IsAccessor(Option(getIdentifier(sym.underlyingSymbol)).filterNot(_ => isAbstract)))
+      else Seq())
 
     if (sym.name == nme.unapply) {
       val isEmptyDenot = typer.Applications.extractorMember(sym.info.finalResultType, nme.isEmpty)


### PR DESCRIPTION
The inlining require having the inlined functions as dependencies in the cache. I put all dependencies for simplicity but we could reduce the dependencies to only the dependencies that could to be inlined.