### PR TITLE
Disable measure injection in InductElimination

### DIFF
--- a/core/src/main/scala/stainless/extraction/induction/InductElimination.scala
+++ b/core/src/main/scala/stainless/extraction/induction/InductElimination.scala
@@ -54,12 +54,15 @@ trait InductElimination extends CachingPhase
 
     val (specs, oldBodyOpt) = deconstructSpecs(fd.fullBody)
 
-    if (!inductionParams.isEmpty)
-      specs.foreach {
-        case Measure(_) =>
-          context.reporter.warning(fd.getPos, s"Ignoring decreases clause of ${fd.id.asString}. The @induct annotation automatically inserts a decreases clause corresponding to the argument")
-        case _ => ()
-      }
+    // Disabled until we merge the new typechecker, as Stainless can currently properly infer the right measure.
+    // TODO: Typechecker
+    //
+    // if (!inductionParams.isEmpty)
+    //   specs.foreach {
+    //     case Measure(_) =>
+    //       context.reporter.warning(fd.getPos, s"Ignoring decreases clause of ${fd.id.asString}. The @induct annotation automatically inserts a decreases clause corresponding to the argument")
+    //     case _ => ()
+    //   }
 
     val inductionBody = oldBodyOpt.map(oldBody =>
       inductionParams.foldRight(oldBody) { case (vd, currentBody) =>
@@ -135,21 +138,28 @@ trait InductElimination extends CachingPhase
       }
     )
 
-    val newMeasure: Option[Specification] =
-      if (inductionParams.isEmpty) None
-      else if (inductionParams.size == 1) Some(Measure((inductionParams.head.toVariable)))
-      else Some(Measure(Tuple(inductionParams.map(_.toVariable))))
-    val newSpecs =
-      if (inductionParams.isEmpty) specs
-      else specs.filterNot(_.isInstanceOf[Measure]) ++ newMeasure
+    // Disabled until we merge the new typechecker, as Stainless can currently properly infer the right measure.
+    // TODO: Typechecker
+    //
+    // val newMeasure: Option[Specification] =
+    //   if (inductionParams.isEmpty) None
+    //   else if (inductionParams.size == 1) Some(Measure((inductionParams.head.toVariable)))
+    //   else Some(Measure(Tuple(inductionParams.map(_.toVariable))))
+    //
+    // val newSpecs =
+    //   if (inductionParams.isEmpty) specs
+    //   else specs.filterNot(_.isInstanceOf[Measure]) ++ newMeasure
+
+    val newSpecs = specs
     val newBody = reconstructSpecs(newSpecs, inductionBody, fd.returnType)
 
     new FunDef(
       fd.id,
       fd.tparams,
       fd.params,
-      // FIXME: fd.params should be fd.params.map(vd => vd.copy(flags = vd.flags.filterNot(_.name == "induct")).copiedFrom(vd)),
-      // but that creates a well-formedness exception
+      // FIXME: fd.params should be
+      //        `fd.params.map(vd => vd.copy(flags = vd.flags.filterNot(_.name == "induct")).copiedFrom(vd))`,
+      //         but that creates a well-formedness exception
       fd.returnType,
       newBody,
       fd.flags

--- a/core/src/main/scala/stainless/extraction/termination/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/termination/Trees.scala
@@ -6,10 +6,6 @@ package termination
 
 trait Trees extends extraction.Trees { self =>
 
-  override def extractFlag(name: String, args: Seq[Expr]): Flag = (name, args) match {
-    case _ => super.extractFlag(name, args)
-  }
-
   override def getDeconstructor(that: inox.ast.Trees): inox.ast.TreeDeconstructor { val s: self.type; val t: that.type } = that match {
     case tree: Trees => new TreeDeconstructor {
       protected val s: self.type = self
@@ -27,8 +23,4 @@ trait Printer extends extraction.Printer {
 trait TreeDeconstructor extends extraction.TreeDeconstructor {
   protected val s: Trees
   protected val t: Trees
-
-  override def deconstruct(f: s.Flag): DeconstructedFlag = f match {
-    case _ => super.deconstruct(f)
-  }
 }

--- a/frontends/benchmarks/verification/valid/ListOperations.scala
+++ b/frontends/benchmarks/verification/valid/ListOperations.scala
@@ -90,6 +90,7 @@ object ListOperations {
     def concat(l1: List, l2: List) : List = 
       concat0(l1, l2, Nil()) ensuring(content(_) == content(l1) ++ content(l2))
 
+    @induct // This is not required but is kept as a sanity check
     def concat0(l1: List, l2: List, l3: List) : List = (l1 match {
       case Nil() => l2 match {
         case Nil() => reverse(l3)


### PR DESCRIPTION
This is needed until we merge the typechecker, as the injected measure throws
off the termination checker, and Stainless can currently already properly
infer the appropriate measure.