### PR TITLE
Emit warning when dropping the non-empty body of a user @extern function

### DIFF
--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -605,7 +605,24 @@ trait CodeExtraction extends ASTExtractors {
       }
     }
 
+    object KeywordChecker extends xt.SelfTreeTraverser {
+      override def traverse(e: xt.Expr) = {
+        e match {
+          case _: xt.Require =>
+            reporter.warning(e.getPos, s"This require is ignored for verification because it is not at the top-level of this @extern function.")
+          case _: xt.Ensuring =>
+            reporter.warning(e.getPos, s"This ensuring is ignored for verification because it is not at the top-level of this @extern function.")
+          case _: xt.Assert =>
+            reporter.warning(e.getPos, s"This assert is ignored for verification because it is not at the top-level of this @extern function.")
+          case _ =>
+            ()
+        }
+        super.traverse(e)
+      }
+    }
+
     val fullBody = if (fctx.isExtern) {
+      xt.exprOps.withoutSpecs(finalBody) foreach { KeywordChecker.traverse }
       xt.exprOps.withBody(finalBody, xt.NoTree(returnType).setPos(body.pos))
     } else {
       finalBody


### PR DESCRIPTION
Run on the example from https://github.com/epfl-lara/stainless/issues/549, this will print:

```
[Warning ] Dropped non-empty body of @extern function g.
```

Would that even help the user figuring out what's happening? Also, I'm afraid this warning will get annoying if you actually want to have non-empty `@extern` functions.