### PR TITLE
Fix bug where anonymous inner classes would have same id

### DIFF
--- a/core/src/main/scala/stainless/utils/StringUtils.scala
+++ b/core/src/main/scala/stainless/utils/StringUtils.scala
@@ -7,7 +7,7 @@ object StringUtils {
 
   def indent(text: String, spaces: Int): String = {
     val prefix = " " * spaces
-    text.lines.map(prefix ++ _).mkString("\n")
+    text.linesIterator.map(prefix ++ _).mkString("\n")
   }
 
 }

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
@@ -17,20 +17,13 @@ object SymbolMapping {
 
   def empty = new SymbolMapping()
 
-  /**
-   * To avoid suffering too much from changes in symbols' id, we generate a
-   * more stable kind to disambiguate symbols. This allows --watch to not be
-   * fooled by the insertion/deletion of symbols (e.g. new top level classes)
-   * but unfortunately not methods because overloading/generics makes things
-   * ambiguous and hard to unify.
-   */
   private def kind(sym: Global#Symbol): String = {
     if (sym.isPackageClass) "0"
     else if (sym.isModule) "1"
     else if (sym.isModuleClass) "2"
-    else if (sym.isClass) "3"
+    else if (sym.isClass) "c" + sym.id
     else if (sym.isMethod) "m" + sym.id
-    else if (sym.isType) "5"
+    else if (sym.isType) "tp" + sym.id
     else if (sym.isTerm) "t" + sym.id // Many things are terms... Fallback to its id
     else ???
   }


### PR DESCRIPTION
This would occur when instantiating two or more anonymous classes within a function,
they would both get the same identifier because of how the Symbol=>Identifier cache
would work for scalac.

This might unfortunately cripple the watch mode, as identifiers
might now sometimes differ between runs whereas they wouldn't before, which was the
whole point of this previous attempt to normalize them based on their owner chain.

Dotty was unaffected as it relies on the unique symbol id generated by the compiler.