### PR TITLE
Add MutableMapType support in imperative trees

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -278,6 +278,7 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       case ClassSelector(e, id) => rec(e, ClassFieldAccessor(id) +: path)
       case ArraySelect(a, idx) => rec(a, ArrayAccessor(idx) +: path)
       case MutableMapApply(a, idx) => rec(a, MutableMapAccessor(idx) +: path)
+
       case ADT(id, _, args) => path match {
         case ADTFieldAccessor(fid) +: rest =>
           rec(args(symbols.getConstructor(id).fields.indexWhere(_.id == fid)), rest)
@@ -396,6 +397,12 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       case MutableMapUpdate(map, key, value) =>
         rec(map, env) ++ rec(key, env) ++ rec(value, env) ++
         effect(map, env).map(_ + MutableMapAccessor(key))
+
+      case MutableMapUpdated(map, key, value) =>
+        rec(map, env) ++ rec(key, env) ++ rec(value, env)
+
+      case MutableMapDuplicate(map) =>
+        rec(map, env)
 
       case FieldAssignment(o, id, v) =>
         val accessor = o.getType match {

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -118,6 +118,22 @@ trait EffectsChecker { self: EffectsAnalyzer =>
 
               super.traverse(adt)
 
+            case MutableMapUpdated(m, k, v) =>
+              m.getType match {
+                case MutableMapType(_, to) if !isMutableType(to) => ()
+                case _ =>
+                  throw ImperativeEliminationException(e,
+                    s"Cannot use `updated` on a MutableMap whose range is a mutable type (${m.getType}).")
+              }
+
+            case MutableMapDuplicate(m) =>
+              m.getType match {
+                case MutableMapType(_, to) if !isMutableType(to) => ()
+                case _ =>
+                  throw ImperativeEliminationException(e,
+                    s"Cannot use `duplicate` on a MutableMap whose range is a mutable type (${m.getType}).")
+              }
+
             case _ => super.traverse(e)
           }
         }

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
@@ -32,6 +32,7 @@ trait ImperativeCleanup
     }
 
     override def transform(tpe: s.Type): t.Type = tpe match {
+      case s.MutableMapType(from, to) => t.MapType(transform(from), transform(to))
       case s.TypeParameter(id, flags) if flags exists isImperativeFlag =>
         t.TypeParameter(id, flags filterNot isImperativeFlag map transform).copiedFrom(tpe)
       case _ => super.transform(tpe)
@@ -54,6 +55,11 @@ trait ImperativeCleanup
 
       case s.Variable(id, tpe, flags) =>
         t.Variable(id, transform(tpe), flags filterNot isImperativeFlag map transform).copiedFrom(expr)
+
+      case s.MutableMapWithDefault(from, to, default) =>
+        t.FiniteMap(Seq(), t.Application(transform(default), Seq()), transform(from), transform(to))
+      case s.MutableMapApply(map, index) => t.MapApply(transform(map), transform(index))
+      case s.MutableMapUpdated(map, key, value) => t.MapUpdated(transform(map), transform(key), transform(value))
 
       case _ => super.transform(expr)
     }

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCleanup.scala
@@ -60,6 +60,7 @@ trait ImperativeCleanup
         t.FiniteMap(Seq(), t.Application(transform(default), Seq()), transform(from), transform(to))
       case s.MutableMapApply(map, index) => t.MapApply(transform(map), transform(index))
       case s.MutableMapUpdated(map, key, value) => t.MapUpdated(transform(map), transform(key), transform(value))
+      case s.MutableMapDuplicate(map) => transform(map)
 
       case _ => super.transform(expr)
     }

