### PR TITLE
Setting `stainlessEnabled := false` keeps library sources and ghost elimination

### DIFF
--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/GhostAccessRewriter.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/GhostAccessRewriter.scala
@@ -13,14 +13,24 @@ import stainless.frontend.{CallBack, UnsupportedCodeException}
 trait GhostAccessRewriter extends Transform {
   import global._
 
+  val pluginOptions: PluginOptions
   val phaseName = "ghost-removal"
 
-  override def newTransformer(unit: global.CompilationUnit): Transformer =
-    new GhostRewriteTransformer
+  override def newTransformer(unit: global.CompilationUnit): Transformer = {
+    if (pluginOptions.enableGhostElimination) {
+      new GhostRewriteTransformer
+    } else {
+      new IdentityTransformer
+    }
+  }
 
   lazy val ghostAnnotation = rootMirror.getRequiredClass("stainless.annotation.ghost")
 
-  class GhostRewriteTransformer extends Transformer {
+  private class IdentityTransformer extends Transformer {
+    override def transform(tree: Tree): Tree = tree
+  }
+
+  private class GhostRewriteTransformer extends Transformer {
 
     /**
      * Is this symbol @ghost, or enclosed inside a ghost definition?


### PR DESCRIPTION
Only verification is disabled, so it is now possible to enable the plugin on the whole project, in order to  pull in the Stainless library and perform ghost elimination.