### PR TITLE
Help solver deduce that reified type args do not influence evaluation

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -1184,16 +1184,15 @@ trait TypeEncoding
       val elimParams = encoded.params
         .drop(reifiedTypeArgsCount)
         .map(vd => vd.copy(tpe = dropRefinements(vd.tpe)))
-        .map(_.freshen)
 
-      val eliminated = new t.FunDef(
+      val eliminated = t.exprOps.freshenSignature(new t.FunDef(
         original.id.freshen,
-        encoded.tparams.map(_.freshen),
+        encoded.tparams,
         elimParams,
         dropRefinements(encoded.returnType),
         t.NoTree(dropRefinements(encoded.returnType)),
         Seq(t.Derived(original.id))
-      )
+      ))
 
       val (vd, post) = t.exprOps.postconditionOf(encoded.fullBody) match {
         case Some(Lambda(Seq(vd), post)) => (vd, post)

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -1170,7 +1170,7 @@ trait TypeEncoding
      *  equivalent calls to the same method via both the top-level dispatcher,
      *  and a concrete implementation can carry different reified type parameters.
      */
-    def duplicateWithNoTypeArgs(encoded: t.FunDef, original: s.FunDef): Seq[t.FunDef] = {
+    def createTypeArgsElimWitness(encoded: t.FunDef, original: s.FunDef): Seq[t.FunDef] = {
       def dropRefinements(tpe: t.Type): t.Type = {
         t.typeOps.preMap {
           case t.RefinementType(base, _) => Some(base.tpe)
@@ -1298,7 +1298,7 @@ trait TypeEncoding
     // as a witness that type arguments do not influence the result
     // of the computation of its invocation.
     if (encoded.params.size > fd.params.size) {
-      context.duplicateWithNoTypeArgs(encoded, fd)
+      context.createTypeArgsElimWitness(encoded, fd)
     } else {
       Seq(encoded)
     }

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -5,12 +5,10 @@ package extraction
 package oo
 
 import inox.utils.Graphs._
-import java.util.concurrent.atomic.AtomicReference
 
 trait TypeEncoding
   extends ExtractionPipeline
      with SimpleSorts
-     with SimpleFunctions
      with oo.CachingPhase
      with utils.SyntheticSorts { self =>
 
@@ -21,6 +19,9 @@ trait TypeEncoding
   import t.dsl._
   import s.TypeParameterWrapper
 
+  override type FunctionResult = Seq[t.FunDef]
+  protected def registerFunctions(symbols: t.Symbols, functions: Seq[FunctionResult]): t.Symbols =
+    symbols.withFunctions(functions.flatten)
 
   /* ====================================
    *             IDENTIFIERS
@@ -1158,6 +1159,70 @@ trait TypeEncoding
 
     def sorts: Seq[t.ADTSort] =
       OptionSort.sorts :+ refSort
+
+    /** Duplicate function [[encoded]] that was derived from [[original]] into
+     *  another function without the reified type parameters and an empty body.
+     *  The post of [[encoded]] is then modified to assert that its result
+     *  is equals to the result of this new function, when applied
+     *  to (non-type args) parameters. This allows the solver to deduce that the
+     *  reified type parameters themselves do not influence the result of a call
+     *  to [[encoded]], something that is needed eg., in the presence of GADTs where
+     *  equivalent calls to the same method via both the top-level dispatcher,
+     *  and a concrete implementation can carry different reified type parameters.
+     */
+    def duplicateWithNoTypeArgs(encoded: t.FunDef, original: s.FunDef): Seq[t.FunDef] = {
+      def dropRefinements(tpe: t.Type): t.Type = {
+        t.typeOps.preMap {
+          case t.RefinementType(base, _) => Some(base.tpe)
+          case _ => None
+        } (tpe)
+      }
+
+      val reifiedTypeArgsCount = encoded.params.size - original.params.size
+      assert(reifiedTypeArgsCount > 0)
+
+      val elimParams = encoded.params
+        .drop(reifiedTypeArgsCount)
+        .map(vd => vd.copy(tpe = dropRefinements(vd.tpe)))
+        .map(_.freshen)
+
+      val eliminated = new t.FunDef(
+        original.id.freshen,
+        encoded.tparams.map(_.freshen),
+        elimParams,
+        dropRefinements(encoded.returnType),
+        t.NoTree(dropRefinements(encoded.returnType)),
+        Seq(t.Derived(original.id))
+      )
+
+      val (vd, post) = t.exprOps.postconditionOf(encoded.fullBody) match {
+        case Some(Lambda(Seq(vd), post)) => (vd, post)
+        case None => (
+          t.ValDef.fresh("res", encoded.returnType),
+          t.BooleanLiteral(true).copiedFrom(encoded.fullBody)
+        )
+      }
+
+      val newPost = t.Lambda(Seq(vd),
+        t.and(
+          post,
+          t.Annotated(
+            t.Equals(
+              vd.toVariable.copiedFrom(post),
+              t.FunctionInvocation(
+                eliminated.id,
+                encoded.tparams.map(_.tp),
+                encoded.params.drop(reifiedTypeArgsCount).map(_.toVariable.copiedFrom(post))
+              ).copiedFrom(post)
+            ).copiedFrom(post),
+            Seq(t.Unchecked)
+          ).copiedFrom(post)
+        )
+      )
+
+      val newBody = t.exprOps.withPostcondition(encoded.fullBody, Some(newPost))
+      Seq(encoded.copy(fullBody = newBody), eliminated)
+    }
   }
 
   override protected def extractSymbols(context: TransformerContext, symbols: s.Symbols): t.Symbols = {
@@ -1226,7 +1291,20 @@ trait TypeEncoding
   // Classes are simply dropped by this phase, so any cache is valid here
   override protected val classCache = new SimpleCache[s.ClassDef, ClassResult]
 
-  override protected def extractFunction(context: TransformerContext, fd: s.FunDef): t.FunDef = context.transform(fd)
+  override protected def extractFunction(context: TransformerContext, fd: s.FunDef): Seq[t.FunDef] = {
+    val encoded = context.transform(fd)
+
+    // If function has gained new parameters for reifed types,
+    // we create a dummy version of it without any type arguments
+    // as a witness that type arguments do not influence the result
+    // of the computation of its invocation.
+    if (encoded.params.size > fd.params.size) {
+      context.duplicateWithNoTypeArgs(encoded, fd)
+    } else {
+      Seq(encoded)
+    }
+  }
+
   override protected def extractSort(context: TransformerContext, sort: s.ADTSort): t.ADTSort = context.transform(sort)
 
   // Classes are simply dropped by this extraction phase

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -1192,7 +1192,7 @@ trait TypeEncoding
         dropRefinements(encoded.returnType),
         t.NoTree(dropRefinements(encoded.returnType)),
         Seq(t.Derived(original.id))
-      ))
+      ).copiedFrom(encoded))
 
       val (vd, post) = t.exprOps.postconditionOf(encoded.fullBody) match {
         case Some(Lambda(Seq(vd), post)) => (vd, post)

--- a/frontends/benchmarks/verification/valid/LawTypeArgsElim.scala
+++ b/frontends/benchmarks/verification/valid/LawTypeArgsElim.scala
@@ -24,7 +24,7 @@ object LawTypeArgsElim {
     }
   }
 
-  def ok[A](s: Structure[A], a: A, b: A) = {
+  def ok1[A](s: Structure[A], a: A, b: A) = {
     assert(s.someLaw(a, b))                            // valid
     assert(s.doSomething(a, b) == s.doSomething(b, a)) // valid
   }
@@ -49,5 +49,10 @@ object LawTypeArgsElim {
         }
       }
     }
+  }
+
+  def ok2[A](s: Structure[Option[A]], a: Option[A], b: Option[A]) = {
+    assert(s.someLaw(a, b))                            // valid
+    assert(s.doSomething(a, b) == s.doSomething(b, a)) // valid
   }
 }

