### PR TITLE
Add snapshot keyword for imperative code

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -90,7 +90,9 @@ lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
 
   testOptions in Test := Seq(Tests.Argument("-oDF")),
 
-  testOptions in IntegrationTest := Seq(Tests.Argument("-oDF"))
+  testOptions in IntegrationTest := Seq(Tests.Argument("-oDF")),
+
+  mappings in (Compile, packageDoc) := Seq()
 )
 
 lazy val libraryFiles: Seq[(String, File)] = {

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -321,6 +321,7 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       case IsInstanceOf(e, _) => rec(e, path)
       case AsInstanceOf(e, _) => rec(e, path)
       case Old(_) => Set.empty
+      case Snapshot(_) => Set.empty
 
       case Let(vd, e, b) if !symbols.isMutableType(vd.tpe) =>
         rec(b, path)

--- a/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
@@ -44,6 +44,8 @@ trait GhostChecker { self: EffectsAnalyzer =>
       // Measures are also considered ghost, as they are never executed
       case Decreases(_, body) => isGhostExpression(body)
 
+      case Snapshot(e) => true
+
       case FunInvocation(id, _, args, _) =>
         val fun = lookupFunction(id).map(Outer(_)).getOrElse(analysis.local(id))
         (fun.flags contains Ghost) ||
@@ -157,6 +159,10 @@ trait GhostChecker { self: EffectsAnalyzer =>
         case Assignment(v, e) if !(v.flags contains Ghost) && isGhostExpression(e) =>
           throw ImperativeEliminationException(expr,
             "Right-hand side of non-ghost variable assignment cannot be ghost")
+
+        case Snapshot(e) if !inGhost =>
+          throw ImperativeEliminationException(expr,
+            "Snapshots can only be used in ghost contexts")
 
         case FieldAssignment(obj, id, e) if isADT(obj) && isGhostExpression(ADTSelector(obj, id)) =>
           effects(e).find(!isGhostEffect(_)) match {

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -59,6 +59,8 @@ trait ImperativeCodeElimination
           val scope = (body: Expr) => rhsScope(Let(newVd, rhsVal, body).copiedFrom(expr))
           (UnitLiteral(), scope, rhsFun + (v -> newVd.toVariable))
 
+        case Snapshot(e) => toFunction(e)
+
         case ite @ IfExpr(cond, tExpr, eExpr) =>
           val (cRes, cScope, cFun) = toFunction(cond)
           val (tRes, tScope, tFun) = toFunction(tExpr)
@@ -409,6 +411,7 @@ trait ImperativeCodeElimination
       case (e: While) => true
       case (e: LetVar) => true
       case (e: Old) => true
+      case (e: Snapshot) => true
       case _ => false
     }
 

--- a/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
@@ -66,6 +66,9 @@ trait TransformerWithType extends oo.TransformerWithType {
     case s.Old(e) =>
       t.Old(transform(e, tpe)).copiedFrom(expr)
 
+    case s.Snapshot(e) =>
+      t.Snapshot(transform(e, tpe)).copiedFrom(expr)
+
     case s.BoolBitwiseAnd(lhs, rhs) =>
       t.BoolBitwiseAnd(transform(lhs, s.BooleanType()), transform(rhs, s.BooleanType())).copiedFrom(expr)
 

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -109,6 +109,11 @@ trait Trees extends oo.Trees with Definitions { self =>
     protected def computeType(implicit s: Symbols): Type = e.getType
   }
 
+  /** $encodingof `snapshot(e)` */
+  case class Snapshot(e: Expr) extends Expr with CachingTyped {
+    protected def computeType(implicit s: Symbols): Type = e.getType
+  }
+
   /** $encodingof `a & b` for Boolean; desuggared to { val l = lhs; val r = rhs; l && r } when removing imperative style. */
   case class BoolBitwiseAnd(lhs: Expr, rhs: Expr) extends Expr with CachingTyped {
     protected def computeType(implicit s: Symbols): Type =
@@ -229,6 +234,9 @@ trait Printer extends oo.Printer {
     case Old(e) =>
       p"old($e)"
 
+    case Snapshot(e) =>
+      p"snapshot($e)"
+
     case BoolBitwiseAnd(lhs, rhs) => optP {
       p"$lhs & $rhs"
     }
@@ -312,6 +320,9 @@ trait TreeDeconstructor extends oo.TreeDeconstructor {
 
     case s.MutableMapDuplicate(map) =>
       (Seq(), Seq(), Seq(map), Seq(), Seq(), (_, _, es, _, _) => t.MutableMapDuplicate(es(0)))
+
+    case s.Snapshot(e) =>
+      (Seq(), Seq(), Seq(e), Seq(), Seq(), (_, _, es, _, _) => t.Snapshot(es.head))
 
     case _ => super.deconstruct(e)
   }

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -73,9 +73,9 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
   /** An extension to the set of registered classes in the `StainlessSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 180 to 238.
+    * The new identifiers in the mapping range from 180 to 239.
     *
-    * NEXT ID: 239
+    * NEXT ID: 240
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -147,6 +147,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       classSerializer[MethodInvocation](216),
       classSerializer[IsMethodOf]      (217),
       classSerializer[IsAccessor]      (231),
+      classSerializer[Snapshot]        (239),
 
       classSerializer[MutableMapType]         (232),
       classSerializer[MutableMapWithDefault]  (233),

--- a/frontends/benchmarks/imperative/valid/Snapshot.scala
+++ b/frontends/benchmarks/imperative/valid/Snapshot.scala
@@ -1,8 +1,8 @@
 import stainless.lang._
-import stainless.annotation._
 import stainless.lang.StaticChecks._
+import stainless.annotation._
 
-trait Test {
+trait Snapshot {
   var x: BigInt
 
   def f() = {

--- a/frontends/benchmarks/imperative/valid/Snapshot.scala
+++ b/frontends/benchmarks/imperative/valid/Snapshot.scala
@@ -1,0 +1,14 @@
+import stainless.lang._
+import stainless.annotation._
+import stainless.lang.StaticChecks._
+
+trait Test {
+  var x: BigInt
+
+  def f() = {
+    require(x == 0)
+    @ghost val old = snapshot(this)
+    x = 1
+    assert(old.x == 0)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/Snapshot2.scala
+++ b/frontends/benchmarks/imperative/valid/Snapshot2.scala
@@ -1,0 +1,15 @@
+import stainless.lang._
+import stainless.lang.StaticChecks._
+import stainless.annotation._
+
+trait Snapshot2 {
+  var x: BigInt
+
+  def f() = {
+    require(x == 2)
+    @ghost val other = snapshot(this)
+    ghost { other.x = 5 }
+    assert(x == 2)
+    assert(other.x == 5)
+  }
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -703,6 +703,13 @@ trait ASTExtractors {
         case _ => None
       }
     }
+
+    object ExSnapshot {
+      def unapply(tree: tpd.Apply): Option[tpd.Tree] = tree match {
+        case Apply(TypeApply(ExSymbol("stainless", "lang", "package$", "snapshot"), Seq(_)), Seq(arg)) => Some(arg)
+        case _ => None
+      }
+    }
   }
 
   object ExIdentity {

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1002,6 +1002,8 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
 
     case ExOld(e) => xt.Old(extractTree(e))
 
+    case ExSnapshot(e) => xt.Snapshot(extractTree(e))
+
     case t @ Select(
       str @ ExSymbol("stainless", "lang", "package$", "StringDecorations"),
       ExNamed("bigLength")

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -84,6 +84,9 @@ package object lang {
   @ignore
   def old[T](value: T): T = value
 
+  @ignore @ghost
+  def snapshot[T](value: T): T = value
+
   @library
   @partialEval
   def partialEval[A](x: A): A = x

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -630,6 +630,15 @@ trait ASTExtractors {
       }
     }
 
+    object ExSnapshotExpression {
+      def unapply(tree: Apply) : Option[Tree] = tree match {
+        case a @ Apply(TypeApply(ExSymbol("stainless", "lang", "snapshot"), List(tpe)), List(arg)) =>
+          Some(arg)
+        case _ =>
+          None
+      }
+    }
+
     object ExChooseExpression {
       def unapply(tree: Apply) : Option[Tree] = tree match {
         case a @ Apply(

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -937,6 +937,8 @@ trait CodeExtraction extends ASTExtractors {
 
     case ExOldExpression(t) => xt.Old(extractTree(t))
 
+    case ExSnapshotExpression(t) => xt.Snapshot(extractTree(t))
+
     case ExErrorExpression(str, tpt) =>
       xt.Error(extractType(tpt), str)
 

--- a/frontends/stainless-dotty/src/it/scala/stainless/DottyExtractionSuite.scala
+++ b/frontends/stainless-dotty/src/it/scala/stainless/DottyExtractionSuite.scala
@@ -8,8 +8,8 @@ class DottyExtractionSuite extends ExtractionSuite {
   testExtractAll("verification/invalid")
   testExtractAll("verification/unchecked")
 
-  testExtractAll("imperative/valid"/*,
-    "imperative/valid/Blocks1.scala",*/
+  testExtractAll("imperative/valid",
+    "imperative/valid/Snapshot2.scala" // excluded due to https://github.com/epfl-lara/stainless/issues/419
   )
   testExtractAll("imperative/invalid")
 


### PR DESCRIPTION
Depends on #399, thanks @romac for the tips.

The Snapshot tree can be used to save the state of a mutable object, so that we can refer to it at a later point of the code.

— @jad-hamza 

Original PR at #418