### PR TITLE
Minor changes in EffectsChecker error messages and EffectsAnalysis

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -53,7 +53,7 @@ trait EffectsAnalyzer extends CachingPhase {
   import s._
   import exprOps._
 
-  private[this] val effectsCache = new ExtractionCache[FunDef, Result]((fd, context) => 
+  private[this] val effectsCache = new ExtractionCache[FunDef, Result]((fd, context) =>
     getDependencyKey(fd.id)(context.symbols)
   )
 
@@ -62,6 +62,16 @@ trait EffectsAnalyzer extends CachingPhase {
     locals: Map[Identifier, FunAbstraction]) {
 
     def merge(that: Result): Result = Result(effects ++ that.effects, locals ++ that.locals)
+
+    def asString(implicit printerOpts: PrinterOptions): String = {
+      val effectsString = effects.map(e => "  " + e._1.id.asString -> e._2.map(_.asString)).mkString("\n")
+      val localsString = locals.map(p => "  " + p._1.asString + "," + p._2.asString).mkString("\n")
+      s"""|effects:
+          |$effectsString
+          |
+          |locals:
+          |$localsString""".stripMargin
+    }
   }
 
   protected object Result {
@@ -142,7 +152,7 @@ trait EffectsAnalyzer extends CachingPhase {
     }
 
     def asString(implicit printerOpts: PrinterOptions): String =
-      s"EffectsAnalysis(effects: ${result.effects.map(e => e._1.id -> e._2)}, locals: ${result.locals})"
+      s"EffectsAnalysis(\n${result.asString}\n)"
 
     override def toString: String = asString
   }

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -64,8 +64,8 @@ trait EffectsAnalyzer extends CachingPhase {
     def merge(that: Result): Result = Result(effects ++ that.effects, locals ++ that.locals)
 
     def asString(implicit printerOpts: PrinterOptions): String = {
-      val effectsString = effects.map(e => "  " + e._1.id.asString -> e._2.map(_.asString)).mkString("\n")
-      val localsString = locals.map(p => "  " + p._1.asString + "," + p._2.asString).mkString("\n")
+      val effectsString = effects.map(e => "  " + e._1.id.asString + " -> " + e._2.map(_.asString)).toList.sorted.mkString("\n")
+      val localsString = locals.map(p => "  " + p._1.asString + "," + p._2.asString).toList.sorted.mkString("\n")
       s"""|effects:
           |$effectsString
           |

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -191,8 +191,11 @@ trait EffectsAnalyzer extends CachingPhase {
     def prefixOf(that: Effect): Boolean =
       receiver == that.receiver && (target prefixOf that.target)
 
+    def targetString(implicit printerOpts: PrinterOptions): String =
+      s"${receiver.asString}${target.asString}"
+
     def asString(implicit printerOpts: PrinterOptions): String =
-      s"Effect(${receiver.asString}${target.asString})"
+      s"Effect($targetString)"
 
     override def toString: String = asString
   }

--- a/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
@@ -64,8 +64,10 @@ trait GhostChecker { self: EffectsAnalyzer =>
       if (fun.flags contains Synthetic) {
         () // Synthetic functions should always be fine with respect to ghost flow
       } else if (fun.flags contains Ghost) {
-        if (!effects(fun).forall(isGhostEffect))
-          throw ImperativeEliminationException(fun, s"Ghost function cannot have effect on non-ghost state")
+        effects(fun).find(!isGhostEffect(_)) match {
+          case Some(eff) => throw ImperativeEliminationException(fun, s"Ghost function cannot have effect on non-ghost state: ${eff.targetString}")
+          case None => ()
+        }
         new Checker(true).traverse(fun)
       } else {
         if (!inGhost && isGhostExpression(fun.fullBody))
@@ -77,13 +79,14 @@ trait GhostChecker { self: EffectsAnalyzer =>
     class Checker(inGhost: Boolean) extends SelfTreeTraverser {
       override def traverse(expr: Expr): Unit = expr match {
         case Let(vd, e, b) if vd.flags contains Ghost =>
-          if (!effects(e).forall(isGhostEffect)) {
-            throw ImperativeEliminationException(expr,
-              "Right-hand side of ghost variable must only have effects on ghost fields")
-          } else {
-            traverse(vd)
-            new Checker(true).traverse(e)
-            traverse(b)
+          effects(e).find(!isGhostEffect(_)) match {
+            case Some(eff) =>
+              throw ImperativeEliminationException(expr,
+                s"Right-hand side of ghost variable must only have effects on ghost fields (${eff.targetString} is not ghost)")
+            case None =>
+              traverse(vd)
+              new Checker(true).traverse(e)
+              traverse(b)
           }
 
         case Let(vd, e, b) if !(vd.flags contains Ghost) && inGhost =>
@@ -95,13 +98,14 @@ trait GhostChecker { self: EffectsAnalyzer =>
             "Right-hand side of non-ghost variable cannot be ghost")
 
         case LetVar(vd, e, b) if vd.flags contains Ghost =>
-          if (!effects(e).forall(isGhostEffect)) {
-            throw ImperativeEliminationException(expr,
-              "Right-hand side of ghost variable must only have effects on ghost fields")
-          } else {
-            traverse(vd)
-            new Checker(true).traverse(e)
-            traverse(b)
+          effects(e).find(!isGhostEffect(_)) match {
+            case Some(eff) =>
+              throw ImperativeEliminationException(expr,
+                s"Right-hand side of ghost variable must only have effects on ghost fields (${eff.targetString} is not ghost)")
+            case None =>
+              traverse(vd)
+              new Checker(true).traverse(e)
+              traverse(b)
           }
 
         case LetVar(vd, e, b) if !(vd.flags contains Ghost) && inGhost =>
@@ -113,12 +117,13 @@ trait GhostChecker { self: EffectsAnalyzer =>
             "Right-hand side of non-ghost variable cannot be ghost")
 
         case Assignment(v, e) if v.flags contains Ghost =>
-          if (!effects(e).forall(isGhostEffect)) {
-            throw ImperativeEliminationException(expr,
-              "Right-hand side of ghost variable assignment must only have effects on ghost fields")
-          } else {
-            traverse(v)
-            new Checker(true).traverse(e)
+          effects(e).find(!isGhostEffect(_)) match {
+            case Some(eff) =>
+              throw ImperativeEliminationException(expr,
+                s"Right-hand side of ghost variable assignment must only have effects on ghost fields (${eff.targetString} is not ghost)")
+            case None =>
+              traverse(v)
+              new Checker(true).traverse(e)
           }
 
         case Assignment(v, e) if !(v.flags contains Ghost) && isGhostExpression(e) =>
@@ -126,13 +131,14 @@ trait GhostChecker { self: EffectsAnalyzer =>
             "Right-hand side of non-ghost variable assignment cannot be ghost")
 
         case FieldAssignment(obj, id, e) if isGhostExpression(ADTSelector(obj, id)) =>
-          if (!effects(e).forall(isGhostEffect)) {
-            throw ImperativeEliminationException(expr,
-              "Right-hand side of ghost field assignment must only have effects on ghost fields")
-          } else {
-            traverse(obj)
-            traverse(id)
-            new Checker(true).traverse(e)
+          effects(e).find(!isGhostEffect(_)) match {
+            case Some(eff) =>
+              throw ImperativeEliminationException(expr,
+                s"Right-hand side of ghost field assignment must only have effects on ghost fields (${eff.targetString} is not ghost)")
+            case None =>
+              traverse(obj)
+              traverse(id)
+              new Checker(true).traverse(e)
           }
 
         case FieldAssignment(obj, id, e) if (
@@ -159,10 +165,13 @@ trait GhostChecker { self: EffectsAnalyzer =>
           (lookupFunction(id).map(Outer(_)).getOrElse(analysis.local(id)).params zip args)
             .foreach { case (vd, arg) =>
               if (vd.flags contains Ghost) {
-                if (!effects(arg).forall(isGhostEffect))
-                  throw ImperativeEliminationException(arg,
-                    s"Argument to ghost parameter `${vd.id}` of `${id}` must only have effects on ghost fields")
-                new Checker(true).traverse(arg)
+                effects(arg).find(!isGhostEffect(_)) match {
+                  case Some(eff) =>
+                    throw ImperativeEliminationException(arg,
+                      s"Argument to ghost parameter `${vd.id}` of `${id}` must only have effects on ghost fields (${eff.targetString} is not ghost)")
+                  case None =>
+                    new Checker(true).traverse(arg)
+                }
               } else {
                 traverse(arg)
               }


### PR DESCRIPTION
- Use `asString` when displaying effects (one function per line)
- Display the effect at fault when checking ghost code