--- a/frontends/benchmarks/verification/valid/LawTypeArgsElim.scala
+++ b/frontends/benchmarks/verification/valid/LawTypeArgsElim.scala
@@ -1,0 +1,53 @@
+import stainless.lang._
+import stainless.annotation._
+import stainless.proof._
+
+object LawTypeArgsElim {
+  abstract class Structure[A] {
+    def doSomething(x: A, y: A): A
+
+    @law
+    def someLaw(x: A, y: A): Boolean = {
+      doSomething(x, y) == doSomething(y, x)
+    }
+  }
+
+  case class BigIntStructure() extends Structure[BigInt] {
+    override def doSomething(x: BigInt, y: BigInt): BigInt = {
+      x + y
+    }
+
+    override def someLaw(x: BigInt, y: BigInt): Boolean = {
+      super.someLaw(x, y) because {
+        x + y == y + x
+      }
+    }
+  }
+
+  def ok[A](s: Structure[A], a: A, b: A) = {
+    assert(s.someLaw(a, b))                            // valid
+    assert(s.doSomething(a, b) == s.doSomething(b, a)) // valid
+  }
+
+  case class OptionStructure[A](ev: Structure[A]) extends Structure[Option[A]] {
+    override def doSomething(x: Option[A], y: Option[A]): Option[A] = {
+      (x, y) match {
+        case (None(), None())   => None()
+        case (_, None())        => None()
+        case (None(), _)        => None()
+        case (Some(a), Some(b)) => Some(ev.doSomething(a, b))
+      }
+    }
+
+    override def someLaw(x: Option[A], y: Option[A]): Boolean = {
+      super.someLaw(x, y) because {
+        (x, y) match {
+          case (None(), None())   => true
+          case (_, None())        => true
+          case (None(), _)        => true
+          case (Some(a), Some(b)) => ev.someLaw(a, b)
+        }
+      }
+    }
+  }
+}

--- a/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
@@ -19,6 +19,7 @@ class TerminationSuite extends ComponentTestSuite {
     case "verification/valid/Nested14" => Ignore // Too slow, make regression unstable
     // smt-z3 crashes on some permutations of the MergeSort2 problem encoding due to Bags...
     case "verification/valid/MergeSort2" => WithContext(ctx.copy(options = ctx.options + optIgnorePosts(true)))
+    case "verification/valid/LawTypeArgsElim" => Ignore // Crashes the termination checker
     case _ => super.filter(ctx, name)
   }
 


### PR DESCRIPTION
If function has gained new parameters for reifed types during
TypeEncoding, we create a dummy version of it without any
type arguments as a witness that type arguments do not
influence the result of the computation of its invocation.

We do this by duplicating the encoded function into
another function without the reified type parameters
and an empty body.

The post of the encoded function is then modified to assert
that its result is equals to the result of this new function,
when applied to (non-type args) parameters.

This allows the solver to deduce that the reified type parameters
themselves do not influence the result of a call
to the original function, something that is needed eg.,
in the presence of GADTs where equivalent calls to the same method
via both the top-level dispatcher, and a concrete implementation
can carry different reified type parameters.

Thanks @samarion for helping me figuring this stuff out and coming up with this fix.