### PR TITLE
Use triple quotes and escape \u for extraClasspath and extraCompilerArguments

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -171,8 +171,8 @@ lazy val commonFrontendSettings: Seq[Setting[_]] = Defaults.itSettings ++ Seq(
           |
           |object Main extends MainHelpers {
           |
-          |  val extraClasspath = "${extraClasspath.value}"
-          |  val extraCompilerArguments = List("-classpath", "${extraClasspath.value}")
+          |  val extraClasspath = \"\"\"${removeSlashU(extraClasspath.value)}\"\"\"
+          |  val extraCompilerArguments = List("-classpath", \"\"\"${removeSlashU(extraClasspath.value)}\"\"\")
           |
           |  val libraryPaths = List(
           |    ${removeSlashU(libraryFiles.map(_._1).mkString("\"\"\"", "\"\"\",\n    \"\"\"", "\"\"\""))}


### PR DESCRIPTION
I had issues building stainless on windows because of `\` and `\u` characters in `extraClasspath` and `extraCompilerArguments`. This PR fixes the issue for me.