### PR TITLE
Iterables

### DIFF
--- a/frontends/benchmarks/verification/valid/Iterables.scala
+++ b/frontends/benchmarks/verification/valid/Iterables.scala
@@ -40,6 +40,7 @@ object Iterables {
     assert(!res.contains(6))
   }
 
+  // See https://github.com/epfl-lara/inox/issues/109
   // def test_setWithFilter(set: Set[BigInt]) = {
   //   require((set & oneToSix) == oneToSix)
 

--- a/frontends/benchmarks/verification/valid/Iterables.scala
+++ b/frontends/benchmarks/verification/valid/Iterables.scala
@@ -1,0 +1,55 @@
+
+import stainless.lang._
+import stainless.collection._
+import stainless.annotation._
+
+object Iterables {
+
+  def test_setToList(set: Set[BigInt]) = {
+    require(set.contains(1) && set.contains(2) && !set.contains(3))
+
+    val res = set.toList
+
+    assert(res.contains(1))
+    assert(res.contains(2))
+    assert(!res.contains(3))
+  }
+
+  def test_setMap(set: Set[BigInt]) = {
+    require(set.contains(1) && set.contains(2) && !set.contains(3))
+
+    val res = set.map(_ + 1)
+
+    assert(res.contains(2))
+    assert(res.contains(3))
+    assert(!res.contains(4))
+  }
+
+  def test_mapKeys(map: Map[Int, String]) = {
+    require(map.contains(1) && map.contains(2) && !map.contains(3))
+
+    val res = map.keys
+
+    assert(res.contains(1))
+    assert(res.contains(2))
+    assert(!res.contains(3))
+  }
+
+  def test_mapValues(map: Map[Int, String]) = {
+    require(map.get(1) == Some("foo") && map.get(2) == Some("bar"))
+
+    val res = map.values
+
+    assert(res.contains("foo"))
+    assert(res.contains("bar"))
+  }
+
+  def test_mapToList(map: Map[Int, String]) = {
+    require(map.get(1) == Some("foo") && map.get(2) == Some("bar"))
+
+    val res = map.toList
+
+    assert(res.contains((1, "foo")))
+    assert(res.contains((2, "bar")))
+  }
+}

--- a/frontends/benchmarks/verification/valid/Iterables.scala
+++ b/frontends/benchmarks/verification/valid/Iterables.scala
@@ -25,6 +25,37 @@ object Iterables {
     assert(!res.contains(4))
   }
 
