### PR TITLE
Add serialization code for LocalMethodInvocation

### DIFF
--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -73,9 +73,9 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
   /** An extension to the set of registered classes in the `StainlessSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 180 to 239.
+    * The new identifiers in the mapping range from 180 to 240.
     *
-    * NEXT ID: 240
+    * NEXT ID: 241
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -135,6 +135,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       classSerializer[LocalMethodDef]       (234),
       classSerializer[LocalClassConstructor](235),
       classSerializer[LocalClassType]       (236),
+      classSerializer[LocalMethodInvocation](240),
 
       // Throwing trees
       classSerializer[Throwing](211),


### PR DESCRIPTION
This commit fixes a crash on example `AnonymousClasses3.scala` (due to a missing serialization code).