### PR TITLE
Fix null pointer exception when running --eval

### DIFF
--- a/core/src/main/scala/stainless/termination/DecreasesTransformer.scala
+++ b/core/src/main/scala/stainless/termination/DecreasesTransformer.scala
@@ -36,8 +36,9 @@ trait DecreasesTransformer extends transformers.TreeTransformer {
 object DecreasesTransformer {
   def apply(tr: ast.Trees)(syms: tr.Symbols): DecreasesTransformer {
     val trees: tr.type
-  } = new DecreasesTransformer {
+  } = new {
     val trees: tr.type = tr
+  } with DecreasesTransformer {
     implicit val symbols: syms.type = syms
   }
 }


### PR DESCRIPTION
Because `DecreasesProcessor` did not initialize its `trees` early enough,
a null pointer exception would be raised when attempting to combine
the `SymbolTransformer` it is wrapped in within `TerminationComponent#lowering`
together with the lowering transformer of `VerificationComponent.`