### PR TITLE
Support for configuration file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 # Stainless
 /bin/stainless-*
 .stainless-cache/
+.stainless.conf
+stainless.conf
 
 # Vim
 *.swp

--- a/build.sbt
+++ b/build.sbt
@@ -76,7 +76,8 @@ lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
     "org.scalatest" %% "scalatest" % "3.0.1" % "test",
     "io.circe" %% "circe-core" % circeVersion,
     "io.circe" %% "circe-generic" % circeVersion,
-    "io.circe" %% "circe-parser" % circeVersion
+    "io.circe" %% "circe-parser" % circeVersion,
+    "com.typesafe" % "config" % "1.3.2"
   ),
 
   // disable documentation packaging in universal:stage to speedup development

--- a/core/src/main/scala/stainless/Configuration.scala
+++ b/core/src/main/scala/stainless/Configuration.scala
@@ -1,0 +1,92 @@
+/* Copyright 2009-2019 EPFL, Lausanne */
+
+package stainless
+
+import inox.{Reporter, OptionDef, OptionValue}
+
+import java.io.File
+import java.nio.file.{FileSystems, Path}
+
+import com.typesafe.config.{ConfigFactory, ConfigValue, ConfigValueType, ConfigException}
+
+object Configuration {
+
+  import scala.collection.JavaConverters._
+
+  val ConfigName = "stainless.conf"
+
+  def findConfigFile(): Option[File] = {
+    RecursiveFileFinder.find(ConfigName)
+  }
+
+  def parseDefault(options: Seq[OptionDef[_]])(implicit reporter: Reporter): Seq[OptionValue[_]] = {
+    findConfigFile() map { file =>
+      parse(file, options)
+    } getOrElse Seq.empty
+  }
+
+  def parse(file: File, options: Seq[OptionDef[_]])(implicit reporter: Reporter): Seq[OptionValue[_]] = try {
+    val conf = ConfigFactory.parseFile(file)
+    val entries = asScalaSet(conf.entrySet).map { entry =>
+      entry.getKey -> convert(entry.getKey, entry.getValue)
+    }.toMap
+
+    val optDefMap = options.groupBy(_.name).mapValues(_.head)
+
+    val optValues = entries map { case (name, str) =>
+      optDefMap.get(name) map { optDef =>
+        optDef.parse(str)
+      } getOrElse {
+        reporter.fatalError(s"Unknown option: $name")
+      }
+    }
+
+    optValues.toSeq
+  } catch {
+    case e: ConfigException =>
+      reporter.error(s"Invalid configuration file at '$file': ${e.getMessage}")
+      Seq.empty
+  }
+
+  private def convert(name: String, config: ConfigValue)(implicit reporter: Reporter): String = {
+    val unwrapped = config.unwrapped
+
+    config.valueType match {
+      case ConfigValueType.BOOLEAN => unwrapped.toString
+      case ConfigValueType.NUMBER => unwrapped.toString
+      case ConfigValueType.STRING => unwrapped.toString
+      case ConfigValueType.LIST =>
+        val values = asScalaIterator(unwrapped.asInstanceOf[java.util.List[Any]].iterator).toList
+        values.map(_.toString).mkString(",")
+      case _ =>
+        reporter.fatalError(s"Unsupported option type for option '$name': $config")
+    }
+  }
+}
+
+object RecursiveFileFinder {
+
+  import scala.collection.JavaConverters._
+
+  def currentDirectory(): File = {
+    FileSystems.getDefault().getPath(".").normalize.toAbsolutePath().toFile
+  }
+
+  def find(name: String): Option[File] = {
+    findIn(name, currentDirectory())
+  }
+
+  def findIn(name: String, directory: File): Option[File] = {
+    findWithin(name, directory) orElse {
+      val parent = Option(directory.toPath.getParent).map(_.toFile)
+      parent flatMap (p => findIn(name, p))
+    }
+  }
+
+  private def findWithin(name: String, directory: File): Option[File] = {
+    directory.listFiles().toList
+      .filter(_.isFile)
+      .find(_.getName == name)
+  }
+
+}


### PR DESCRIPTION
The file must be named `stainless.conf` or `.stainless.conf` and be a valid HOCON file.

It will be searched for recursively starting from the current
directory and walking up the directory hierarchy.

So, if one runs stainless from `/a/b/c`, and there is a config
file in any of `c`, `b` or `a`, the first of those is going to be
loaded.

For example, the config file could contain the following:

```
vc-cache = false
debug = [verification, trees]
timeout = 5
check-models = true
print-ids = true
```

This will translate to the following command line options:

```
--vc-cache=false --debug=verification,trees --timeout=5 --print-ids
```

Closes #465