### PR TITLE
Do not consider built-in classes in override chain

### DIFF
--- a/core/src/main/scala/stainless/ast/SymbolIdentifier.scala
+++ b/core/src/main/scala/stainless/ast/SymbolIdentifier.scala
@@ -14,6 +14,8 @@ class Symbol private[stainless](val path: Seq[String], private[stainless] val id
   }
 
   override def hashCode: Int = id
+
+  override def toString: String = s"$name@$id"
 }
 
 object Symbol {

--- a/frontends/benchmarks/extraction/valid/ToString.scala
+++ b/frontends/benchmarks/extraction/valid/ToString.scala
@@ -1,0 +1,15 @@
+object ToString {
+  abstract class A {
+    def toString: String
+    def fooBar: Int
+  }
+
+  case class C(s: String) extends A {
+    override def toString: String = s
+    override def fooBar: Int = 42
+  }
+
+  case class Auto(s: String) {
+    override def toString: String = s
+  }
+}


### PR DESCRIPTION
Doing so for methods such as `toString` would give us mismatched symbols corresponding to `java.lang.Object` instead of the topmost ancestor of the class where `toString` is overridden, which then prevents the override check and the method lifting phase from functioning correctly.

Fix #655