### PR TITLE
Use static checks for SetOps as they invoke forall

### DIFF
--- a/frontends/library/stainless/lang/Set.scala
+++ b/frontends/library/stainless/lang/Set.scala
@@ -2,6 +2,7 @@
 
 package stainless.lang
 
+import StaticChecks._
 import stainless.annotation._
 import stainless.collection.List
 


### PR DESCRIPTION
Without static checks these operations cannot be executed at runtime, as `forall` yields an exception.