### PR TITLE
Work around a bug in scalac which would crash the compiler

### DIFF
--- a/frontends/library/stainless/lang/Map.scala
+++ b/frontends/library/stainless/lang/Map.scala
@@ -24,6 +24,14 @@ object Map {
     new Map(map)
   }
 
+  @library @extern @pure
+  def mkString[A, B](map: Map[A, B], innerSep: String, outerSep: String)(fA: A => String, fB: B => String): String = {
+    map.theMap
+      .map { case (k, v) => fA(k) + innerSep + fB(v) }
+      .toList.sorted
+      .mkString(outerSep)
+  }
+
   @library
   implicit class MapOps[A, B](val map: Map[A, B]) extends AnyVal {
 
@@ -51,14 +59,6 @@ object Map {
     @extern @pure
     def toScala: ScalaMap[A, B] = {
       map.theMap
-    }
-
-    @extern @pure
-    def mkString(inkv: String, betweenkv: String)(fA: A => String, fB: B => String): String = {
-      map.theMap
-        .map { case (k, v) => fA(k) + inkv + fB(v) }
-        .toList.sorted
-        .mkString(betweenkv)
     }
   }
 }

--- a/frontends/library/stainless/lang/Set.scala
+++ b/frontends/library/stainless/lang/Set.scala
@@ -23,6 +23,11 @@ object Set {
     new Set(set)
   }
 
+  @extern @pure @library
+  def mkString[A](set: Set[A], infix: String)(format: A => String): String = {
+    set.theSet.map(format).toList.sorted.mkString(infix)
+  }
+
   @library
   implicit class SetOps[A](val set: Set[A]) extends AnyVal {
 

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -129,7 +129,7 @@ package object lang {
 
     def unapply(b: scala.math.BigInt): scala.Option[Int] = {
       if(b >= Integer.MIN_VALUE && b <= Integer.MAX_VALUE) {
-        scala.Some(b.intValue())
+        scala.Some(b.intValue)
       } else {
         scala.None
       }


### PR DESCRIPTION
The other possibility would have been to remove the `AnyVal` on MapOps and SetOps but that would clutter the trees, so I figured it's better to just move `mkString` into the companion object itself.