+  val oneToSix = Set[BigInt](1,2,3,4,5,6)
+
+  def test_setFilter(set: Set[BigInt]) = {
+    require((set & oneToSix) == oneToSix)
+
+    val res = set.filter(_ < 4)
+
+    assert(res.contains(1))
+    assert(res.contains(2))
+    assert(res.contains(3))
+    assert(!res.contains(4))
+    assert(!res.contains(5))
+    assert(!res.contains(6))
+  }
+
+  // def test_setWithFilter(set: Set[BigInt]) = {
+  //   require((set & oneToSix) == oneToSix)
+
+  //   val res = for {
+  //     x <- set
+  //     if x < 4
+  //   } yield x
+
+  //   assert(res.contains(1))
+  //   assert(res.contains(2))
+  //   assert(res.contains(3))
+  //   assert(!res.contains(4))
+  //   assert(!res.contains(5))
+  //   assert(!res.contains(6))
+  // }
+
   def test_mapKeys(map: Map[Int, String]) = {
     require(map.contains(1) && map.contains(2) && !map.contains(3))
 

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -470,8 +470,10 @@ trait ASTExtractors {
     object ExUnwrapped {
       def unapply(tree: tpd.Tree): Option[tpd.Tree] = tree match {
         case Apply(
-          ExSymbol("scala", "Predef$", "Ensuring") |
-          ExSymbol("stainless", "lang", "StaticChecks$", "any2Ensuring"), Seq(arg)) => Some(arg)
+            ExSymbol("scala", "Predef$", "Ensuring") |
+            ExSymbol("stainless", "lang", "StaticChecks$", "Ensuring"),
+            Seq(arg)) => Some(arg)
+
         case Apply(ExSymbol("stainless", "lang", "package$", "Throwing"), Seq(arg)) => Some(arg)
         case Apply(ExSymbol("stainless", "lang", "package$", "BooleanDecorations"), Seq(arg)) => Some(arg)
         case Apply(ExSymbol("stainless", "lang", "package$", "SpecsDecorations"), Seq(arg)) => Some(arg)

--- a/frontends/library/stainless/collection/List.scala
+++ b/frontends/library/stainless/collection/List.scala
@@ -3,6 +3,7 @@
 package stainless.collection
 
 import scala.language.implicitConversions
+import scala.collection.immutable.{List => ScalaList}
 
 import stainless._
 import stainless.lang._
@@ -551,6 +552,11 @@ sealed abstract class List[T] {
   def toSet: Set[T] = foldLeft(Set[T]()){
     case (current, next) => current ++ Set(next)
   }
+
+  @extern @pure
+  def toScala[A](list: List[A]): ScalaList[A] = {
+    list.foldRight(ScalaList.empty[A])(_ :: _)
+  }
 }
 
 @library
@@ -573,6 +579,11 @@ object List {
 
   @library
   def empty[T]: List[T] = Nil[T]()
+
+  @library @extern @pure
+  def fromScala[A](list: ScalaList[A]): List[A] = {
+    list.foldRight(List.empty[A])(_ :: _)
+  }
 
   @library
   def fill[T](n: BigInt)(x: T) : List[T] = {

--- a/frontends/library/stainless/collection/List.scala
+++ b/frontends/library/stainless/collection/List.scala
@@ -481,7 +481,13 @@ sealed abstract class List[T] {
   }
 
   // In case we implement for-comprehensions
-  def withFilter(p: T => Boolean) = filter(p)
+  def withFilter(p: T => Boolean): List[T] = {
+    filter(p)
+  } ensuring { res =>
+    res.size <= this.size &&
+    res.content.subsetOf(this.content) &&
+    res.forall(p)
+  }
 
   @isabelle.function(term = "%xs P. List.list_all P xs")
   def forall(p: T => Boolean): Boolean = this match {

--- a/frontends/library/stainless/lang/Set.scala
+++ b/frontends/library/stainless/lang/Set.scala
@@ -3,34 +3,68 @@
 package stainless.lang
 
 import stainless.annotation._
-import stainless.lang.StaticChecks._
+import stainless.collection.List
 
 import scala.language.implicitConversions
+import scala.collection.immutable.{Set => ScalaSet}
 
 object Set {
+
   @library @inline
   def empty[T] = Set[T]()
 
   @ignore
   def apply[T](elems: T*) = {
-    new Set[T](scala.collection.immutable.Set[T](elems : _*))
+    new Set[T](ScalaSet[T](elems : _*))
   }
-  
-  @extern @library
-  def mkString[A](map: Set[A], infix: String, fA : A => String) = {
-    map.theSet.map(fA).toList.sorted.mkString(infix)
+
+  @extern @pure @library
+  def fromScala[A](set: ScalaSet[A]): Set[A] = {
+    new Set(set)
   }
+
+  @library
+  implicit class SetOps[A](val set: Set[A]) extends AnyVal {
+
+    @extern @pure
+    def map[B](f: A => B): Set[B] = {
+      new Set(set.theSet.map(f))
+    } ensuring { res =>
+      forall((a: A) => set.contains(a) == res.contains(f(a)))
+    }
+
+    @extern @pure
+    def toList: List[A] = {
+      List.fromScala(set.theSet.toList)
+    } ensuring { res =>
+      forall((a: A) => res.contains(a) == set.contains(a))
+    }
+
+    @extern @pure
+    def toScala: ScalaSet[A] = set.theSet
+
+    @extern @pure
+    def mkString(infix: String)(format: A => String): String = {
+      set.theSet.map(format).toList.sorted.mkString(infix)
+    }
+  }
+
 }
 
 @ignore
 case class Set[T](theSet: scala.collection.immutable.Set[T]) {
+
   def +(a: T): Set[T] = new Set[T](theSet + a)
   def ++(a: Set[T]): Set[T] = new Set[T](theSet ++ a.theSet)
+
   def -(a: T): Set[T] = new Set[T](theSet - a)
   def --(a: Set[T]): Set[T] = new Set[T](theSet -- a.theSet)
-  def size: BigInt = theSet.size
-  def contains(a: T): Boolean = theSet.contains(a)
-  def isEmpty: Boolean = theSet.isEmpty
-  def subsetOf(b: Set[T]): Boolean = theSet.subsetOf(b.theSet)
+
   def &(a: Set[T]): Set[T] = new Set[T](theSet & a.theSet)
+
+  def size: BigInt = theSet.size
+  def isEmpty: Boolean = theSet.isEmpty
+
+  def contains(a: T): Boolean = theSet.contains(a)
+  def subsetOf(b: Set[T]): Boolean = theSet.subsetOf(b.theSet)
 }

--- a/frontends/library/stainless/lang/Set.scala
+++ b/frontends/library/stainless/lang/Set.scala
@@ -34,6 +34,20 @@ object Set {
     }
 
     @extern @pure
+    def filter(p: A => Boolean): Set[A] = {
+      new Set(set.theSet.filter(p))
+    } ensuring { res =>
+      forall((a: A) => if (set.contains(a) && p(a)) res.contains(a) else !res.contains(a))
+    }
+
+    @extern @pure
+    def withFilter(p: A => Boolean): Set[A] = {
+      new Set(set.theSet.filter(p))
+    } ensuring { res =>
+      forall((a: A) => if (set.contains(a) && p(a)) res.contains(a) else !res.contains(a))
+    }
+
+    @extern @pure
     def toList: List[A] = {
       List.fromScala(set.theSet.toList)
     } ensuring { res =>
@@ -47,8 +61,9 @@ object Set {
     def mkString(infix: String)(format: A => String): String = {
       set.theSet.map(format).toList.sorted.mkString(infix)
     }
-  }
 
+    def nonEmpty: Boolean = !set.isEmpty
+  }
 }
 
 @ignore

--- a/frontends/library/stainless/lang/StaticChecks.scala
+++ b/frontends/library/stainless/lang/StaticChecks.scala
@@ -6,12 +6,9 @@ import scala.language.implicitConversions
 object StaticChecks {
 
   @library
-  case class Ensuring[A](x: A) {
+  implicit class Ensuring[A](val x: A) extends AnyVal {
     def ensuring(@ghost cond: (A) => Boolean): A = x
   }
-
-  @library
-  implicit def any2Ensuring[A](x: A): Ensuring[A] = Ensuring(x)
 
   @library
   def require(@ghost pred: Boolean): Unit = ()

--- a/frontends/scalac/src/it/scala/stainless/verification/TypeCheckerSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/TypeCheckerSuite.scala
@@ -85,6 +85,7 @@ class SMTCVC4TypeCheckerSuite extends TypeCheckerSuite {
     case "verification/valid/CovariantList" => Ignore
     case "verification/valid/Huffman" => Ignore
     case "verification/valid/InnerClasses4" => Ignore
+    case "verification/valid/Iterables" => Ignore
     case "verification/valid/List" => Ignore
     case "verification/valid/MoreExtendedEuclidGCD" => Ignore
     case "verification/valid/MoreExtendedEuclidReachability" => Ignore

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -106,6 +106,7 @@ class SMTCVC4VerificationSuite extends VerificationSuite {
 
     // Requires map with non-default values, unsupported by CVC4
     case "verification/valid/ArraySlice" => Ignore
+    case "verification/valid/Iterables" => Ignore
 
     // These tests are too slow on CVC4 and make the regression unstable
     case "verification/valid/ConcRope" => Ignore

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -212,7 +212,8 @@ trait ASTExtractors {
           unapplySeq(from).map(prefix => prefix :+ name.toString)
 
         case Select(from: Ident, name) =>
-          Some(Seq(from.toString, name.toString))
+          val full = name.toString :: from.symbol.ownerChain.init.map(_.name.toString)
+          Some(full.reverse)
 
         case _ =>
           None
@@ -232,7 +233,7 @@ trait ASTExtractors {
           => Some((body, contract, false))
 
         case Apply(Select(Apply(TypeApply(
-              ExSelected("stainless", "lang", "StaticChecks", "any2Ensuring"),
+              ExSelected("stainless", "lang", "StaticChecks", "Ensuring"),
               _ :: Nil), body :: Nil), ExNamed("ensuring")), contract :: Nil)
           => Some((body, contract, true))
 

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/FragmentChecker.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/FragmentChecker.scala
@@ -232,8 +232,9 @@ trait FragmentChecker extends SubComponent { _: StainlessExtraction =>
         if stainlessReplacement.contains(tp.dealias.typeSymbol)
       } yield tp -> stainlessReplacement(tp.typeSymbol)
 
-      for ((tp, replacement) <- errors.distinct)
-        reportError(pos, s"Scala API ($tp) no longer extracted, please use ${replacement}")
+      for ((tp, replacement) <- errors.distinct) {
+        reportError(pos, s"Scala API `$tp` is not directly supported, please use `$replacement` instead.")
+      }
     }
 
     private var classBody = false
@@ -252,14 +253,18 @@ trait FragmentChecker extends SubComponent { _: StainlessExtraction =>
         val isIgnore = sym.hasAnnotation(IgnoreAnnotation)
 
         // exit early if it's a subtree we shouldn't validate
-        if (isExtern || isIgnore || sym.isSynthetic)
-          return
+        if (isExtern || isIgnore || sym.isSynthetic) {
+          return ()
+        }
 
         // ignore param accessors because they are duplicates of constructor parameters.
         // We catch them when we check constructors
-        if ((sym.tpe ne null) && !sym.isParamAccessor)
+        if ((sym.tpe ne null) && !sym.isParamAccessor) {
           checkType(tree.pos, sym.tpe)
-      } else super.traverse(tree)
+        }
+      } else {
+        super.traverse(tree)
+      }
 
       tree match {
         case od @ ExObjectDef(_, tmpl) =>


### PR DESCRIPTION
- Add methods `toScala` and `fromScala` to `List`
- Add methods `keys`, `values`, `toList` and `toScala` to `Map`
- Add methods `map`, `toList` and `toScala` to `Set`
- \+ other related and/or needed changes