--- a/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
@@ -56,6 +56,13 @@ trait TransformerWithType extends oo.TransformerWithType {
       val mmt @ s.MutableMapType(from, to) = widen(map.getType)
       t.MutableMapUpdate(transform(map, mmt), transform(key, from), transform(value, to)).copiedFrom(expr)
 
+    case s.MutableMapUpdated(map, key, value) =>
+      val mmt @ s.MutableMapType(from, to) = widen(map.getType)
+      t.MutableMapUpdated(transform(map, mmt), transform(key, from), transform(value, to)).copiedFrom(expr)
+
+    case s.MutableMapDuplicate(map) =>
+      val mmt @ s.MutableMapType(from, to) = widen(map.getType)
+      t.MutableMapDuplicate(transform(map, mmt)).copiedFrom(expr)
     case s.Old(e) =>
       t.Old(transform(e, tpe)).copiedFrom(expr)
 

--- a/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
@@ -43,6 +43,19 @@ trait TransformerWithType extends oo.TransformerWithType {
         transform(value, base)
       ).copiedFrom(expr)
 
+    case s.MutableMapWithDefault(from, to, default) =>
+      t.MutableMapWithDefault(transform(from), transform(to),
+        transform(default, s.FunctionType(Seq(), to))
+      )
+
+    case s.MutableMapApply(map, index) =>
+      val mmt @ s.MutableMapType(from, to) = widen(map.getType)
+      t.MutableMapApply(transform(map, mmt), transform(index, from)).copiedFrom(expr)
+
+    case s.MutableMapUpdate(map, key, value) =>
+      val mmt @ s.MutableMapType(from, to) = widen(map.getType)
+      t.MutableMapUpdate(transform(map, mmt), transform(key, from), transform(value, to)).copiedFrom(expr)
+
     case s.Old(e) =>
       t.Old(transform(e, tpe)).copiedFrom(expr)
 

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -91,6 +91,11 @@ trait Trees extends oo.Trees with Definitions { self =>
     }
   }
 
