### PR TITLE
Keep ghost/library flags when overriding methods

### DIFF
--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -33,7 +33,7 @@ trait ASTExtractors {
    * practice, however, it seems to work.
    */
   def getAnnotations(sym: Symbol, ignoreOwner: Boolean = false): Seq[(String, Seq[Tree])] = {
-    val actualSymbol = sym.accessedOrSelf
+    val actualSymbol = sym.accessedOrSelf.orElse(sym)
     val selfs = actualSymbol.annotations
     val owners = if (ignoreOwner) Set.empty else actualSymbol.owner.annotations
     val companions = if (actualSymbol.isSynthetic) actualSymbol.companionSymbol.annotations else Set.empty


### PR DESCRIPTION
This enables inheritance of the ghost flag (and library) when overriding accessors and when creating fields for accessors in the `Sealing` phase.

PS: We don't need the `Final` flag here right?