### PR TITLE
Remove warnings for asserts in extern functions

### DIFF
--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -599,8 +599,6 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
             reporter.warning(e.getPos, s"This require is ignored for verification because it is not at the top-level of this @extern function.")
           case _: xt.Ensuring =>
             reporter.warning(e.getPos, s"This ensuring is ignored for verification because it is not at the top-level of this @extern function.")
-          case _: xt.Assert =>
-            reporter.warning(e.getPos, s"This assert is ignored for verification because it is not at the top-level of this @extern function.")
           case _ =>
             ()
         }

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -618,8 +618,6 @@ trait CodeExtraction extends ASTExtractors {
             reporter.warning(e.getPos, s"This require is ignored for verification because it is not at the top-level of this @extern function.")
           case _: xt.Ensuring =>
             reporter.warning(e.getPos, s"This ensuring is ignored for verification because it is not at the top-level of this @extern function.")
-          case _: xt.Assert =>
-            reporter.warning(e.getPos, s"This assert is ignored for verification because it is not at the top-level of this @extern function.")
           case _ =>
             ()
         }


### PR DESCRIPTION
Asserts at the top-level would be ignored as well right?