### PR TITLE
Add `Nat` type to the library

### DIFF
--- a/core/src/main/scala/stainless/ast/Printers.scala
+++ b/core/src/main/scala/stainless/ast/Printers.scala
@@ -7,12 +7,52 @@ trait Printer extends inox.ast.Printer {
   protected val trees: Trees
   import trees._
 
+  protected object Operator {
+    private val isOp = new java.util.function.IntPredicate {
+      override def test(n: Int): Boolean = {
+        n >= 33 && n <= 47 ||
+        n >= 58 && n <= 63 ||
+        n == 94 || n == 124 || n == 126
+      }
+    }
+
+    def unapply(id: Identifier): Option[String] = {
+      if (id.name.chars.allMatch(isOp)) Some(id.name) else None
+    }
+  }
+
+  protected object FunctionOperator {
+    def unapply(expr: Expr): Option[(String, Expr, Expr)] = expr match {
+      case FunctionInvocation(id, Nil, Seq(a, b)) => Some((id.name, a, b))
+      case _ => None
+    }
+  }
+
+  override protected def precedence(ex: Expr): Int = ex match {
+    case (FunctionOperator("|", _, _))                                 => 1
+    case (FunctionOperator("^", _, _))                                 => 2
+    case (FunctionOperator("&", _, _))                                 => 3
+    case (FunctionOperator("<", _, _) | FunctionOperator(">", _, _))   => 4
+    case (FunctionOperator("<<", _, _) | FunctionOperator(">>", _, _)) => 4
+    case (FunctionOperator("<=", _, _) | FunctionOperator(">=", _, _)) => 4
+    case (FunctionOperator("==> ", _, _))                              => 5
+    case (FunctionOperator("+", _, _) | FunctionOperator("-", _, _))   => 7
+    case (FunctionOperator("*", _, _) | FunctionOperator("/", _, _))   => 8
+    case (FunctionOperator("%", _, _))                                 => 8
+    case _ => super.precedence(ex)
+  }
+
   override protected def ppBody(tree: Tree)(implicit ctx: PrinterContext): Unit = tree match {
     case NoTree(tpe) =>
       p"<empty tree>[$tpe]"
 
     case Error(tpe, desc) =>
       p"""error[$tpe]("$desc")"""
+
+    case FunctionOperator(id, a, b) =>
+      optP {
+        p"$a $id $b"
+      }
 
     case Require(pred, body) =>
       p"""|require($pred)
@@ -115,6 +155,7 @@ trait Printer extends inox.ast.Printer {
   override protected def requiresParentheses(ex: Tree, within: Option[Tree]): Boolean = (ex, within) match {
     case (_, Some(_: Ensuring | _: Require | _: Assert | _: MatchExpr | _: MatchCase)) => false
     case (_: Pattern, _) => false
+    case (e1: Expr, Some(e2 @ FunctionOperator(_, _, _))) if precedence(e2) > precedence(e1) => true
     case _ => super.requiresParentheses(ex, within)
   }
 

--- a/frontends/benchmarks/verification/valid/NaturalBuiltin.scala
+++ b/frontends/benchmarks/verification/valid/NaturalBuiltin.scala
@@ -1,0 +1,26 @@
+
+import stainless.math._
+
+object NaturalBuiltin {
+
+  def test = {
+    assert(Nat.Zero + Nat.Zero == Nat.Zero)
+    assert(Nat.Zero + Nat.One == Nat.One)
+  }
+
+  def test2(n: Nat) = {
+    assert(Nat.Zero + n == n)
+    assert(n + Nat.Zero == n)
+  }
+
+  def test3(n: Nat) = {
+    assert(Nat.One * n == n)
+    assert(n * Nat.One == n)
+  }
+
+  def test4(n: Nat) = {
+    assert(Nat.Zero * n == Nat.Zero)
+    assert(n * Nat.Zero == Nat.Zero)
+  }
+
+}

--- a/frontends/benchmarks/verification/valid/NaturalBuiltin.scala
+++ b/frontends/benchmarks/verification/valid/NaturalBuiltin.scala
@@ -3,22 +3,22 @@ import stainless.math._
 
 object NaturalBuiltin {
 
-  def test = {
+  def natTest0 = {
     assert(Nat.`0` + Nat.`0` == Nat.`0`)
     assert(Nat.`0` + Nat.`1` == Nat.`1`)
   }
 
-  def test2(n: Nat) = {
+  def natTest2(n: Nat) = {
     assert(Nat.`0` + n == n)
     assert(n + Nat.`0` == n)
   }
 
-  def test3(n: Nat) = {
+  def natTest3(n: Nat) = {
     assert(Nat.`1` * n == n)
     assert(n * Nat.`1` == n)
   }
 
-  def test4(n: Nat) = {
+  def natTest4(n: Nat) = {
     assert(Nat.`0` * n == Nat.`0`)
     assert(n * Nat.`0` == Nat.`0`)
   }

--- a/frontends/benchmarks/verification/valid/NaturalBuiltin.scala
+++ b/frontends/benchmarks/verification/valid/NaturalBuiltin.scala
@@ -4,23 +4,22 @@ import stainless.math._
 object NaturalBuiltin {
 
   def test = {
-    assert(Nat.Zero + Nat.Zero == Nat.Zero)
-    assert(Nat.Zero + Nat.One == Nat.One)
+    assert(Nat.`0` + Nat.`0` == Nat.`0`)
+    assert(Nat.`0` + Nat.`1` == Nat.`1`)
   }
 
   def test2(n: Nat) = {
-    assert(Nat.Zero + n == n)
-    assert(n + Nat.Zero == n)
+    assert(Nat.`0` + n == n)
+    assert(n + Nat.`0` == n)
   }
 
   def test3(n: Nat) = {
-    assert(Nat.One * n == n)
-    assert(n * Nat.One == n)
+    assert(Nat.`1` * n == n)
+    assert(n * Nat.`1` == n)
   }
 
   def test4(n: Nat) = {
-    assert(Nat.Zero * n == Nat.Zero)
-    assert(n * Nat.Zero == Nat.Zero)
+    assert(Nat.`0` * n == Nat.`0`)
+    assert(n * Nat.`0` == Nat.`0`)
   }
-
 }

--- a/frontends/benchmarks/verification/valid/Peano.scala
+++ b/frontends/benchmarks/verification/valid/Peano.scala
@@ -3,7 +3,7 @@
 import stainless.annotation._
 import stainless.lang._
 
-object Nat {
+object Peano {
   sealed abstract class Nat
   case class Zero() extends Nat
   case class Succ(num: Nat) extends Nat

--- a/frontends/library/stainless/math/Nat.scala
+++ b/frontends/library/stainless/math/Nat.scala
@@ -43,16 +43,16 @@ final case class Nat(toBigInt: BigInt) { n =>
 
 @library
 object Nat {
-  @inline val `0` : Nat = Nat(0)
-  @inline val `1` : Nat = Nat(1)
-  @inline val `2` : Nat = Nat(2)
-  @inline val `3` : Nat = Nat(3)
-  @inline val `4` : Nat = Nat(4)
-  @inline val `5` : Nat = Nat(5)
-  @inline val `6` : Nat = Nat(6)
-  @inline val `7` : Nat = Nat(7)
-  @inline val `8` : Nat = Nat(8)
-  @inline val `9` : Nat = Nat(9)
-  @inline val `10`: Nat = Nat(10)
+  val `0` : Nat = Nat(0)
+  val `1` : Nat = Nat(1)
+  val `2` : Nat = Nat(2)
+  val `3` : Nat = Nat(3)
+  val `4` : Nat = Nat(4)
+  val `5` : Nat = Nat(5)
+  val `6` : Nat = Nat(6)
+  val `7` : Nat = Nat(7)
+  val `8` : Nat = Nat(8)
+  val `9` : Nat = Nat(9)
+  val `10`: Nat = Nat(10)
 }
 

--- a/frontends/library/stainless/math/Nat.scala
+++ b/frontends/library/stainless/math/Nat.scala
@@ -43,8 +43,16 @@ final case class Nat(toBigInt: BigInt) { n =>
 
 @library
 object Nat {
-  @inline val `0`: Nat = Nat(0)
-  @inline val `1`: Nat = Nat(1)
-  @inline val `2`: Nat = Nat(2)
+  @inline val `0` : Nat = Nat(0)
+  @inline val `1` : Nat = Nat(1)
+  @inline val `2` : Nat = Nat(2)
+  @inline val `3` : Nat = Nat(3)
+  @inline val `4` : Nat = Nat(4)
+  @inline val `5` : Nat = Nat(5)
+  @inline val `6` : Nat = Nat(6)
+  @inline val `7` : Nat = Nat(7)
+  @inline val `8` : Nat = Nat(8)
+  @inline val `9` : Nat = Nat(9)
+  @inline val `10`: Nat = Nat(10)
 }
 

--- a/frontends/library/stainless/math/Nat.scala
+++ b/frontends/library/stainless/math/Nat.scala
@@ -1,0 +1,50 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package math
+
+import stainless.annotation._
+
+@library
+final case class Nat(toBigInt: BigInt) { n =>
+  require(toBigInt >= 0)
+
+  def +(m: Nat): Nat = Nat(n.toBigInt + m.toBigInt)
+  def *(m: Nat): Nat = Nat(n.toBigInt * m.toBigInt)
+
+  def -(m: Nat): Nat = {
+    require(n.toBigInt - m.toBigInt >= 0)
+    Nat(n.toBigInt - m.toBigInt)
+  }
+
+  def /(m: Nat): Nat = {
+    require(m.isNonZero && n.toBigInt / m.toBigInt > 0)
+    Nat(n.toBigInt / m.toBigInt)
+  }
+
+  def %(m: Nat): Nat = {
+    require(m.isNonZero)
+    Nat(n.toBigInt % m.toBigInt)
+  }
+
+  def > (m: Nat): Boolean = n.toBigInt >  m.toBigInt
+  def >=(m: Nat): Boolean = n.toBigInt >= m.toBigInt
+  def < (m: Nat): Boolean = n.toBigInt <  m.toBigInt
+  def <=(m: Nat): Boolean = n.toBigInt <= m.toBigInt
+
+  def mod(m: Nat): Nat = {
+    require(m.isNonZero && n.toBigInt.mod(m.toBigInt) > 0)
+    Nat(n.toBigInt mod m.toBigInt)
+  }
+
+  def isNonZero: Boolean = toBigInt != 0
+  def isZero: Boolean    = toBigInt == 0
+}
+
+@library
+object Nat {
+  @inline val `0`: Nat = Nat(0)
+  @inline val `1`: Nat = Nat(1)
+  @inline val `2`: Nat = Nat(2)
+}
+

--- a/frontends/library/stainless/math/package.scala
+++ b/frontends/library/stainless/math/package.scala
@@ -1,6 +1,9 @@
 /* Copyright 2009-2018 EPFL, Lausanne */
 
 package stainless
+
+import scala.language.implicitConversions
+
 import stainless.annotation._
 
 package object math {
@@ -18,5 +21,18 @@ package object math {
   def max(i1: BigInt, i2: BigInt) = if (i1 >= i2) i1 else i2
 
   @library
+  def min(i1: Nat, i2: Nat) = if (i1 <= i2) i1 else i2
+
+  @library
+  def max(i1: Nat, i2: Nat) = if (i1 >= i2) i1 else i2
+
+  @library
   def abs(n: BigInt) = if(n < 0) -n else n
+
+  @library
+  implicit def bigIntToNat(b: BigInt): Nat = {
+    require(b >= 0)
+    Nat(b)
+  }
 }
+


### PR DESCRIPTION
Also includes a change that prints function calls with non-alphanumeric identifiers as infix.

For example:

```scala
case class Nat(value: BigInt) {
  def +(that: Nat): Nat = Nat(this.value + that.value)
}

Nat(0) + Nat(1) == Nat(2)
```

will be printed as written above, instead of as:

```scala
+(Nat(0), Nat(1)) == Nat(2)
```