### PR TITLE
Removes @library flag on typeclasses which have non-library subclasses

### DIFF
--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -97,25 +97,10 @@ trait ComponentRun { self =>
   def apply(ids: Seq[Identifier], symbols: xt.Symbols, filterSymbols: Boolean = false): Future[Analysis] = try {
     val exSymbols = extract(symbols)
 
-    def isDerivedFrom(ids: Set[Identifier])(fd: trees.FunDef): Boolean =
-      fd.flags.exists { case trees.Derived(id) => ids(id) case _ => false }
+    val toProcess = extractionFilter.filter(ids, exSymbols, reporter, component.name)
 
-    val toCheck = inox.utils.fixpoint { (ids: Set[Identifier]) =>
-      ids ++ exSymbols.functions.values.toSeq
-        .filter(isDerivedFrom(ids))
-        .filter(extractionFilter.shouldBeChecked)
-        .map(_.id)
-    } (ids.flatMap(id => exSymbols.lookupFunction(id).toSeq).filter(extractionFilter.shouldBeChecked).map(_.id).toSet)
-
-    val toProcess = toCheck.toSeq.sortBy(exSymbols.getFunction(_).getPos)
-
-    for (id <- toProcess) {
-      val fd = exSymbols.getFunction(id)
-      if (fd.flags exists (_.name == "library")) {
-        val fullName = fd.id.fullName
-        reporter.warning(s"Component [${component.name}]: Forcing processing of $fullName which was assumed verified")
-      }
-    }
+    println(toProcess.map(_.asString(new xt.PrinterOptions(printUniqueIds = true))))
+    println(exSymbols.asString(new trees.PrinterOptions(printUniqueIds = true)))
 
     if (filterSymbols)
       execute(toProcess, filter(toProcess, exSymbols))

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -97,7 +97,7 @@ trait ComponentRun { self =>
   def apply(ids: Seq[Identifier], symbols: xt.Symbols, filterSymbols: Boolean = false): Future[Analysis] = try {
     val exSymbols = extract(symbols)
 
-    val toProcess = extractionFilter.filter(ids, exSymbols, reporter, component.name)
+    val toProcess = extractionFilter.filter(ids, exSymbols, component)
 
     if (filterSymbols)
       execute(toProcess, filter(toProcess, exSymbols))

--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -99,9 +99,6 @@ trait ComponentRun { self =>
 
     val toProcess = extractionFilter.filter(ids, exSymbols, reporter, component.name)
 
-    println(toProcess.map(_.asString(new xt.PrinterOptions(printUniqueIds = true))))
-    println(exSymbols.asString(new trees.PrinterOptions(printUniqueIds = true)))
-
     if (filterSymbols)
       execute(toProcess, filter(toProcess, exSymbols))
     else

--- a/core/src/main/scala/stainless/ast/Deconstructors.scala
+++ b/core/src/main/scala/stainless/ast/Deconstructors.scala
@@ -201,6 +201,7 @@ trait TreeDeconstructor extends inox.ast.TreeDeconstructor {
     case s.Private => (Seq(), Seq(), Seq(), (_, _, _) => t.Private)
     case s.Final => (Seq(), Seq(), Seq(), (_, _, _) => t.Final)
     case s.Unchecked => (Seq(), Seq(), Seq(), (_, _, _) => t.Unchecked)
+    case s.Library => (Seq(), Seq(), Seq(), (_, _, _) => t.Library)
     case s.Synthetic => (Seq(), Seq(), Seq(), (_, _, _) => t.Synthetic)
     case s.Derived(id) => (Seq(id), Seq(), Seq(), (ids, _, _) => t.Derived(ids.head))
     case s.IsField(isLazy) => (Seq(), Seq(), Seq(), (_, _, _) => t.IsField(isLazy))

--- a/core/src/main/scala/stainless/ast/Definitions.scala
+++ b/core/src/main/scala/stainless/ast/Definitions.scala
@@ -18,6 +18,7 @@ trait Definitions extends inox.ast.Definitions { self: Trees =>
   case object Private extends Flag("private", Seq.empty)
   case object Final extends Flag("final", Seq.empty)
   case object Unchecked extends Flag("unchecked", Seq.empty)
+  case object Library extends Flag("library", Seq.empty)
   case object Synthetic extends Flag("synthetic", Seq())
   case object PartialEval extends Flag("partialEval", Seq())
   case class Derived(id: Identifier) extends Flag("derived", Seq(id))
@@ -32,6 +33,7 @@ trait Definitions extends inox.ast.Definitions { self: Trees =>
     case ("extern", Seq()) => Extern
     case ("opaque", Seq()) => Opaque
     case ("unchecked", Seq()) => Unchecked
+    case ("library", Seq()) => Library
     case ("partialEval", Seq()) => PartialEval
     case _ => Annotation(name, args)
   }

--- a/core/src/main/scala/stainless/extraction/methods/Laws.scala
+++ b/core/src/main/scala/stainless/extraction/methods/Laws.scala
@@ -238,6 +238,7 @@ trait Laws
           .map(tp => t.TypeParameterDef(transform(tp, env).asInstanceOf[t.TypeParameter]).copiedFrom(tp))
         val params = lawFd.params
           .map(vd => transform(vd.copy(tpe = s.typeOps.instantiateType(vd.tpe, acd.tpSubst)), env))
+        val libraryFlag = if (cd.flags.contains(s.Library)) Seq(t.Library, t.Unchecked) else Seq.empty
 
         t.exprOps.freshenSignature(new t.FunDef(
           SymbolIdentifier(lawFd.id.unsafeToSymbolIdentifier.symbol),
@@ -255,7 +256,7 @@ trait Laws
               ).setPos(lawFd)
             ).setPos(lawFd)
           ).setPos(lawFd),
-          Seq(t.IsMethodOf(cd.id), t.Derived(lawFd.id), t.Law)
+          Seq(t.IsMethodOf(cd.id), t.Derived(lawFd.id), t.Law) ++ libraryFlag.toSeq
         ).setPos(cd))
       }
 

--- a/core/src/main/scala/stainless/extraction/methods/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/methods/Trees.scala
@@ -208,6 +208,7 @@ trait Trees extends throwing.Trees { self =>
   implicit class ClassDefWrapper(cd: ClassDef) {
     def isSealed: Boolean = cd.flags contains IsSealed
     def isAbstract: Boolean = cd.flags contains IsAbstract
+    def isLibrary: Boolean = cd.flags contains Library
 
     def methods(implicit s: Symbols): Seq[SymbolIdentifier] = {
       s.functions.values
@@ -251,6 +252,7 @@ trait Trees extends throwing.Trees { self =>
     def isInvariant: Boolean = fd.flags contains IsInvariant
     def isExtern: Boolean = fd.flags contains Extern
     def isLaw: Boolean = fd.flags contains Law
+    def isLibrary: Boolean = fd.flags contains Library
   }
 
   override def getDeconstructor(that: inox.ast.Trees): inox.ast.TreeDeconstructor { val s: self.type; val t: that.type } = that match {

--- a/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
@@ -47,6 +47,46 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
   def failed(): Unit = {}
 
   def endExtractions(): Unit = {
+    implicit val popts = xt.PrinterOptions.fromContext(context)
+
+    def rewriteSymbols(symbols: xt.Symbols): xt.Symbols = {
+      // remove library flag from all classes and laws that have subclasses without @library
+      ???
+    }
+
+    def keepDefinition(defn: xt.Definition, symbols: xt.Symbols): Boolean = {
+      if(defn.flags.contains(xt.Synthetic))
+        false
+      else defn match {
+        case cd: xt.ClassDef => !cd.flags.exists(f => f.name == "library")
+        case td: xt.TypeDef => !td.flags.exists(f => f.name == "library")
+        case fn: xt.FunDef =>
+          val isLibrary = fn.flags.exists(f => f.name == "library")
+
+          if (fn.isLaw)
+            if(isLibrary) {
+              val optClass = fn.getClassDef(symbols)
+
+              optClass match {
+                case None => false
+                case Some(cd) => {
+
+                  (for {
+                    subclass <- cd.descendants(symbols)
+
+                    if !subclass.flags.exists(f => f.name == "library")
+                    if !subclass.methods(symbols).map(symbols.getFunction).exists(subFn => subFn.id.name == fn.id.name && subFn.flags.exists(flag => flag.name == "library"))
+                  } yield subclass).nonEmpty
+                }
+              }
+
+            } else
+              true
+          else
+            !isLibrary
+      }
+    }
+
     val allSymbols = xt.NoSymbols
       .withClasses(currentClasses)
       .withFunctions(currentFunctions)
@@ -55,9 +95,11 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
     def notUserFlag(f: xt.Flag) = f.name == "library" || f == xt.Synthetic
 
     val userIds =
-      currentClasses.filterNot(cd => cd.flags.exists(notUserFlag)).map(_.id) ++
-      currentFunctions.filterNot(fd => fd.flags.exists(notUserFlag)).map(_.id) ++
-      currentTypeDefs.filterNot(td => td.flags.exists(notUserFlag)).map(_.id)
+      currentClasses.filter(cd => keepDefinition(cd, allSymbols)).map(_.id) ++
+      currentFunctions.filter(fd => keepDefinition(fd, allSymbols)).map(_.id) ++
+      currentTypeDefs.filter(td => keepDefinition(td, allSymbols)).map(_.id)
+
+    // println(userIds.map(_.asString))
 
     val userDependencies = userIds.flatMap(id => allSymbols.dependencies(id)) ++ userIds
     val keepGroups = context.options.findOptionOrDefault(optKeep)
@@ -69,6 +111,8 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
       xt.NoSymbols.withClasses(currentClasses.filter(cd => hasKeepFlag(cd.flags) || userDependencies.contains(cd.id)))
                   .withFunctions(currentFunctions.filter(fd => hasKeepFlag(fd.flags) || userDependencies.contains(fd.id)))
                   .withTypeDefs(currentTypeDefs.filter(td => hasKeepFlag(td.flags) || userDependencies.contains(td.id)))
+
+    // println(preSymbols.asString)
 
     val symbols = Recovery.recover(preSymbols)
 

--- a/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
@@ -4,6 +4,7 @@ package stainless
 package frontend
 
 import stainless.extraction.xlang.{trees => xt, TreeSanitizer}
+import stainless.utils.LibraryFilter._
 
 import scala.util.{Try, Success, Failure}
 import scala.concurrent.Await
@@ -47,76 +48,30 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
   def failed(): Unit = {}
 
   def endExtractions(): Unit = {
-    implicit val popts = xt.PrinterOptions.fromContext(context)
-
-    def shouldRemoveLibraryFlag(fn: xt.FunDef, symbols: xt.Symbols): Boolean = {
-      if(fn.flags.contains(xt.Synthetic) || !fn.isLibrary || !fn.isLaw)
-        false
-      else {
-        val optClass = fn.getClassDef(symbols)
-
-        optClass match {
-          case None => false
-          case Some(cd) =>
-            (for {
-              subclass <- cd.descendants(symbols)
-
-              // Check if subclass is not library
-              if !subclass.isLibrary
-
-              // Check if the subclass doesn't override the method with one that is specifically flagged as library
-              if !subclass.methods(symbols).map(symbols.getFunction).exists(subFn =>
-                    subFn.id.name == fn.id.name && subFn.isLibrary)
-            } yield subclass).nonEmpty
-        }
-      }
-    }
-
     val allSymbols = xt.NoSymbols
       .withClasses(currentClasses)
       .withFunctions(currentFunctions)
       .withTypeDefs(currentTypeDefs)
 
-    val funsToRemoveLibrary: Set[Identifier] =
-      (for {
-        fd <- allSymbols.functions.values
-        if shouldRemoveLibraryFlag(fd, allSymbols)
-      } yield fd.id).toSet
-
-    def removeLibrary(fd: xt.FunDef): xt.FunDef =
-      if (funsToRemoveLibrary.contains(fd.id))
-        fd.copy(flags = fd.flags.filterNot(_.name == "library"))
-      else
-        fd
-
-    currentFunctions = currentFunctions.map(removeLibrary)
-
-    val allSymbolsLibraryFlagRemoved = xt.NoSymbols
-      .withClasses(currentClasses)
-      .withFunctions(currentFunctions)
-      .withTypeDefs(currentTypeDefs)
+    val symbolsRmFlag = removeLibraryFlag(allSymbols)
 
     def notUserFlag(f: xt.Flag) = f.name == "library" || f == xt.Synthetic
 
     val userIds =
-      currentClasses.filterNot(cd => cd.flags.exists(notUserFlag)).map(_.id) ++
-      currentFunctions.filterNot(fd => fd.flags.exists(notUserFlag)).map(_.id) ++
-      currentTypeDefs.filterNot(td => td.flags.exists(notUserFlag)).map(_.id)
+      symbolsRmFlag.classes.values.filterNot(cd => cd.flags.exists(notUserFlag)).map(_.id) ++
+      symbolsRmFlag.functions.values.filterNot(fd => fd.flags.exists(notUserFlag)).map(_.id) ++
+      symbolsRmFlag.typeDefs.values.filterNot(td => td.flags.exists(notUserFlag)).map(_.id)
 
-    // println(userIds.map(_.asString))
-
-    val userDependencies = userIds.flatMap(id => allSymbolsLibraryFlagRemoved.dependencies(id)) ++ userIds
+    val userDependencies = (userIds.flatMap(id => symbolsRmFlag.dependencies(id)) ++ userIds).toSeq
     val keepGroups = context.options.findOptionOrDefault(optKeep)
 
     def hasKeepFlag(flags: Seq[xt.Flag]) =
       keepGroups.exists(g => flags.contains(xt.Annotation("keep", Seq(xt.StringLiteral(g)))))
 
     val preSymbols =
-      xt.NoSymbols.withClasses(currentClasses.filter(cd => hasKeepFlag(cd.flags) || userDependencies.contains(cd.id)))
-                  .withFunctions(currentFunctions.filter(fd => hasKeepFlag(fd.flags) || userDependencies.contains(fd.id)))
-                  .withTypeDefs(currentTypeDefs.filter(td => hasKeepFlag(td.flags) || userDependencies.contains(td.id)))
-
-    // println(preSymbols.asString)
+      xt.NoSymbols.withClasses(symbolsRmFlag.classes.values.filter(cd => hasKeepFlag(cd.flags) || userDependencies.contains(cd.id)).toSeq)
+                  .withFunctions(symbolsRmFlag.functions.values.filter(fd => hasKeepFlag(fd.flags) || userDependencies.contains(fd.id)).toSeq)
+                  .withTypeDefs(symbolsRmFlag.typeDefs.values.filter(td => hasKeepFlag(td.flags) || userDependencies.contains(td.id)).toSeq)
 
     val symbols = Recovery.recover(preSymbols)
 

--- a/core/src/main/scala/stainless/frontend/SplitCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/SplitCallBack.scala
@@ -3,6 +3,8 @@
 package stainless
 package frontend
 
+import stainless.utils.LibraryFilter._
+
 import scala.language.existentials
 
 import extraction.xlang.{ TreeSanitizer, trees => xt }
@@ -60,6 +62,8 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
   final override def failed(): Unit = ()
 
   final override def endExtractions(): Unit = {
+    symbols = removeLibraryFlag(symbols)
+
     processSymbols(symbols)
 
     if (report != null) report = report.filter(recentIdentifiers.toSet)

--- a/core/src/main/scala/stainless/frontend/SplitCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/SplitCallBack.scala
@@ -3,7 +3,7 @@
 package stainless
 package frontend
 
-import stainless.utils.LibraryFilter._
+import stainless.utils.LibraryFilter
 
 import scala.language.existentials
 
@@ -62,7 +62,7 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
   final override def failed(): Unit = ()
 
   final override def endExtractions(): Unit = {
-    symbols = removeLibraryFlag(symbols)
+    symbols = LibraryFilter.removeLibraryFlag(symbols)
 
     processSymbols(symbols)
 

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -18,7 +18,7 @@ trait InoxEncoder extends ProgramEncoder {
   import context._
 
   private[this] def keepFlag(flag: Flag): Boolean = flag match {
-    case Unchecked | Synthetic | PartialEval | Extern | Opaque | Private | Final | Law | Ghost | Erasable => false
+    case Unchecked | Library | Synthetic | PartialEval | Extern | Opaque | Private | Final | Law | Ghost | Erasable => false
     case Derived(_) | IsField(_) | IsUnapply(_, _) | IndexedAt(_) => false
     case _ => true
   }

--- a/core/src/main/scala/stainless/utils/CheckFilter.scala
+++ b/core/src/main/scala/stainless/utils/CheckFilter.scala
@@ -3,8 +3,6 @@
 package stainless
 package utils
 
-import inox.Reporter
-
 /** Filter functions for verification purposes. */
 trait CheckFilter {
   protected val context: inox.Context
@@ -49,7 +47,7 @@ trait CheckFilter {
       }
   }
 
-  def filter(ids: Seq[Identifier], symbols: trees.Symbols, reporter: Reporter, componentName: String): Seq[Identifier] = {
+  def filter(ids: Seq[Identifier], symbols: trees.Symbols, component: Component): Seq[Identifier] = {
     def isDerivedFrom(ids: Set[Identifier])(fd: trees.FunDef): Boolean =
       fd.flags.exists { case trees.Derived(id) => ids(id) case _ => false }
 
@@ -68,7 +66,8 @@ trait CheckFilter {
       val fd = symbols.getFunction(id)
       if (fd.flags exists (_.name == "library")) {
         val fullName = fd.id.fullName
-        reporter.warning(s"Component [${componentName}]: Forcing processing of $fullName which was assumed verified")
+        context.reporter.warning(
+          s"Component [${component.name}]: Forcing processing of $fullName which was assumed verified")
       }
     }
 

--- a/core/src/main/scala/stainless/utils/CheckFilter.scala
+++ b/core/src/main/scala/stainless/utils/CheckFilter.scala
@@ -55,9 +55,6 @@ trait CheckFilter {
 
     val init = ids.flatMap(id => symbols.lookupFunction(id).toSeq).filter(shouldBeChecked).map(_.id).toSet
 
-    println(('ids, ids.map(_.asString(new trees.PrinterOptions(printUniqueIds = true)))))
-    println(('init, init.map(_.asString(new trees.PrinterOptions(printUniqueIds = true)))))
-
     val toCheck = inox.utils.fixpoint { (ids: Set[Identifier]) =>
       ids ++ symbols.functions.values.toSeq
         .filter(isDerivedFrom(ids))

--- a/core/src/main/scala/stainless/utils/LibraryFilter.scala
+++ b/core/src/main/scala/stainless/utils/LibraryFilter.scala
@@ -1,0 +1,53 @@
+package stainless
+package utils
+
+import stainless.extraction.xlang.{trees => xt}
+
+object LibraryFilter {
+
+  private def shouldRemoveLibraryFlag(fn: xt.FunDef, symbols: xt.Symbols): Boolean = {
+    if(fn.flags.contains(xt.Synthetic) || !fn.isLibrary || !fn.isLaw)
+      false
+    else {
+      val optClass = fn.getClassDef(symbols)
+
+      optClass match {
+        case None => false
+        case Some(cd) =>
+          (for {
+            subclass <- cd.descendants(symbols)
+
+            // Check if subclass is not library
+            if !subclass.isLibrary
+
+            // Check if the subclass doesn't override the method with one that is specifically flagged as library
+            if !subclass.methods(symbols).map(symbols.getFunction).exists(subFn =>
+                  subFn.id.name == fn.id.name && subFn.isLibrary)
+          } yield subclass).nonEmpty
+      }
+    }
+  }
+
+  def removeLibraryFlag(symbols: xt.Symbols): xt.Symbols = {
+    val funsToRemoveLibrary: Set[Identifier] =
+      (for {
+        fd <- symbols.functions.values
+        if shouldRemoveLibraryFlag(fd, symbols)
+      } yield fd.id).toSet
+
+    def removeLibrary(fd: xt.FunDef): xt.FunDef =
+      if (funsToRemoveLibrary.contains(fd.id))
+        fd.copy(flags = fd.flags.filterNot(_.name == "library"))
+      else
+        fd
+
+    val currentClasses = symbols.classes.values.toSeq
+    val currentFunctions = symbols.functions.values.toSeq.map(removeLibrary)
+    val currentTypeDefs = symbols.typeDefs.values.toSeq
+
+    xt.NoSymbols
+      .withClasses(currentClasses)
+      .withFunctions(currentFunctions)
+      .withTypeDefs(currentTypeDefs)
+  }
+}

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -55,6 +55,7 @@ class StainlessSerializer(override val trees: ast.Trees, serializeProducts: Bool
       classSerializer[Extern.type]     (139),
       classSerializer[Opaque.type]     (140),
       classSerializer[Unchecked.type]  (141),
+      classSerializer[Library.type]    (158),
       classSerializer[Derived]         (142),
       classSerializer[IsField]         (143),
       classSerializer[IsUnapply]       (144),

--- a/frontends/common/src/test/scala/stainless/ast/LawsLibrarySuite.scala
+++ b/frontends/common/src/test/scala/stainless/ast/LawsLibrarySuite.scala
@@ -7,7 +7,7 @@ import org.scalatest._
 import scala.language.existentials
 import extraction.methods.trees.Library
 
-class LibraryInheritanceSuite extends FunSuite with InputUtils {
+class LawsLibrarySuite extends FunSuite with InputUtils {
 
   val sources = List(
     """|import stainless.lang._
@@ -40,41 +40,73 @@ class LibraryInheritanceSuite extends FunSuite with InputUtils {
        |
        |case class UserBigInt() extends AssociativeBigInt {
        |  def append(x: BigInt, y: BigInt): BigInt = x + y + List[Int]().length
-       |}""".stripMargin)
+       |}
+       |""".stripMargin)
 
   implicit val ctx = stainless.TestContext.empty
   val (_, xlangProgram) = load(sources)
 
   val libraryBigInt = xlangProgram.symbols.classes.values.find(_.id.name == "LibraryBigInt").get
-  val libraryAppend = libraryBigInt.methods(xlangProgram.symbols).map(xlangProgram.symbols.getFunction).find(_.id.name == "append").get
+  val libraryAppend = libraryBigInt.methods(xlangProgram.symbols)
+    .find(_.name == "append")
+    .map(xlangProgram.symbols.getFunction)
+    .get
 
   def pipeline = {
     extraction.xlang.extractor        andThen
     extraction.innerclasses.extractor andThen
-    extraction.utils.DebugPipeline("Laws", extraction.methods.Laws(extraction.methods.trees))
+    extraction.methods.Laws(extraction.methods.trees)
   }
 
   val symbols = pipeline extract xlangProgram.symbols
 
+  test("LibraryBigInt#append has @library flag before extraction") {
+    assert(libraryAppend.flags.contains(xlangProgram.trees.Library))
+  }
+
+  test("LibraryBigInt#append still has @library flag after extraction") {
+    val libraryBigInt = symbols.classes.values.find(_.id.name == "LibraryBigInt").get
+
+    val libraryAppend = libraryBigInt.methods(symbols)
+      .find(_.name == "append")
+      .map(symbols.getFunction)
+      .get
+
+    assert(libraryAppend.flags.contains(Library))
+  }
+
   test("Remove library flag from library laws that have non-library subclasses") {
     val userBigInt = symbols.classes.values.find(_.id.name == "UserBigInt").get
 
-    val law_commu = userBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_commutative").get
-    val law_asso = userBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_associative").get
+    val law_commutative = userBigInt.methods(symbols)
+      .find(_.name == "law_commutative")
+      .map(symbols.getFunction)
+      .get
 
-    assert(!law_commu.flags.contains(Library))
-    assert(!law_asso.flags.contains(Library))
+    val law_associative = userBigInt.methods(symbols)
+      .find(_.name == "law_associative")
+      .map(symbols.getFunction)
+      .get
+
+    assert(!law_commutative.flags.contains(Library))
+    assert(!law_associative.flags.contains(Library))
   }
 
-  test("Don't remove library flag from library case classes that have non-library 'brothers'") {
+  test("Don't remove library flag from library case classes that have non-library siblings") {
     val libraryBigInt = symbols.classes.values.find(_.id.name == "LibraryBigInt").get
 
-    val law_commu = libraryBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_commutative").get
-    val law_asso = libraryBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_associative").get
+    val law_commutative = libraryBigInt.methods(symbols)
+      .find(_.name == "law_commutative")
+      .map(symbols.getFunction)
+      .get
 
-    assert(libraryAppend.flags.contains(xlangProgram.trees.Library))
-    assert(law_commu.flags.contains(Library))
-    assert(law_asso.flags.contains(Library))
+    val law_associative = libraryBigInt.methods(symbols)
+      .find(_.name == "law_associative")
+      .map(symbols.getFunction)
+      .get
+
+    assert(law_commutative.flags.contains(Library))
+    assert(law_associative.flags.contains(Library))
   }
 
   test("Don't remove library flag from library functions that are used in non-library methods") {

--- a/frontends/common/src/test/scala/stainless/ast/LibraryInheritanceSuite.scala
+++ b/frontends/common/src/test/scala/stainless/ast/LibraryInheritanceSuite.scala
@@ -1,0 +1,84 @@
+/* Copyright 2009-2018 EPFL, Lausanne */
+
+package stainless
+package ast
+
+import org.scalatest._
+import scala.language.existentials
+import extraction.methods.trees.Library
+
+class LibraryInheritanceSuite extends FunSuite with InputUtils {
+
+  val sources = List(
+    """|import stainless.lang._
+       |import stainless.proof._
+       |import stainless.collection._
+       |import stainless.annotation._
+       |
+       |@library
+       |sealed abstract class CommutativeBigInt {
+       |  def append(x: BigInt, y: BigInt): BigInt
+       |
+       |  @law
+       |  def law_commutative(x: BigInt, y: BigInt): Boolean = {
+       |    append(x, y) == append(y, x)
+       |  }
+       |}
+       |
+       |@library
+       |sealed abstract class AssociativeBigInt extends CommutativeBigInt {
+       |  @law
+       |  def law_associative(x: BigInt, y: BigInt, z: BigInt): Boolean = {
+       |    append(append(x, y), z) == append(x, append(y, z))
+       |  }
+       |}
+       |
+       |@library
+       |case class LibraryBigInt() extends AssociativeBigInt {
+       |  def append(x: BigInt, y: BigInt): BigInt = x + y
+       |}
+       |
+       |case class UserBigInt() extends AssociativeBigInt {
+       |  def append(x: BigInt, y: BigInt): BigInt = x + y + List[Int]().length
+       |}""".stripMargin)
+
+  implicit val ctx = stainless.TestContext.empty
+  val (_, xlangProgram) = load(sources)
+
+  val libraryBigInt = xlangProgram.symbols.classes.values.find(_.id.name == "LibraryBigInt").get
+  val libraryAppend = libraryBigInt.methods(xlangProgram.symbols).map(xlangProgram.symbols.getFunction).find(_.id.name == "append").get
+
+  def pipeline = {
+    extraction.xlang.extractor        andThen
+    extraction.innerclasses.extractor andThen
+    extraction.utils.DebugPipeline("Laws", extraction.methods.Laws(extraction.methods.trees))
+  }
+
+  val symbols = pipeline extract xlangProgram.symbols
+
+  test("Remove library flag from library laws that have non-library subclasses") {
+    val userBigInt = symbols.classes.values.find(_.id.name == "UserBigInt").get
+
+    val law_commu = userBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_commutative").get
+    val law_asso = userBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_associative").get
+
+    assert(!law_commu.flags.contains(Library))
+    assert(!law_asso.flags.contains(Library))
+  }
+
+  test("Don't remove library flag from library case classes that have non-library 'brothers'") {
+    val libraryBigInt = symbols.classes.values.find(_.id.name == "LibraryBigInt").get
+
+    val law_commu = libraryBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_commutative").get
+    val law_asso = libraryBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_associative").get
+
+    assert(libraryAppend.flags.exists(_.name == "library"))
+    assert(law_commu.flags.contains(Library))
+    assert(law_asso.flags.contains(Library))
+  }
+
+  test("Don't remove library flag from library functions that are used in non-library methods") {
+    val fd = symbols.functions.values.find(_.id.name == "length").get
+    assert(fd.flags.contains(Library))
+  }
+}

--- a/frontends/common/src/test/scala/stainless/ast/LibraryInheritanceSuite.scala
+++ b/frontends/common/src/test/scala/stainless/ast/LibraryInheritanceSuite.scala
@@ -72,7 +72,7 @@ class LibraryInheritanceSuite extends FunSuite with InputUtils {
     val law_commu = libraryBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_commutative").get
     val law_asso = libraryBigInt.methods(symbols).map(symbols.getFunction).find(_.id.name == "law_associative").get
 
-    assert(libraryAppend.flags.exists(_.name == "library"))
+    assert(libraryAppend.flags.contains(xlangProgram.trees.Library))
     assert(law_commu.flags.contains(Library))
     assert(law_asso.flags.contains(Library))
   }


### PR DESCRIPTION
Removes the library flag to laws flagged as library that have non-library subclasses, in order to verify non-library case classes that extend library abstract classes.

Close #521 