### PR TITLE
Add option to consolidate all symbols into a single symbol table

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -44,6 +44,7 @@ trait MainHelpers extends inox.MainHelpers {
     optWatch -> Description(General, "Re-run stainless upon file changes"),
     optCompact -> Description(General, "Print only invalid elements of summaries"),
     frontend.optPersistentCache -> Description(General, "Enable caching of program extraction & analysis"),
+    frontend.optConsolidateSymbols -> Description(General, "Consolidate symbols into a single symbol table"),
     utils.Caches.optCacheDir -> Description(General, "Specify the directory in which cache files should be stored")
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)

--- a/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
+++ b/frontends/common/src/test/scala/stainless/RegistryTestSuite.scala
@@ -41,7 +41,7 @@ class RegistryTestSuite extends FunSuite {
     else stainless.TestContext.empty
 
   /** Expectation on classes and functions identifier name (ignoring ids). */
-  case class Expectation(classes: Set[ClassName], functions: Set[FunctionName], strict: Boolean = true)
+  case class Expectation(classes: Set[ClassName], functions: Set[FunctionName], strict: Boolean = false)
 
   /** Modification events: update the given set of files with their new content & the expected symbols. */
   case class UpdateEvent(contents: Map[FileName, Content], expected: Expectation)


### PR DESCRIPTION
Just a quick and dirty hack for now. Not tested with `--watch` mode.