### PR TITLE
Keep annotation and option to avoid filtering out library symbols

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -42,6 +42,7 @@ trait MainHelpers extends inox.MainHelpers {
     optCompact -> Description(General, "Print only invalid elements of summaries"),
     frontend.optPersistentCache -> Description(General, "Enable caching of program extraction & analysis"),
     frontend.optBatchedProgram -> Description(General, "Process the whole program together, skip dependency analysis"),
+    frontend.optKeep -> Description(General, "Keep library objects marked by @keep(g) for some g in g1,g2,... (implies --batched)"),
     utils.Caches.optCacheDir -> Description(General, "Specify the directory in which cache files should be stored")
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)

--- a/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
@@ -40,7 +40,7 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
     val userDependencies = userIds.flatMap(id => allSymbols.dependencies(id) ) ++ userIds
     val keepGroups = context.options.findOptionOrDefault(optKeep)
     def hasKeepFlag(flags: Seq[xt.Flag]) =
-      keepGroups.exists(g => flags.contains(xt.Annotation("keep",Seq(g))))
+      keepGroups.exists(g => flags.contains(xt.Annotation("keep",Seq(xt.StringLiteral(g)))))
 
     val symbols =
       xt.NoSymbols.withClasses(currentClasses.filter(cd => hasKeepFlag(cd.flags) || userDependencies.contains(cd.id)))

--- a/core/src/main/scala/stainless/frontend/CallBack.scala
+++ b/core/src/main/scala/stainless/frontend/CallBack.scala
@@ -5,6 +5,14 @@ package frontend
 
 import extraction.xlang.{ trees => xt }
 
+// Always keep library objects marked by @keep(g) for some g in g1,...,gn
+object optKeep extends inox.OptionDef[Seq[String]] {
+  val name = "keep"
+  val default = Seq[String]()
+  val parser = inox.OptionParsers.seqParser(inox.OptionParsers.stringParser)
+  val usageRhs = "g1,g2,..."
+}
+
 /**
  * Process the extracted units.
  *

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -75,6 +75,7 @@ package object frontend {
 
   private def batchSymbols(activeComponents: Seq[Component])(implicit ctx: inox.Context): Boolean = {
     ctx.options.findOptionOrDefault(optBatchedProgram) ||
+    !ctx.options.findOptionOrDefault(optKeep).isEmpty ||
     activeComponents.contains(termination.TerminationComponent)
   }
 }

--- a/frontends/library/stainless/annotation/annotations.scala
+++ b/frontends/library/stainless/annotation/annotations.scala
@@ -54,6 +54,13 @@ class law          extends Annotation
 @ignore
 class mutable          extends Annotation
 
+/** Can be used to mark a library function/class/object so that it is not
+  * filtered out by the keep objects. Use the command-line option `--keep=g` to
+  * keep all objects marked by `@keep(g)`
+  */
+@ignore
+class keep(g: String)      extends Annotation
+
 /**
  * Code annotated with @ghost is removed after stainless extraction.
  *


### PR DESCRIPTION
Implement @romac's idea for keeping symbols.

At the moment writing keep forces the use of `BatchedCallBack`.

In `BatchedCallBack`, we filter all library symbols except those marked by `@keep(g)` for some `g` given in the command-line option `--keep=g1,g2,...`

— @jad-hamza 

See #476