### PR TITLE
Report positions when going through the compiler reporter from the sbt plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -13,7 +13,7 @@ val isMac     = osInf.indexOf("Mac") >= 0
 val osName = if (isWindows) "win" else if (isMac) "mac" else "unix"
 val osArch = System.getProperty("sun.arch.data.model")
 
-val inoxVersion = "1.1.0-322-g6cdfa72"
+val inoxVersion = "1.1.0-326-g397ae7b"
 val dottyLibrary = "dotty-compiler_2.12"
 val dottyVersion = "0.12.0-RC1-nonbootstrapped"
 val circeVersion = "0.10.0-M2"

--- a/core/src/main/scala/stainless/Context.scala
+++ b/core/src/main/scala/stainless/Context.scala
@@ -1,0 +1,12 @@
+/* Copyright 2009-2019 EPFL, Lausanne */
+
+package stainless
+
+import inox.utils.InterruptManager
+
+object Context {
+  def empty = {
+    val reporter = new stainless.DefaultReporter(Set())
+    inox.Context(reporter, new InterruptManager(reporter))
+  }
+}

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -86,6 +86,9 @@ trait MainHelpers extends inox.MainHelpers {
 
   // TODO add (optional) customisation points for CallBacks to access intermediate reports(?)
 
+  override protected def newReporter(debugSections: Set[inox.DebugSection]): inox.Reporter =
+    new stainless.DefaultReporter(debugSections)
+
   def main(args: Array[String]): Unit = try {
     val ctx = setup(args)
     import ctx.{ reporter, timers }

--- a/core/src/main/scala/stainless/Reporter.scala
+++ b/core/src/main/scala/stainless/Reporter.scala
@@ -1,0 +1,20 @@
+/* Copyright 2009-2019 EPFL, Lausanne */
+
+package stainless
+
+import inox.DebugSection
+
+abstract class ReportMessage {
+  def sbtPluginOnly: Boolean
+  def toString: String
+  def emit(reporter: inox.Reporter): Unit
+}
+
+class DefaultReporter(debugSections: Set[DebugSection]) extends inox.DefaultReporter(debugSections) {
+  override def emit(msg: Message): Unit = msg.msg match {
+    case rm: ReportMessage if rm.sbtPluginOnly => ()
+    case _ => super.emit(msg)
+  }
+}
+
+class PlainTextReporter(debugSections: Set[DebugSection]) extends stainless.DefaultReporter(debugSections)

--- a/core/src/main/scala/stainless/verification/VCResultMessage.scala
+++ b/core/src/main/scala/stainless/verification/VCResultMessage.scala
@@ -1,0 +1,38 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package verification
+
+case class VCResultMessage[T <: ast.Trees, +M](
+  vc: VC[T],
+  result: VCResult[M]
+) {
+
+  override def toString: String = {
+    s"VC '${vc.kind}' @ ${vc.getPos}: " +
+    s"${result.status.name.toUpperCase}"
+  }
+
+  def emit(reporter: inox.Reporter): Unit = {
+    result.status match {
+      case VCStatus.Valid =>
+        reporter.warning(vc.getPos, toString)
+
+      case VCStatus.Invalid(reason) =>
+        reporter.error(vc.getPos, toString)
+
+        reason match {
+          case VCStatus.CounterExample(cex) =>
+            reporter.error(vc.getPos, "Found counter-example:")
+            reporter.error(vc.getPos, "  " + cex.toString.replaceAll("\n", "\n  "))
+
+          case VCStatus.Unsatisfiable =>
+            reporter.error(vc.getPos, "Property wasn't satisfiable")
+        }
+
+      case status =>
+        reporter.error(vc.getPos, toString)
+        reporter.error(vc.getPos, " => " + result.status.name.toUpperCase)
+    }
+  }
+}

--- a/core/src/main/scala/stainless/verification/VCResultMessage.scala
+++ b/core/src/main/scala/stainless/verification/VCResultMessage.scala
@@ -6,14 +6,16 @@ package verification
 case class VCResultMessage[T <: ast.Trees, +M](
   vc: VC[T],
   result: VCResult[M]
-) {
+) extends ReportMessage {
+
+  override val sbtPluginOnly: Boolean = true
 
   override def toString: String = {
     s"VC '${vc.kind}' @ ${vc.getPos}: " +
     s"${result.status.name.toUpperCase}"
   }
 
-  def emit(reporter: inox.Reporter): Unit = {
+  override def emit(reporter: inox.Reporter): Unit = {
     result.status match {
       case VCStatus.Valid =>
         reporter.warning(vc.getPos, toString)

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -264,6 +264,9 @@ trait VerificationChecker { self =>
         case Failure(e) => reporter.internalError(e)
       }
 
+      val vcResultMsg = VCResultMessage(vc, vcres)
+      reporter.info(vcResultMsg)
+
       reporter.synchronized {
         reporter.info(s" - Result for '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}:")
 

--- a/frontends/common/src/test/scala/stainless/TestContext.scala
+++ b/frontends/common/src/test/scala/stainless/TestContext.scala
@@ -2,7 +2,7 @@
 
 package stainless
 
-import inox.{ Context, DebugSection, Options, OptionValue }
+import inox.{ DebugSection, Options, OptionValue }
 import stainless.verification.optVCCache
 
 object TestContext {
@@ -13,7 +13,7 @@ object TestContext {
    * Unless explicitely present in [[options]], the returned
    * context is set to use no VC cache.
    */
-  def apply(options: Options): Context = {
+  def apply(options: Options): inox.Context = {
     val newOptions =
       if ((options findOption optVCCache).isDefined) options
       else options + OptionValue(optVCCache)(false)
@@ -25,15 +25,15 @@ object TestContext {
    *
    * The returned context has a DefaultReporter.
    **/
-  def debug(sections: Set[DebugSection], options: Options): Context = {
-    val reporter = new inox.DefaultReporter(sections)
+  def debug(sections: Set[DebugSection], options: Options): inox.Context = {
+    val reporter = new stainless.DefaultReporter(sections)
     val ctx = apply(options)
-    Context(reporter, ctx.interruptManager, ctx.options, ctx.timers)
+    inox.Context(reporter, ctx.interruptManager, ctx.options, ctx.timers)
   }
 
-  def debug(sections: Set[DebugSection]): Context = debug(sections, Options.empty)
+  def debug(sections: Set[DebugSection]): inox.Context = debug(sections, Options.empty)
 
-  def empty: Context = apply(Options.empty)
+  def empty: inox.Context = apply(Options.empty)
 
 }
 

--- a/frontends/scalac/src/it/scala/stainless/GhostRewriteSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/GhostRewriteSuite.scala
@@ -53,7 +53,9 @@ class GhostRewriteSuite extends FunSpec {
 
   def ignoreError(i: reporter.Info) = {
     val s = i.toString
-    s.contains("The Z3 native interface is not available")
+
+    s.contains("The Z3 native interface is not available") ||
+    s.endsWith("VALID WARNING")
   }
 
   def compileFile(file: String) = {

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessPlugin.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessPlugin.scala
@@ -1,4 +1,6 @@
-package stainless.frontends.scalac
+package stainless
+package frontends
+package scalac
 
 import scala.reflect.io.AbstractFile
 import scala.reflect.internal.util.{NoPosition, Position, BatchSourceFile}
@@ -11,7 +13,7 @@ import inox.{utils => InoxPosition}
 import stainless.frontend.CallBack
 
 class StainlessPlugin(override val global: Global) extends Plugin {
-  val stainlessContext: inox.Context = inox.Context.empty
+  val stainlessContext: inox.Context = stainless.Context.empty
 
   override val name: String = "stainless-plugin"
   override val description: String = "stainless scala compiler plugin"
@@ -23,7 +25,7 @@ class StainlessPlugin(override val global: Global) extends Plugin {
 
 class StainlessPluginComponent(
   val global: Global,
-  val stainlessContext: inox.Context = inox.Context.empty
+  val stainlessContext: inox.Context = stainless.Context.empty
 ) extends PluginComponent with StainlessExtraction {
   override implicit val ctx: inox.Context = {
     val adapter = new ReporterAdapter(global.reporter, Set())
@@ -64,8 +66,8 @@ class ReporterAdapter(underlying: ScalacReporter, debugSections: Set[DebugSectio
     val pos = toScalaPos(message.position)
 
     message.msg match {
-      case vc: stainless.verification.VCResultMessage[_, _] =>
-        vc.emit(this)
+      case msg: ReportMessage =>
+        msg.emit(this)
 
       case msg: String =>
         message.severity match {


### PR DESCRIPTION
Result:

<img width="1792" alt="screenshot 2019-01-17 15 06 59" src="https://user-images.githubusercontent.com/106849/51334899-19f37600-1a81-11e9-8374-19f4c7d55344.png">
<img width="1792" alt="screenshot 2019-01-17 16 00 30" src="https://user-images.githubusercontent.com/106849/51334902-1bbd3980-1a81-11e9-81d1-fa820548fd3e.png">

Some more work is needed on the Inox side to avoid having duplicated output in the SBT console.

Fixes #434