### PR TITLE
Prevent over-simplifications in ImperativeCodeElimination

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -181,14 +181,17 @@ trait ImperativeCodeElimination
           val (scope, fun) = exprs.foldRight((body: Expr) => body, Map[Variable, Variable]()) { (e, acc) =>
             val (accScope, accFun) = acc
             val (rVal, rScope, rFun) = toFunction(e)
-            val scope = (body: Expr) => rVal match {
-              case fi: FunctionInvocation =>
-                rScope(replaceFromSymbols(rFun, Let(ValDef.fresh("tmp", fi.tfd.returnType).copiedFrom(body), rVal, accScope(body)).copiedFrom(body)))
-              case alr: ApplyLetRec =>
-                rScope(replaceFromSymbols(rFun, Let(ValDef.fresh("tmp", alr.getType).copiedFrom(body), rVal, accScope(body)).copiedFrom(body)))
-              case _ =>
-                rScope(replaceFromSymbols(rFun, accScope(body)))
-            }
+            val scope = (body: Expr) =>
+              rScope(
+                replaceFromSymbols(
+                  rFun,
+                  Let(
+                    ValDef.fresh("tmp", rVal.getType).copiedFrom(body),
+                    rVal,
+                    accScope(body)
+                  ).copiedFrom(body)
+                )
+              )
             (scope, rFun ++ accFun)
           }
 

--- a/frontends/benchmarks/imperative/valid/OldThis3.scala
+++ b/frontends/benchmarks/imperative/valid/OldThis3.scala
@@ -5,6 +5,7 @@ object OldThis3 {
   case class A(var a: Int) {
     def foo(b: Int): Unit = {
       a + b // no assignement
+      ()
     } ensuring(_ => a == old(this).a)
   }
 

--- a/frontends/benchmarks/imperative/valid/OldThis4.scala
+++ b/frontends/benchmarks/imperative/valid/OldThis4.scala
@@ -5,6 +5,7 @@ object OldThis4 {
   case class A(var a: Int) {
     def foo(b: Int): Unit = {
       b + b // a never used
+      ()
     } ensuring(_ => a == old(this).a)
   }
 


### PR DESCRIPTION
(In conjunction with https://github.com/epfl-lara/inox/pull/99) Fixes https://github.com/epfl-lara/stainless/issues/532

I'm not sure what this code does, but it was throwing away the tuple https://github.com/epfl-lara/stainless/issues/532, and only keeping `FunctionInvocation`'s and `ApplyLetRec`'s. I replaced that part so that all expressions are kept, does that seem correct?