### PR TITLE
Lift contracts

### DIFF
--- a/core/src/main/scala/stainless/ast/Deconstructors.scala
+++ b/core/src/main/scala/stainless/ast/Deconstructors.scala
@@ -136,6 +136,12 @@ trait TreeDeconstructor extends inox.ast.TreeDeconstructor {
       (Seq(), Seq(), Seq(body, pred), Seq(), Seq(), (_, _, es, _, _) => t.Ensuring(es(0), es(1).asInstanceOf[t.Lambda]))
     case s.Assert(pred, error, body) =>
       (Seq(), Seq(), Seq(pred, body), Seq(), Seq(), (_, _, es, _, _) => t.Assert(es(0), error, es(1)))
+    case s.StaticRequire(pred, body) =>
+      (Seq(), Seq(), Seq(pred, body), Seq(), Seq(), (_, _, es, _, _) => t.StaticRequire(es(0), es(1)))
+    case s.StaticEnsuring(body, pred) =>
+      (Seq(), Seq(), Seq(body, pred), Seq(), Seq(), (_, _, es, _, _) => t.StaticEnsuring(es(0), es(1).asInstanceOf[t.Lambda]))
+    case s.StaticAssert(pred, error, body) =>
+      (Seq(), Seq(), Seq(pred, body), Seq(), Seq(), (_, _, es, _, _) => t.StaticAssert(es(0), error, es(1)))
     case s.Annotated(body, flags) =>
       (Seq(), Seq(), Seq(body), Seq(), flags, (_, _, es, _, flags) => {
         t.Annotated(es(0), flags)

--- a/core/src/main/scala/stainless/evaluators/EvaluatorComponent.scala
+++ b/core/src/main/scala/stainless/evaluators/EvaluatorComponent.scala
@@ -83,9 +83,9 @@ class EvaluatorRun(override val pipeline: extraction.StainlessPipeline)
       val nakedBody = nakedBodyOpt.get
       val postOpt = exprOps postconditionOf fd.fullBody
 
-      val body = exprOps.withPrecondition(nakedBody, preOpt)
+      val body = exprOps.withPrecondition(nakedBody, preOpt.map(_.expr))
 
-      (body, postOpt)
+      (body, postOpt.map(_.expr))
     }
 
     // Build an evaluator once and only if there is something to evaluate

--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -139,7 +139,7 @@ trait AntiAliasing
         }
 
         val newSpecs = specs.map {
-          case exprOps.Postcondition(post @ Lambda(Seq(res), postBody)) =>
+          case exprOps.Postcondition(post @ Lambda(Seq(res), postBody), isStatic) =>
             val newRes = ValDef(res.id.freshen, newFd.returnType).copiedFrom(res)
             val newBody = exprOps.replaceSingle(
               aliasedParams.map(vd => (Old(vd.toVariable), vd.toVariable): (Expr, Expr)).toMap ++
@@ -149,7 +149,7 @@ trait AntiAliasing
               makeSideEffectsExplicit(postBody, fd, env)
             )
 
-            exprOps.Postcondition(Lambda(Seq(newRes), newBody).copiedFrom(post))
+            exprOps.Postcondition(Lambda(Seq(newRes), newBody).copiedFrom(post), isStatic)
 
           case spec => spec
         }

--- a/core/src/main/scala/stainless/extraction/methods/Laws.scala
+++ b/core/src/main/scala/stainless/extraction/methods/Laws.scala
@@ -188,7 +188,7 @@ trait Laws
 
           val (specs, body) = s.exprOps.deconstructSpecs(fd.fullBody)(symbols)
           val newSpecs = specs.map {
-            case s.exprOps.Postcondition(l @ s.Lambda(Seq(vd), pred)) =>
+            case s.exprOps.Postcondition(l @ s.Lambda(Seq(vd), pred), isStatic) =>
               val nvd = transform(vd, env)
               t.exprOps.Postcondition(t.Lambda(Seq(nvd),
                 t.and(transform(pred, env), nvd.toVariable, t.MethodInvocation(
@@ -197,7 +197,7 @@ trait Laws
                   tparams map (_.tp),
                   params map (_.toVariable)
                 ).copiedFrom(fd)).copiedFrom(fd)
-              ).copiedFrom(fd))
+              ).copiedFrom(fd), isStatic)
 
             case spec => spec.map(t)(transform(_, env))
           }

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -28,6 +28,7 @@ package object extraction {
   val phases: Seq[(String, String)] = Seq(
     "PartialFunctions"          -> "Lift partial function preconditions",
     "InnerClasses"              -> "Lift inner classes",
+    "ContractLifting"           -> "Lift contracts to refinement types",
     "Laws"                      -> "Rewrite laws as abstract functions with contracts",
     "SuperCalls"                -> "Resolve super-function calls",
     "Sealing"                   -> "Seal every class and add mutable flags",

--- a/core/src/main/scala/stainless/extraction/xlang/ContractLifting.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/ContractLifting.scala
@@ -1,0 +1,110 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package extraction
+package xlang
+
+import scala.language.existentials
+
+trait ContractLifting
+  extends oo.SimplePhase
+     with SimplyCachedFunctions
+     with SimplyCachedSorts
+     with oo.IdentityTypeDefs
+     with oo.SimplyCachedClasses { self =>
+
+  val s: Trees
+  val t: self.s.type
+  import s._
+
+  override protected def getContext(symbols: Symbols) = new TransformerContext(symbols)
+
+  protected class TransformerContext(symbols: s.Symbols) extends oo.TreeTransformer {
+    override final val s: self.s.type = self.s
+    override final val t: self.t.type = self.t
+
+    private def hasContracts(fd: FunDef): Boolean =
+      exprOps.preconditionOf(fd.fullBody).isDefined ||
+      exprOps.postconditionOf(fd.fullBody).isDefined
+
+    private def hasPrecondition: Set[Identifier] =
+      symbols.functions.values
+        .filter(fd => exprOps.preconditionOf(fd.fullBody).isDefined)
+        .map(_.id)
+        .toSet
+
+    private def hasPostcondition: Set[Identifier] =
+      symbols.functions.values
+        .filter(fd => exprOps.postconditionOf(fd.fullBody).isDefined)
+        .map(_.id)
+        .toSet
+
+    private def toLift: Set[Identifier] = hasPrecondition ++ hasPostcondition
+
+    private val transformer = new SelfTreeTransformer {
+      override def transform(expr: Expr): Expr = expr match {
+        case fi: FunctionInvocation if hasPrecondition(fi.id) =>
+          super.transform(fi.copy(args = fi.args :+ UnitLiteral().copiedFrom(fi)))
+
+        case mi: MethodInvocation if hasPrecondition(mi.id) =>
+          super.transform(mi.copy(args = mi.args :+ UnitLiteral().copiedFrom(mi)))
+
+        case a @ Assert(pred, err, body) => // TODO: What to do with error message?
+          val tpe = RefinementType(ValDef.fresh("_", UnitType()), super.transform(pred))
+          val vd = ValDef.fresh("assert", tpe)
+          Let(vd, UnitLiteral().copiedFrom(a), super.transform(body)).copiedFrom(a)
+
+        case _ => super.transform(expr)
+      }
+    }
+
+    private def liftContracts(fd: FunDef): FunDef = {
+      val pre = exprOps.preconditionOf(fd.fullBody)
+      val post = exprOps.postconditionOf(fd.fullBody)
+
+      val returnType = addPostcondition(fd.returnType, post)
+
+      val proofParam = pre map { pre =>
+        val proofType = RefinementType(ValDef.fresh("_", UnitType()), pre).copiedFrom(pre)
+        ValDef.fresh("pre", proofType)
+      }
+
+      val lifted = fd.copy(
+        params = fd.params ++ proofParam.toSeq,
+        returnType = returnType,
+        fullBody = exprOps.withoutSpecs(fd.fullBody).getOrElse(fd.fullBody),
+      ).copiedFrom(fd)
+
+      transformer.transform(lifted)
+    }
+
+    private def addPostcondition(returnType: Type, post: Option[Lambda]): Type = returnType match {
+      case RefinementType(vd, pred) =>
+        val newPred = post.map { post =>
+          And(pred, post.withParamSubst(Seq(vd.toVariable), post.body))
+        }.getOrElse(pred)
+        RefinementType(vd, newPred)
+
+      case tpe => post.map { post =>
+        val vd = ValDef.fresh("res", tpe)
+        RefinementType(vd, post.withParamSubst(Seq(vd.toVariable), post.body))
+      }.getOrElse(tpe)
+    }
+
+    override def transform(fd: FunDef): FunDef = {
+      if (toLift(fd.id)) liftContracts(fd)
+      else transformer.transform(fd)
+    }
+  }
+}
+
+object ContractLifting {
+  def apply(trees: xlang.Trees)(implicit ctx: inox.Context): ExtractionPipeline {
+    val s: trees.type
+    val t: trees.type
+  } = new ContractLifting {
+    override val s: trees.type = trees
+    override val t: trees.type = trees
+    override val context = ctx
+  }
+}

--- a/core/src/main/scala/stainless/extraction/xlang/ExprOps.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/ExprOps.scala
@@ -7,36 +7,4 @@ package xlang
 trait ExprOps extends innerclasses.ExprOps { self =>
   protected val trees: Trees
   import trees._
-
-  /** Extracts the body without its specification
-    *
-    * [[Expressions.Expr]] trees contain its specifications as part of certain nodes.
-    * This function helps extracting only the body part of an expression
-    *
-    * @return An option type with the resulting expression if not [[Expressions.NoTree]]
-    * @see [[Expressions.Ensuring]]
-    * @see [[Expressions.Require]]
-    */
-  override def withoutSpecs(expr: Expr): Option[Expr] = expr match {
-    case Let(i, e, b)                    => withoutSpecs(b).map(Let(i, e, _).copiedFrom(expr))
-    case Require(pre, b)                 => Option(b).filterNot(_.isInstanceOf[NoTree])
-    case Ensuring(Require(pre, b), post) => Option(b).filterNot(_.isInstanceOf[NoTree])
-    case Ensuring(b, post)               => Option(b).filterNot(_.isInstanceOf[NoTree])
-    case b                               => Option(b).filterNot(_.isInstanceOf[NoTree])
-  }
-
-  /** Returns the precondition of an expression wrapped in Option */
-  override def preconditionOf(expr: Expr): Option[Expr] = expr match {
-    case Let(i, e, b)                 => preconditionOf(b).map(Let(i, e, _).copiedFrom(expr))
-    case Require(pre, _)              => Some(pre)
-    case Ensuring(Require(pre, _), _) => Some(pre)
-    case b                            => None
-  }
-
-  /** Returns the postcondition of an expression wrapped in Option */
-  override def postconditionOf(expr: Expr): Option[Lambda] = expr match {
-    case Let(i, e, b)      => postconditionOf(b).map(l => l.copy(body = Let(i, e, l.body).copiedFrom(expr)).copiedFrom(l))
-    case Ensuring(_, post) => Some(post)
-    case _                 => None
-  }
 }

--- a/core/src/main/scala/stainless/extraction/xlang/ExprOps.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/ExprOps.scala
@@ -1,0 +1,42 @@
+/* Copyright 2009-2019 EPFL, Lausanne */
+
+package stainless
+package extraction
+package xlang
+
+trait ExprOps extends innerclasses.ExprOps { self =>
+  protected val trees: Trees
+  import trees._
+
+  /** Extracts the body without its specification
+    *
+    * [[Expressions.Expr]] trees contain its specifications as part of certain nodes.
+    * This function helps extracting only the body part of an expression
+    *
+    * @return An option type with the resulting expression if not [[Expressions.NoTree]]
+    * @see [[Expressions.Ensuring]]
+    * @see [[Expressions.Require]]
+    */
+  override def withoutSpecs(expr: Expr): Option[Expr] = expr match {
+    case Let(i, e, b)                    => withoutSpecs(b).map(Let(i, e, _).copiedFrom(expr))
+    case Require(pre, b)                 => Option(b).filterNot(_.isInstanceOf[NoTree])
+    case Ensuring(Require(pre, b), post) => Option(b).filterNot(_.isInstanceOf[NoTree])
+    case Ensuring(b, post)               => Option(b).filterNot(_.isInstanceOf[NoTree])
+    case b                               => Option(b).filterNot(_.isInstanceOf[NoTree])
+  }
+
+  /** Returns the precondition of an expression wrapped in Option */
+  override def preconditionOf(expr: Expr): Option[Expr] = expr match {
+    case Let(i, e, b)                 => preconditionOf(b).map(Let(i, e, _).copiedFrom(expr))
+    case Require(pre, _)              => Some(pre)
+    case Ensuring(Require(pre, _), _) => Some(pre)
+    case b                            => None
+  }
+
+  /** Returns the postcondition of an expression wrapped in Option */
+  override def postconditionOf(expr: Expr): Option[Lambda] = expr match {
+    case Let(i, e, b)      => postconditionOf(b).map(l => l.copy(body = Let(i, e, l.body).copiedFrom(expr)).copiedFrom(l))
+    case Ensuring(_, post) => Some(post)
+    case _                 => None
+  }
+}

--- a/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/PartialFunctions.scala
@@ -55,14 +55,14 @@ trait PartialFunctions
             val (preOpt, bareBody) = body0 match {
               // Call to another function: Lift the function's definition
               case fi2: FunctionInvocation =>
-                (exprOps.preconditionOf(fi2.inlined(symbols)), fi2)
+                (exprOps.preconditionOf(fi2.inlined(symbols)).map(_.expr), fi2)
 
               // scala.PartialFunction: Infer pattern match condition
               case m: MatchExpr =>
                 (inferPrecondition(m), m)
 
               case _ =>
-                (exprOps.preconditionOf(body0), exprOps.withPrecondition(body0, None))
+                (exprOps.preconditionOf(body0).map(_.expr), exprOps.withPrecondition(body0, None))
             }
 
             val modifiedBody = preOpt match {

--- a/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
@@ -132,9 +132,10 @@ trait TreeSanitizer { self =>
       case wh @ While(cond, body, optInv) =>
         traverse(cond)
         val (specs, without) = exprOps.deconstructSpecs(body)
-        val (measures, otherSpecs) = specs.partition { case exprOps.Measure(_) => true case _ => false }
-        measures.foreach(s => traverse(s.expr))
-        traverse(exprOps.reconstructSpecs(otherSpecs, without, body.getType))
+        // val (measures, otherSpecs) = specs.partition { case exprOps.Measure(_) => true case _ => false }
+        // measures.foreach(s => traverse(s.expr))
+        // traverse(exprOps.reconstructSpecs(otherSpecs, without, body.getType))
+        traverse(exprOps.reconstructSpecs(specs, without, body.getType))
         optInv.foreach(traverse)
 
       case e: Require =>

--- a/core/src/main/scala/stainless/extraction/xlang/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/Trees.scala
@@ -61,6 +61,10 @@ trait Trees extends innerclasses.Trees { self =>
 
     case _ => super.getDeconstructor(that)
   }
+
+  override val exprOps: ExprOps { val trees: Trees.this.type } = new {
+    protected val trees: Trees.this.type = Trees.this
+  } with ExprOps
 }
 
 

--- a/core/src/main/scala/stainless/extraction/xlang/package.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/package.scala
@@ -55,6 +55,8 @@ package object xlang {
         transformer.transform(cd.copy(flags = cd.flags filterNot (_ == s.Ignore)))
     }
 
-    utils.DebugPipeline("PartialFunctions", PartialFunctions(trees)) andThen lowering
+    utils.DebugPipeline("PartialFunctions", PartialFunctions(trees)) andThen
+    utils.DebugPipeline("ContractLifting", ContractLifting(trees))   andThen
+    lowering
   }
 }

--- a/core/src/main/scala/stainless/termination/DecreasesProcessor.scala
+++ b/core/src/main/scala/stainless/termination/DecreasesProcessor.scala
@@ -66,7 +66,7 @@ trait DecreasesProcessor extends Processor { self =>
             case tpe => reporter.fatalError("Unexpected measure type: " + tpe)
           }
 
-          api.solveVALID(Implies(fd.precondition.getOrElse(BooleanLiteral(true)), nonNeg(measure))) match {
+          api.solveVALID(Implies(fd.precondition.map(_.expr).getOrElse(BooleanLiteral(true)), nonNeg(measure))) match {
             case Some(true) => true
             case Some(false) =>
               reporter.warning(s" ==> INVALID: measure is not well-founded in ${fd.id}")

--- a/core/src/main/scala/stainless/termination/Strengthener.scala
+++ b/core/src/main/scala/stainless/termination/Strengthener.scala
@@ -51,7 +51,7 @@ trait Strengthener { self: OrderingRelation =>
       def strengthen(cmp: (Seq[Expr], Seq[Expr]) => Expr): Boolean = {
         val postcondition = {
           val res = ValDef.fresh("res", fd.returnType)
-          val post = fd.postcondition match {
+          val post = fd.postcondition.map(_.expr) match {
             case Some(post) if !ignorePosts => application(post, Seq(res.toVariable))
             case _ => BooleanLiteral(true)
           }
@@ -59,7 +59,7 @@ trait Strengthener { self: OrderingRelation =>
           Lambda(Seq(res), and(post, sizePost))
         }
 
-        val formula = implies(fd.precOrTrue, application(postcondition, Seq(fd.body.get)))
+        val formula = implies(fd.precOrTrue.expr, application(postcondition, Seq(fd.body.get)))
 
         val strengthener = new IdentitySymbolTransformer {
           override def transform(syms: Symbols): Symbols = super.transform(syms).withFunctions {

--- a/core/src/main/scala/stainless/transformers/PartialEvaluator.scala
+++ b/core/src/main/scala/stainless/transformers/PartialEvaluator.scala
@@ -19,8 +19,8 @@ trait PartialEvaluator extends SimplifierWithPC { self =>
         val (specs, body) = deconstructSpecs(tfd.fullBody)
 
         body.map { body =>
-          val pre = specs.collectFirst { case Precondition(e) => e }.get
-          val l @ Lambda(Seq(res), post) = specs.collectFirst { case Postcondition(e) => e }.get
+          val pre = specs.collectFirst { case Precondition(e, _) => e }.get
+          val l @ Lambda(Seq(res), post) = specs.collectFirst { case Postcondition(e, _) => e }.get
 
           val newBody: Expr = Assert(pre, Some("Inlined precondition of " + tfd.id.name), Let(res, body,
             Assert(post, Some("Inlined postcondition of " + tfd.id.name), res.toVariable).copiedFrom(l)

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -17,9 +17,9 @@ class StainlessSerializer(override val trees: ast.Trees, serializeProducts: Bool
   /** An extension to the set of registered classes in the `InoxSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 120 to 158.
+    * The new identifiers in the mapping range from 120 to 161.
     *
-    * NEXT ID: 159
+    * NEXT ID: 162
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -72,7 +72,11 @@ class StainlessSerializer(override val trees: ast.Trees, serializeProducts: Bool
       classSerializer[Decreases]       (151),
       classSerializer[Erasable.type]   (155),
       classSerializer[IndexedAt]       (156),
-      classSerializer[Synthetic.type]  (182)
+      classSerializer[Synthetic.type]  (182),
+
+      classSerializer[StaticRequire]   (159),
+      classSerializer[StaticEnsuring]  (160),
+      classSerializer[StaticAssert]    (161),
     )
 }
 

--- a/core/src/main/scala/stainless/utils/StringUtils.scala
+++ b/core/src/main/scala/stainless/utils/StringUtils.scala
@@ -7,7 +7,7 @@ object StringUtils {
 
   def indent(text: String, spaces: Int): String = {
     val prefix = " " * spaces
-    text.lines.map(prefix ++ _).mkString("\n")
+    text.linesIterator.map(prefix ++ _).mkString("\n")
   }
 
 }


### PR DESCRIPTION
**TODO**:

- [ ] Only lift contracts when `--type-checker` is enabled
- [ ] Thus, no need to distinguish between static and non-static contracts