### PR TITLE
Improve position reporting for postconditions

### DIFF
--- a/core/src/main/scala/stainless/verification/DefaultTactic.scala
+++ b/core/src/main/scala/stainless/verification/DefaultTactic.scala
@@ -62,7 +62,7 @@ trait DefaultTactic extends Tactic {
       case (Some(post @ Lambda(Seq(res), _)), Some(body)) if !res.flags.contains(Unchecked) =>
         getPostconditions(body, post).map { vc =>
           val vcKind = if (fd.flags.exists(_.name == "law")) VCKind.Law else VCKind.Postcondition
-          VC(exprOps.freshenLocals(implies(fd.precOrTrue, vc)), id, vcKind, false).setPos(fd)
+          VC(exprOps.freshenLocals(implies(fd.precOrTrue, vc)), id, vcKind, false).setPos(vc)
         }
       case _ => Nil
     }


### PR DESCRIPTION
```scala
import stainless.collection._
import stainless.lang._

object InsertionSort {

  def isSorted(l: List[BigInt]): Boolean = l match {
    case Nil() => true
    case Cons(x, Nil()) => true
    case Cons(x, xs @ Cons(y, ys)) => x <= y && isSorted(xs)
  }

  def insert(x: BigInt, l: List[BigInt]): List[BigInt] = {
    require(isSorted(l))
    l match {
      case Nil() => Cons(x, Nil())
      case Cons(y, ys) =>
        if (x < y) Cons(x, l)
        else Cons(y, insert(x, ys))
    }
  } ensuring(res => isSorted(res))
}
```

In `insert`, this will now report postconditions lines 15, 17, and 18 instead of 12 for all branches.