### PR TITLE
Add stainless-scalac-standalone build

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -215,6 +215,15 @@ lazy val `stainless-scalac-plugin` = (project in file("frontends") / "stainless-
   )
   .settings(artifactSettings, publishMavenSettings)
 
+lazy val `stainless-scalac-standalone` = (project in file("frontends") / "stainless-scalac-standalone")
+  .enablePlugins(JavaAppPackaging)
+  .settings(
+    name := "stainless-scalac-standalone",
+    (assemblyJarName in assembly) := (name.value + "-" + (git.baseVersion in ThisBuild).value + ".jar")
+  )
+  .dependsOn(`stainless-scalac`)
+  .settings(artifactSettings)
+
 lazy val `stainless-dotty-frontend` = (project in file("frontends") / "dotty")
   .disablePlugins(AssemblyPlugin)
   .settings(name := "stainless-dotty-frontend")


### PR DESCRIPTION
… which produces a (very) fat jar that can reasonably be distributed by itself. It only depends on the JRE and on of our supported (SMT-LIB-compatible) solvers being installed.

@samarion @romac 
Could you test this on your machines by running
```
$ sbt ";project stainless-scalac-standalone; assembly"
$ java -cp frontends/stainless-scalac-standalone/target/scala-2.11/stainless-scalac-standalone-0.1.0.jar stainless.Main frontends/benchmarks/verification/valid/Trees1.scala
```
from the stainless project root?

Next steps would include having another sbt task in the `stainless-scala-standalone` that fetches a supported Z3 release (e.g. from https://github.com/Z3Prover/z3/releases) and creates a tar ball from the assembly jar and the z3 binaries.