### PR TITLE
Do not check model when invoking solver during partial evaluation 

### DIFF
--- a/core/src/main/scala/stainless/transformers/PartialEvaluator.scala
+++ b/core/src/main/scala/stainless/transformers/PartialEvaluator.scala
@@ -15,23 +15,6 @@ trait PartialEvaluator extends SimplifierWithPC { self =>
       val tfd = fi.tfd
       val (rargs, pargs) = args.map(simplify(_, path)).unzip
 
-      val inlined: Option[Expr] = {
-        val (specs, body) = deconstructSpecs(tfd.fullBody)
-
-        body.map { body =>
-          val pre = specs.collectFirst { case Precondition(e) => e }.get
-          val l @ Lambda(Seq(res), post) = specs.collectFirst { case Postcondition(e) => e }.get
-
-          val newBody: Expr = Assert(pre, Some("Inlined precondition of " + tfd.id.name), Let(res, body,
-            Assert(post, Some("Inlined postcondition of " + tfd.id.name), res.toVariable).copiedFrom(l)
-          ).copiedFrom(body)).copiedFrom(pre)
-
-          freshenLocals((tfd.params zip rargs).foldRight(newBody) {
-            case ((vd, e), body) => Let(vd, e, body).copiedFrom(body)
-          })
-        }
-      }
-
       def containsChoose(expr: Expr): Boolean = exists {
         case (_: Choose) | (_: NoTree) => true
         case _ => false
@@ -65,15 +48,38 @@ trait PartialEvaluator extends SimplifierWithPC { self =>
         res
       }
 
-      inlined
-        .filter(_ => isUnfoldable(id))
-        .filter(!containsChoose(_))
-        .filter(isProductiveUnfolding)
-        .map(unfold)
-        .getOrElse (
+      if (!isUnfoldable(id)) {
+        return (
           FunctionInvocation(id, tps, rargs).copiedFrom(fi),
           pargs.foldLeft(isPureFunction(id))(_ && _)
         )
+      }
+
+      val inlined: Option[Expr] = {
+        val (specs, body) = deconstructSpecs(tfd.fullBody)
+
+        body.map { body =>
+          val pre = specs.collectFirst { case Precondition(e) => e }.get
+          val l @ Lambda(Seq(res), post) = specs.collectFirst { case Postcondition(e) => e }.get
+
+          val newBody: Expr = Assert(pre, Some("Inlined precondition of " + tfd.id.name), Let(res, body,
+            Assert(post, Some("Inlined postcondition of " + tfd.id.name), res.toVariable).copiedFrom(l)
+          ).copiedFrom(body)).copiedFrom(pre)
+
+          freshenLocals((tfd.params zip rargs).foldRight(newBody) {
+            case ((vd, e), body) => Let(vd, e, body).copiedFrom(body)
+          })
+        }
+      }
+
+      inlined
+        .filterNot(containsChoose)
+        .filter(isProductiveUnfolding)
+        .map(unfold)
+        .getOrElse((
+          FunctionInvocation(id, tps, rargs).copiedFrom(fi),
+          pargs.foldLeft(isPureFunction(id))(_ && _)
+        ))
 
     case _ => super.simplify(e, path)
   }

--- a/core/src/main/scala/stainless/transformers/SimplifierWithSolver.scala
+++ b/core/src/main/scala/stainless/transformers/SimplifierWithSolver.scala
@@ -6,6 +6,8 @@ package transformers
 import scala.language.existentials
 import scala.concurrent.duration._
 
+import inox.solvers.optCheckModels
+
 trait SimplifierWithSolver extends inox.transformers.SimplifierWithPC { self =>
   import trees._
   import symbols._
@@ -23,7 +25,7 @@ trait SimplifierWithSolver extends inox.transformers.SimplifierWithPC { self =>
 
   protected val solver =
     semantics.getSemantics(program)
-      .getSolver(context)
+      .getSolver(context.withOpts(optCheckModels(false)))
       .withTimeout(150.millis)
       .toAPI
       .asInstanceOf[inox.solvers.SimpleSolverAPI {

--- a/frontends/benchmarks/typechecker/valid/PartialCompiler.scala
+++ b/frontends/benchmarks/typechecker/valid/PartialCompiler.scala
@@ -3,7 +3,7 @@ import stainless.annotation._
 import stainless.collection._
 import stainless.util.Random
 
-object comp {
+object PartialCompiler {
 
   sealed trait Expr
   case class Var(name: String)     extends Expr

--- a/frontends/benchmarks/verification/valid/PartialCompiler.scala
+++ b/frontends/benchmarks/verification/valid/PartialCompiler.scala
@@ -3,7 +3,7 @@ import stainless.annotation._
 import stainless.collection._
 import stainless.util.Random
 
-object comp {
+object PartialCompiler {
 
   sealed trait Expr
   case class Var(name: String)     extends Expr


### PR DESCRIPTION
Fix #672
