### PR TITLE
Add better-monadic-for compiler plugin

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,7 @@
 import sbt.ScriptedPlugin
 
+addCompilerPlugin("com.olegpy" %% "better-monadic-for" % "0.3.1")
+
 enablePlugins(GitVersioning)
 enablePlugins(GitBranchPrompt)
 


### PR DESCRIPTION
This would let us improve the code in some place, while improving runtime performance a little bit. Also, this desugaring is imho more natural than the convoluted mess that scalac generates.

From its documentation:

## Desugaring `for` patterns without `withFilter`s

This plugin lets you do:
```scala
import cats.implicits._
import cats.effect.IO

def getCounts: IO[(Int, Int)] = ???

for {
  (x, y) <- getCounts
} yield x + y
```

With regular Scala, this desugars to:
```scala
getCounts
  .withFilter((@unchecked _) match {
     case (x, y) => true
     case _ => false
  }
  .map((@unchecked _) match {
    case (x, y) => x + y
  }
```

Which fails to compile, because `IO` does not define `withFilter`

This plugin changes it to:
```scala
getCounts
  .map(_ match { case (x, y) => x + y })
```
Removing both `withFilter` and `unchecked` on generated `map`. So the code just works.

## Final map optimization

Eliminate calls to `.map` in comprehensions like this:

```scala
for {
  x <- xs
  y <- getYs(x)
} yield y
```

Standard desugaring is

```scala
xs.flatMap(x => getYs(x).map(y => y))
```

This plugin simplifies it to

```scala
xs.flatMap(x => getYs(x))
```

## Desugar bindings as vals instead of tuples

If the binding is not used in follow-up `withFilter`, it is desugared as plain `val`s, saving on allocations and primitive boxing.

See https://github.com/oleg-py/better-monadic-for for more information.