### PR TITLE
No EffectsChecker in accessors

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -266,7 +266,9 @@ trait EffectsChecker { self: EffectsAnalyzer =>
     }
 
     try {
-      check(Outer(fd))
+      // We only check the bodies of functions which are not accessors
+      if (!isAccessor(Outer(fd)))
+        check(Outer(fd))
       CheckResult.Ok
     } catch {
       case e: ImperativeEliminationException => CheckResult.Error(e)

--- a/frontends/benchmarks/imperative/valid/TraitVar3.scala
+++ b/frontends/benchmarks/imperative/valid/TraitVar3.scala
@@ -1,0 +1,7 @@
+object TraitVar3 {
+  case class A(var a: BigInt)
+
+  trait TraitVar {
+    var v: A
+  }
+}


### PR DESCRIPTION
Fixes https://github.com/epfl-lara/stainless/issues/413 by removing aliasing checks from accessors. Does this workaround make sense?