### PR TITLE
Error reporting

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -187,13 +187,6 @@ trait MainHelpers extends inox.MainHelpers { self =>
           compiler = newCompiler()
       }
 
-      def regularRunCycle() = try {
-        baseRunCycle()
-      } catch {
-        case e: inox.FatalError => throw e
-        case e: Throwable => reporter.internalError(e)
-      }
-
       val watchMode = isWatchModeOn(ctx)
       if (watchMode) {
         val files: Set[File] = compiler.sources.toSet map {
@@ -204,7 +197,7 @@ trait MainHelpers extends inox.MainHelpers { self =>
         watchRunCycle() // first run
         watcher.run()   // subsequent runs on changes
       } else {
-        regularRunCycle()
+        baseRunCycle()
       }
 
       // Export final results to JSON if asked to.

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -146,10 +146,8 @@ trait MainHelpers extends inox.MainHelpers { self =>
     implicit val ctx: inox.Context = try {
       setup(args)
     } catch {
-      case _: Throwable =>
-        println("There was an exception while parsing command-line options")
-        System.exit(2)
-        ???
+      case e: Throwable =>
+        topLevelErrorHandler(e)(Context.empty)
     }
 
     try {

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -22,6 +22,10 @@ package object frontend {
     */
   object optBatchedProgram extends inox.FlagOptionDef("batched", false)
 
+  /** Print stack trace when Stainless throws an exception
+    */
+  object optPrintStackTrace extends inox.FlagOptionDef("print-trace", false)
+
   /**
    * Given a context (with its reporter) and a frontend factory, proceed to compile,
    * extract, transform and verify the input programs based on the active components

--- a/core/src/main/scala/stainless/package.scala
+++ b/core/src/main/scala/stainless/package.scala
@@ -108,7 +108,7 @@ package object stainless {
     }
   }
 
-  def topLevelErrorHandler(e: Throwable)(implicit ctx: inox.Context): Unit = {
+  def topLevelErrorHandler[T](e: Throwable)(implicit ctx: inox.Context): T = {
     ctx.reporter.error("Stainless terminated with an error.")
 
     val sw = new StringWriter
@@ -121,6 +121,7 @@ package object stainless {
       ctx.reporter.error(sw.toString)
 
     System.exit(2)
+    ??? // unreachable
   }
 
 

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -279,7 +279,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
         outOfSubsetError(t, "Mutable fields in static containers such as objects are not supported")
 
       case other =>
-        reporter.warning(other.pos, "Could not extract tree in static container: " + other)
+        reporter.warning(other.pos, s"Stainless does not support `$other` in static containers")
     }
 
     (imports, classes, functions, typeDefs, subs, allClasses, allFunctions, allTypeDefs)
@@ -510,7 +510,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
         // ignore
 
       case other =>
-        reporter.warning(other.pos, "Could not extract tree in class: " + other)
+        reporter.warning(other.pos, s"Stainless does not support `$other` in class $id")
     }
 
     val optInv = if (invariants.isEmpty) None else Some {
@@ -1712,7 +1712,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
     }
 
     // default behaviour is to complain :)
-    case _ => outOfSubsetError(tr, "Could not extract tree " + tr + " ("+tr.getClass+")")
+    case _ => outOfSubsetError(tr, s"Stainless does not support expression: `$tr`")
   }).ensurePos(tr.pos)
 
 
@@ -1886,7 +1886,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
 
       case tr @ TypeRef(NoPrefix | _: ThisType, _) if dctx.tparams contains tr.symbol =>
         dctx.tparams.get(tr.symbol).getOrElse {
-          outOfSubsetError(tpt.typeSymbol.pos, "Could not extract "+tpt+" with context " + dctx.tparams)
+          outOfSubsetError(tpt.typeSymbol.pos, s"Stainless does not support type $tpt in context ${dctx.tparams}")
         }
 
       case tr: TypeRef if tr.symbol.isAbstractOrAliasType && dctx.resolveTypes =>
@@ -2055,7 +2055,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
 
       case pp @ TypeParamRef(binder, num) =>
         dctx.tparams.collect { case (k, v) if k.name == pp.paramName => v }.lastOption.getOrElse {
-          outOfSubsetError(tpt.typeSymbol.pos, "Could not extract "+tpt+" with context " + dctx.tparams)
+          outOfSubsetError(tpt.typeSymbol.pos, s"Stainless does not support type $tpt in context ${dctx.tparams}")
         }
 
       case tp: TypeVar => extractType(tp.stripTypeVar)
@@ -2067,7 +2067,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
 
       case _ =>
         if (tpt ne null) {
-          outOfSubsetError(tpt.typeSymbol.pos, "Could not extract type: "+tpt+" ("+tpt.getClass+")")
+          outOfSubsetError(tpt.typeSymbol.pos, s"Stainless does not support type $tpt")
         } else {
           outOfSubsetError(NoPosition, "Tree with null-pointer as type found")
         }

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -279,7 +279,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
         outOfSubsetError(t, "Mutable fields in static containers such as objects are not supported")
 
       case other =>
-        reporter.warning(other.pos, s"Stainless does not support `$other` in static containers")
+        reporter.warning(other.pos, s"Stainless does not support the following tree in static containers:\n$other")
     }
 
     (imports, classes, functions, typeDefs, subs, allClasses, allFunctions, allTypeDefs)
@@ -510,7 +510,7 @@ class CodeExtraction(inoxCtx: inox.Context, cache: SymbolsContext)(implicit val 
         // ignore
 
       case other =>
-        reporter.warning(other.pos, s"Stainless does not support `$other` in class $id")
+        reporter.warning(other.pos, s"In class $id, Stainless does not support:\n$other")
     }
 
     val optInv = if (invariants.isEmpty) None else Some {

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -297,7 +297,7 @@ trait CodeExtraction extends ASTExtractors {
         outOfSubsetError(t, "Mutable fields in static containers such as objects are not supported")
 
       case other =>
-        reporter.warning(other.pos, s"Stainless does not support `$other` in static containers")
+        reporter.warning(other.pos, s"Stainless does not support the following tree in static containers:\n$other")
     }
 
     (imports, classes, functions, typeDefs, subs, allClasses, allFunctions, allTypeDefs)
@@ -474,7 +474,7 @@ trait CodeExtraction extends ASTExtractors {
         // ignore
 
       case other =>
-        reporter.warning(other.pos, s"Stainless does not support `$other` in class $id")
+        reporter.warning(other.pos, s"In class $id, Stainless does not support:\n$other")
     }
 
     val optInv = if (invariants.isEmpty) None else Some({

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -297,7 +297,7 @@ trait CodeExtraction extends ASTExtractors {
         outOfSubsetError(t, "Mutable fields in static containers such as objects are not supported")
 
       case other =>
-        reporter.warning(other.pos, "Could not extract tree in static container: " + other)
+        reporter.warning(other.pos, s"Stainless does not support `$other` in static containers")
     }
 
     (imports, classes, functions, typeDefs, subs, allClasses, allFunctions, allTypeDefs)
@@ -474,7 +474,7 @@ trait CodeExtraction extends ASTExtractors {
         // ignore
 
       case other =>
-        reporter.warning(other.pos, "Could not extract tree in class: " + other + " (" + other.getClass + ")")
+        reporter.warning(other.pos, s"Stainless does not support `$other` in class $id")
     }
 
     val optInv = if (invariants.isEmpty) None else Some({
@@ -1521,7 +1521,7 @@ trait CodeExtraction extends ASTExtractors {
     }
 
     // default behaviour is to complain :)
-    case _ => outOfSubsetError(tr, "Could not extract " + tr + " (Scala tree of type "+tr.getClass+")")
+    case _ => outOfSubsetError(tr, s"Stainless does not support expression: `$tr`")
   }).ensurePos(tr.pos)
 
   /** Inject implicit widening casts according to the Java semantics (5.6.2. Binary Numeric Promotion) */
@@ -1734,14 +1734,14 @@ trait CodeExtraction extends ASTExtractors {
           tpe
 
         case None =>
-          outOfSubsetError(tpt.typeSymbol.pos, "Could not extract refined type: "+tpt+" ("+tpt.getClass+")")
+          outOfSubsetError(tpt.typeSymbol.pos, s"Stainless does not support type $tpt")
       }
 
     case AnnotatedType(_, tpe) => extractType(tpe)
 
     case _ =>
       if (tpt ne null) {
-        outOfSubsetError(tpt.typeSymbol.pos, "Could not extract type: "+tpt+" ("+tpt.getClass+")")
+        outOfSubsetError(tpt.typeSymbol.pos, s"Stainless does not support type $tpt")
         throw new Exception()
       } else {
         outOfSubsetError(NoPosition, "Tree with null-pointer as type found")

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/FragmentChecker.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/FragmentChecker.scala
@@ -327,9 +327,9 @@ trait FragmentChecker extends SubComponent { _: StainlessExtraction =>
           if (args.size != 1 || !args.head.isInstanceOf[Literal])
             reportError(args.head.pos, "Only literal arguments are allowed for BigInt.")
 
-      case ExCall(Some(s @ Select(rec: Super, _)), _, _, _) =>
-        if (s.symbol.isAbstract && !s.symbol.isConstructor)
-          reportError(tree.pos, "Cannot issue a super call to an abstract method.")
+        case ExCall(Some(s @ Select(rec: Super, _)), _, _, _) =>
+          if (s.symbol.isAbstract && !s.symbol.isConstructor)
+            reportError(tree.pos, "Cannot issue a super call to an abstract method.")
 
         case Apply(fun, args) =>
           if (stainlessReplacement.contains(sym))

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessPlugin.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/StainlessPlugin.scala
@@ -111,7 +111,7 @@ class StainlessPluginComponent(
   override val runsRightAfter = None
   override val runsBefore     = List("patmat")
 
-  override def onRun(run: () => Unit): Unit = {
+  override def onRun(run: () => Unit): Unit = try {
     callback.beginExtractions()
     run()
     callback.endExtractions()
@@ -121,6 +121,8 @@ class StainlessPluginComponent(
     report foreach { report =>
       report.emit(ctx)
     }
+  } catch {
+    case e: Throwable => topLevelErrorHandler(e)
   }
 }
 


### PR DESCRIPTION
* Add an exception handler that hides the stack trace and prints in the file `stainless-debug.txt`
* Use this exception handler in the Stainless Plugin
* Add an option to print the stack trace when there is an error
* Minor error messages changes