+  /** $encodingof `map.duplicate()` */
+  sealed case class MutableMapDuplicate(map: Expr) extends Expr with CachingTyped {
+    override protected def computeType(implicit s: Symbols): Type = map.getType
+  }
+
   /** $encodingof `map.update(key, value)` (or `map(key) = value`) */
   sealed case class MutableMapUpdate(map: Expr, key: Expr, value: Expr) extends Expr with CachingTyped {
     override protected def computeType(implicit s: Symbols): Type = map.getType match {
@@ -218,6 +223,9 @@ trait Printer extends oo.Printer {
     case MutableMapUpdated(map, key, value) =>
       p"$map.updated($key, $value)"
 
+    case MutableMapDuplicate(map) =>
+      p"$map.duplicate()"
+
     case Old(e) =>
       p"old($e)"
 
@@ -301,6 +309,9 @@ trait TreeDeconstructor extends oo.TreeDeconstructor {
 
     case s.MutableMapUpdated(map, key, value) =>
       (Seq(), Seq(), Seq(map, key, value), Seq(), Seq(), (_, _, es, _, _) => t.MutableMapUpdated(es(0), es(1), es(2)))
+
+    case s.MutableMapDuplicate(map) =>
+      (Seq(), Seq(), Seq(map), Seq(), Seq(), (_, _, es, _, _) => t.MutableMapDuplicate(es(0)))
 
     case _ => super.deconstruct(e)
   }

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -63,6 +63,42 @@ trait Trees extends oo.Trees with Definitions { self =>
     }
   }
 
+
+  /* Mutable Map Operations */
+
+  sealed case class MutableMapType(from: Type, to: Type) extends Type
+
+  /** $encodingof `MutableMap.withDefaultValue[From,To](default)` */
+  sealed case class MutableMapWithDefault(from: Type, to: Type, default: Expr) extends Expr with CachingTyped {
+    override protected def computeType(implicit s: Symbols): Type = {
+      checkParamType(default, FunctionType(Seq(), to), unveilUntyped(MutableMapType(from, to)))
+    }
+  }
+
+  /** $encodingof `map.apply(key)` (or `map(key)`) */
+  sealed case class MutableMapApply(map: Expr, key: Expr) extends Expr with CachingTyped {
+    override protected def computeType(implicit s: Symbols): Type = map.getType match {
+      case MutableMapType(from, to) => checkParamType(key, from, to)
+      case _ => Untyped
+    }
+  }
+
+  /** $encodingof `map.updated(key, value)` (or `map + (key -> value)`) */
+  sealed case class MutableMapUpdated(map: Expr, key: Expr, value: Expr) extends Expr with CachingTyped {
+    override protected def computeType(implicit s: Symbols): Type = map.getType match {
+      case mmt @ MutableMapType(from, to) => checkParamTypes(Seq(key, value), Seq(from, to), MutableMapType(from, to))
+      case _ => Untyped
+    }
+  }
+
+  /** $encodingof `map.update(key, value)` (or `map(key) = value`) */
+  sealed case class MutableMapUpdate(map: Expr, key: Expr, value: Expr) extends Expr with CachingTyped {
+    override protected def computeType(implicit s: Symbols): Type = map.getType match {
+      case mmt @ MutableMapType(from, to) => checkParamTypes(Seq(key, value), Seq(from, to), UnitType())
+      case _ => Untyped
+    }
+  }
+
   /** $encodingof `old(e)` */
   case class Old(e: Expr) extends Expr with CachingTyped {
     protected def computeType(implicit s: Symbols): Type = e.getType
@@ -167,6 +203,21 @@ trait Printer extends oo.Printer {
     case ArrayUpdate(array, index, value) =>
       p"$array($index) = $value"
 
+    case MutableMapType(from,to) =>
+      p"MutableMap[$from,$to]"
+
+    case MutableMapWithDefault(from, to, default) =>
+      p"MutableMap.withDefaultValue[$from,$to]($default)"
+
+    case MutableMapApply(map, index) =>
+      p"$map($index)"
+
+    case MutableMapUpdate(map, key, value) =>
+      p"$map($key) = $value"
+
+    case MutableMapUpdated(map, key, value) =>
+      p"$map.updated($key, $value)"
+
     case Old(e) =>
       p"old($e)"
 
@@ -239,7 +290,24 @@ trait TreeDeconstructor extends oo.TreeDeconstructor {
     case s.Old(e) =>
       (Seq(), Seq(), Seq(e), Seq(), Seq(), (_, _, es, _, _) => t.Old(es.head))
 
+    case s.MutableMapWithDefault(from, to, default) =>
+      (Seq(), Seq(), Seq(default), Seq(from, to), Seq(), (_, _, es, tps, _) => t.MutableMapWithDefault(tps(0), tps(1), es(0)))
+
+    case s.MutableMapApply(map, index) =>
+      (Seq(), Seq(), Seq(map, index), Seq(), Seq(), (_, _, es, _, _) => t.MutableMapApply(es(0), es(1)))
+
+    case s.MutableMapUpdate(map, key, value) =>
+      (Seq(), Seq(), Seq(map, key, value), Seq(), Seq(), (_, _, es, _, _) => t.MutableMapUpdate(es(0), es(1), es(2)))
+
+    case s.MutableMapUpdated(map, key, value) =>
+      (Seq(), Seq(), Seq(map, key, value), Seq(), Seq(), (_, _, es, _, _) => t.MutableMapUpdated(es(0), es(1), es(2)))
+
     case _ => super.deconstruct(e)
+  }
+
+  override def deconstruct(tpe: s.Type): Deconstructed[t.Type] = tpe match {
+    case s.MutableMapType(from, to) => (Seq(), Seq(), Seq(), Seq(from, to), Seq(), (_, _, _, tps, _) => t.MutableMapType(tps(0), tps(1)))
+    case _ => super.deconstruct(tpe)
   }
 
   override def deconstruct(f: s.Flag): DeconstructedFlag = f match {

--- a/core/src/main/scala/stainless/extraction/methods/MutabilityAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MutabilityAnalyzer.scala
@@ -34,6 +34,7 @@ trait MutabilityAnalyzer extends oo.ExtractionPipeline { self =>
         case TypeBounds(NothingType(), AnyType(), flags) => flags contains IsMutable
         case any: AnyType => true
         case arr: ArrayType => true
+        case map: MutableMapType => true
         case ClassType(cid, _) if mutableClasses(cid) => true
         case ClassType(cid, _) if seen(cid) => false
         // We don't need to check for mutable fields here, as at this point every

--- a/core/src/main/scala/stainless/extraction/methods/MutabilityAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/methods/MutabilityAnalyzer.scala
@@ -82,7 +82,8 @@ trait MutabilityAnalyzer extends oo.ExtractionPipeline { self =>
         if !acd.cd.flags.contains(IsMutable) && !acd.cd.isSealed
       ) {
         throw MethodsException(cd,
-          s"A mutable class (${cd.id.asString}) cannot have a non-@mutable and non-sealed parent (${acd.cd.id.asString})."
+          s"""|A mutable class (${cd.id.asString}) cannot have a non-@mutable and non-sealed parent (${acd.cd.id.asString}).
+              |Please annotate ${acd.cd.id.asString} with @mutable."""
         )
       }
 

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -73,9 +73,9 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
   /** An extension to the set of registered classes in the `StainlessSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 180 to 236.
+    * The new identifiers in the mapping range from 180 to 237.
     *
-    * NEXT ID: 237
+    * NEXT ID: 238
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -153,6 +153,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       classSerializer[MutableMapApply]        (234),
       classSerializer[MutableMapUpdate]       (235),
       classSerializer[MutableMapUpdated]      (236),
+      classSerializer[MutableMapDuplicate]    (237),
 
       // XLang trees
       classSerializer[Ignore.type](218),

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -148,6 +148,12 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       classSerializer[IsMethodOf]      (217),
       classSerializer[IsAccessor]      (231),
 
+      classSerializer[MutableMapType]         (232),
+      classSerializer[MutableMapWithDefault]  (233),
+      classSerializer[MutableMapApply]        (234),
+      classSerializer[MutableMapUpdate]       (235),
+      classSerializer[MutableMapUpdated]      (236),
+
       // XLang trees
       classSerializer[Ignore.type](218),
       classSerializer[Import]     (219),

--- a/frontends/benchmarks/extraction/invalid/MapAliasing.scala
+++ b/frontends/benchmarks/extraction/invalid/MapAliasing.scala
@@ -1,0 +1,11 @@
+import stainless.lang._
+
+object MapAliasing {
+
+  case class A(var x: BigInt)
+
+  def f(m: MutableMap[BigInt, A]): A = {
+    m(0)
+  }
+
+}

--- a/frontends/benchmarks/extraction/invalid/MutableMapUpdated.scala
+++ b/frontends/benchmarks/extraction/invalid/MutableMapUpdated.scala
@@ -1,0 +1,11 @@
+import stainless.lang._
+
+object MutableMapUpdated {
+  case class A(var x: BigInt)
+
+  def f(m: MutableMap[BigInt,A], a: A) = {
+    // not allowed due to the creation of aliases between `m` and the result
+    val u = m.updated(0, a)
+    ()
+  }
+}

--- a/frontends/benchmarks/imperative/valid/MutableMapInit.scala
+++ b/frontends/benchmarks/imperative/valid/MutableMapInit.scala
@@ -1,0 +1,17 @@
+import stainless.lang._
+
+object MutableMapInit {
+
+  case class A(var x: BigInt)
+
+  def f() = {
+    val m = MutableMap.withDefaultValue[BigInt, A](() => A(5))
+    assert(m(0).x == 5)
+    m(0).x = 6
+    assert(m(0).x == 6)
+    assert(m(1).x == 5)
+    m(1).x = 8
+    assert(m(1).x == 8)
+    assert(m(0).x == 6)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/MutableMapUpdated.scala
+++ b/frontends/benchmarks/imperative/valid/MutableMapUpdated.scala
@@ -2,7 +2,7 @@ import stainless.lang._
 
 object MutableMapUpdated {
   def f(m: MutableMap[BigInt, BigInt]) = {
-    val m1 = m.duplicate
+    val m1 = m.duplicate()
     m(0) = 5
     assert(m == m1.updated(0,5))
   }

--- a/frontends/benchmarks/imperative/valid/MutableMapUpdated.scala
+++ b/frontends/benchmarks/imperative/valid/MutableMapUpdated.scala
@@ -1,0 +1,9 @@
+import stainless.lang._
+
+object MutableMapUpdated {
+  def f(m: MutableMap[BigInt, BigInt]) = {
+    val m1 = m.duplicate
+    m(0) = 5
+    assert(m == m1.updated(0,5))
+  }
+}

--- a/frontends/benchmarks/imperative/valid/MutateMap.scala
+++ b/frontends/benchmarks/imperative/valid/MutateMap.scala
@@ -1,0 +1,13 @@
+import stainless.lang._
+
+object MutateMap {
+
+  case class A(var x: BigInt)
+
+  def f(m: MutableMap[BigInt, A], a: A) = {
+    require(a.x == 100)
+    m(0) = a
+    assert(m(0).x == 100)
+  }
+
+}

--- a/frontends/benchmarks/imperative/valid/MutateMapElement.scala
+++ b/frontends/benchmarks/imperative/valid/MutateMapElement.scala
@@ -1,0 +1,11 @@
+import stainless.lang._
+
+object MutateMapElement {
+
+  case class A(var x: BigInt)
+
+  def f(m: MutableMap[BigInt, A]) = {
+    m(0).x = 100
+    assert(m(0).x == 100)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/MutateNestedMapElement.scala
+++ b/frontends/benchmarks/imperative/valid/MutateNestedMapElement.scala
@@ -1,6 +1,6 @@
 import stainless.lang._
 
-object MutateMapElement {
+object MutateNestedMapElement {
 
   case class A(var x: BigInt)
 

--- a/frontends/benchmarks/imperative/valid/MutateNestedMapElement.scala
+++ b/frontends/benchmarks/imperative/valid/MutateNestedMapElement.scala
@@ -1,0 +1,11 @@
+import stainless.lang._
+
+object MutateMapElement {
+
+  case class A(var x: BigInt)
+
+  def f(m: MutableMap[BigInt, MutableMap[BigInt, A]]) = {
+    m(0)(0).x = 100
+    assert(m(0)(0).x == 100)
+  }
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -48,10 +48,11 @@ trait ASTExtractors {
 
   protected lazy val exceptionSym = classFromName("stainless.lang.Exception")
 
-  protected lazy val setSym       = classFromName("stainless.lang.Set")
-  protected lazy val mapSym       = classFromName("stainless.lang.Map")
-  protected lazy val bagSym       = classFromName("stainless.lang.Bag")
-  protected lazy val realSym      = classFromName("stainless.lang.Real")
+  protected lazy val setSym         = classFromName("stainless.lang.Set")
+  protected lazy val mapSym         = classFromName("stainless.lang.Map")
+  protected lazy val mutableMapSym  = classFromName("stainless.lang.MutableMap")
+  protected lazy val bagSym         = classFromName("stainless.lang.Bag")
+  protected lazy val realSym        = classFromName("stainless.lang.Real")
 
   protected lazy val optionSymbol = classFromName("stainless.lang.Option")
   protected lazy val someSymbol   = classFromName("stainless.lang.Some")
@@ -122,6 +123,10 @@ trait ASTExtractors {
 
   def isMapSym(sym: Symbol) : Boolean = {
     getResolvedTypeSym(sym) == mapSym
+  }
+
+  def isMutableMapSym(sym: Symbol) : Boolean = {
+    getResolvedTypeSym(sym) == mutableMapSym
   }
 
   def isBagSym(sym: Symbol) : Boolean = {

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1445,6 +1445,12 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
           case (xt.MutableMapType(_, _), "update", Seq(key, value)) =>
             xt.MutableMapUpdate(extractTree(lhs), extractTree(key), extractTree(value))
 
+          case (xt.MutableMapType(_, _), "updated", Seq(key, value)) =>
+            xt.MutableMapUpdated(extractTree(lhs), extractTree(key), extractTree(value))
+
+          case (xt.MutableMapType(_, _), "duplicate", Seq()) =>
+            xt.MutableMapDuplicate(extractTree(lhs))
+
           case (xt.MapType(_, _), "get", Seq(rhs)) =>
             xt.MapApply(extractTree(lhs), extractTree(rhs))
 

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1776,6 +1776,10 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
       case AppliedType(tr: TypeRef, tps) if TupleSymbol.unapply(tr.classSymbol).isDefined =>
         xt.TupleType(tps map extractType)
 
+      case AppliedType(tr: TypeRef, tps) if isMutableMapSym(tr.symbol) =>
+        val Seq(from, to) = tps map extractType
+        xt.MutableMapType(from, to)
+
       case tr: TypeRef if isMutableMapSym(tr.symbol) =>
         val Seq(from, to) = extractTypeParams(tr.classSymbol.typeParams)
         xt.MutableMapType(from, to)

--- a/frontends/library/stainless/lang/MutableMap.scala
+++ b/frontends/library/stainless/lang/MutableMap.scala
@@ -1,0 +1,28 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless.lang
+import stainless.annotation._
+
+object MutableMap {
+  @extern @library
+  def mkString[A, B](map: MutableMap[A, B], inkv: String, betweenkv: String, fA : A => String, fB: B => String) = {
+    map.theMap.map{ case (k, v) => fA(k) + inkv + fB(v)}.toList.sorted.mkString(betweenkv)
+  }
+
+  @ignore
+  def withDefaultValue[A,B](default: () => B) =
+    MutableMap[A,B](scala.collection.mutable.Map[A,B](), default)
+}
+
+@ignore
+case class MutableMap[A, B] (theMap: scala.collection.mutable.Map[A,B], default: () => B) {
+  def apply(k: A): B = if (theMap.contains(k)) {
+    theMap(k)
+  } else {
+    default()
+  }
+
+  def update(k: A, v: B): Unit = {
+    theMap(k) = v
+  }
+}

--- a/frontends/library/stainless/lang/MutableMap.scala
+++ b/frontends/library/stainless/lang/MutableMap.scala
@@ -5,17 +5,17 @@ import stainless.annotation._
 
 object MutableMap {
   @extern @library
-  def mkString[A, B](map: MutableMap[A, B], inkv: String, betweenkv: String, fA : A => String, fB: B => String) = {
+  def mkString[A, @mutable B](map: MutableMap[A, B], inkv: String, betweenkv: String, fA : A => String, fB: B => String) = {
     map.theMap.map{ case (k, v) => fA(k) + inkv + fB(v)}.toList.sorted.mkString(betweenkv)
   }
 
   @ignore
-  def withDefaultValue[A,B](default: () => B) =
+  def withDefaultValue[A, @mutable B](default: () => B) =
     MutableMap[A,B](scala.collection.mutable.Map[A,B](), default)
 }
 
 @ignore
-case class MutableMap[A, B] (theMap: scala.collection.mutable.Map[A,B], default: () => B) {
+case class MutableMap[A, @mutable B] (theMap: scala.collection.mutable.Map[A,B], default: () => B) {
   def apply(k: A): B = if (theMap.contains(k)) {
     theMap(k)
   } else {
@@ -24,5 +24,15 @@ case class MutableMap[A, B] (theMap: scala.collection.mutable.Map[A,B], default:
 
   def update(k: A, v: B): Unit = {
     theMap(k) = v
+  }
+
+  // To avoid the creation of aliases on the elements of `B`,
+  // `updated` and `duplicate` can only be used when `B` is an immutable type
+  def updated(k: A, v: B) = {
+    MutableMap(theMap.updated(k, v), default)
+  }
+
+  def duplicate() = {
+    MutableMap(theMap.clone(), default)
   }
 }

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -64,10 +64,11 @@ trait ASTExtractors {
 
   protected lazy val exceptionSym = classFromName("stainless.lang.Exception")
 
-  protected lazy val setSym      = classFromName("stainless.lang.Set")
-  protected lazy val mapSym      = classFromName("stainless.lang.Map")
-  protected lazy val bagSym      = classFromName("stainless.lang.Bag")
-  protected lazy val realSym     = classFromName("stainless.lang.Real")
+  protected lazy val setSym        = classFromName("stainless.lang.Set")
+  protected lazy val mapSym        = classFromName("stainless.lang.Map")
+  protected lazy val mutableMapSym = classFromName("stainless.lang.MutableMap")
+  protected lazy val bagSym        = classFromName("stainless.lang.Bag")
+  protected lazy val realSym       = classFromName("stainless.lang.Real")
 
   protected lazy val optionSymbol = classFromName("stainless.lang.Option")
   protected lazy val someSymbol   = classFromName("stainless.lang.Some")
@@ -119,6 +120,10 @@ trait ASTExtractors {
 
   def isMapSym(sym: Symbol) : Boolean = {
     getResolvedTypeSym(sym) == mapSym
+  }
+
+  def isMutableMapSym(sym: Symbol) : Boolean = {
+    getResolvedTypeSym(sym) == mutableMapSym
   }
 
   def isFunction(sym: Symbol, i: Int) : Boolean =
@@ -1036,6 +1041,16 @@ trait ASTExtractors {
           Some((fromTypeTree, toTypeTree))
         case _ =>
           None
+      }
+    }
+
+    object ExMutableMapWithDefault {
+      def unapply(tree: Apply): Option[(Tree,Tree,Tree)] = tree match {
+        case Apply(TypeApply(ExSelected("MutableMap", "withDefaultValue"), Seq(tptFrom, tptTo)), Seq(default)) =>
+          Some(tptFrom, tptTo, default)
+        case Apply(TypeApply(ExSelected("stainless", "lang", "MutableMap", "withDefaultValue"), Seq(tptFrom, tptTo)), Seq(default)) =>
+          Some(tptFrom, tptTo, default)
+        case _ => None
       }
     }
 

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -1295,6 +1295,12 @@ trait CodeExtraction extends ASTExtractors {
           case (xt.MutableMapType(_, _), "update", Seq(key, value)) =>
             xt.MutableMapUpdate(extractTree(lhs), extractTree(key), extractTree(value))
 
+          case (xt.MutableMapType(_, _), "updated", Seq(key, value)) =>
+            xt.MutableMapUpdated(extractTree(lhs), extractTree(key), extractTree(value))
+
+          case (xt.MutableMapType(_, _), "duplicate", Seq()) =>
+            xt.MutableMapDuplicate(extractTree(lhs))
+
           case (xt.MapType(_, _), "get", Seq(rhs)) =>
             xt.MapApply(extractTree(lhs), extractTree(rhs))
 


### PR DESCRIPTION
These are treated similarly to arrays and are transformed to normal maps in ImperativeCleanup
— @jad-hamza