### PR TITLE
Rearrange debugging options

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,7 +38,7 @@ pri-sessions/
 stainless.out/
 repairs.dat
 tmp
-stainless-debug.txt
+stainless-stack-trace.txt
 
 #eclipse
 .cache

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -48,7 +48,6 @@ trait MainHelpers extends inox.MainHelpers { self =>
     optWatch -> Description(General, "Re-run stainless upon file changes"),
     optCompact -> Description(General, "Print only invalid elements of summaries"),
     optNoColors -> Description(General, "Disable colored output"),
-    frontend.optPrintStackTrace -> Description(General, "Print stack trace when an exception occurs"),
     frontend.optPersistentCache -> Description(General, "Enable caching of program extraction & analysis"),
     frontend.optBatchedProgram -> Description(General, "Process the whole program together, skip dependency analysis"),
     frontend.optKeep -> Description(General, "Keep library objects marked by @keep(g) for some g in g1,g2,... (implies --batched)"),

--- a/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
@@ -87,8 +87,10 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
       symbols.ensureWellFormed
     } catch {
       case e: symbols.TypeErrorException =>
+        reporter.debug(e)
         reportError(e.pos, e.getMessage, symbols)
       case e @ xt.NotWellFormedException(defn, _) =>
+        reporter.debug(e)
         reportError(defn.getPos, e.getMessage, symbols)
     }
 
@@ -117,11 +119,11 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
   }
 
   private def reportErrorFooter(syms: xt.Symbols): Unit = {
-    reporter.error(s"The extracted program is not well formed.")
-    reporter.error(s"Symbols are:")
-    reporter.error(s"functions -> [${syms.functions.keySet.toSeq.sorted mkString ", "}]")
-    reporter.error(s"classes   -> [\n  ${syms.classes.values mkString "\n  "}\n]")
-    reporter.error(s"typedefs  -> [\n  ${syms.typeDefs.values mkString "\n  "}\n]")
+    reporter.debug(s"The extracted program is not well formed.")
+    reporter.debug(s"Symbols are:")
+    reporter.debug(s"functions -> [${syms.functions.keySet.toSeq.sorted mkString ", "}]")
+    reporter.debug(s"classes   -> [\n  ${syms.classes.values mkString "\n  "}\n]")
+    reporter.debug(s"typedefs  -> [\n  ${syms.typeDefs.values mkString "\n  "}\n]")
     reporter.fatalError(s"Aborting from BatchedCallBack")
   }
 }

--- a/core/src/main/scala/stainless/frontend/SplitCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/SplitCallBack.scala
@@ -166,8 +166,10 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
       syms.ensureWellFormed
     } catch {
       case e: syms.TypeErrorException =>
+        reporter.debug(e)
         reportError(e.pos, e.getMessage, syms)
       case e @ xt.NotWellFormedException(defn, _) =>
+        reporter.debug(e)
         reportError(defn.getPos, e.getMessage, syms)
     }
 
@@ -207,11 +209,11 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
   }
 
   private def reportErrorFooter(syms: xt.Symbols): Unit = {
-    reporter.error(s"The extracted sub-program is not well formed.")
-    reporter.error(s"Symbols are:")
-    reporter.error(s"functions -> [${syms.functions.keySet.toSeq.sorted mkString ", "}]")
-    reporter.error(s"classes   -> [\n  ${syms.classes.values mkString "\n  "}\n]")
-    reporter.error(s"typedefs  -> [\n  ${syms.typeDefs.values mkString "\n  "}\n]")
+    reporter.debug(s"The extracted sub-program is not well formed.")
+    reporter.debug(s"Symbols are:")
+    reporter.debug(s"functions -> [${syms.functions.keySet.toSeq.sorted mkString ", "}]")
+    reporter.debug(s"classes   -> [\n  ${syms.classes.values mkString "\n  "}\n]")
+    reporter.debug(s"typedefs  -> [\n  ${syms.typeDefs.values mkString "\n  "}\n]")
     reporter.fatalError(s"Aborting from SplitCallBack")
   }
 }

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -22,10 +22,6 @@ package object frontend {
     */
   object optBatchedProgram extends inox.FlagOptionDef("batched", false)
 
-  /** Print stack trace when Stainless throws an exception
-    */
-  object optPrintStackTrace extends inox.FlagOptionDef("print-trace", false)
-
   /**
    * Given a context (with its reporter) and a frontend factory, proceed to compile,
    * extract, transform and verify the input programs based on the active components

--- a/core/src/main/scala/stainless/package.scala
+++ b/core/src/main/scala/stainless/package.scala
@@ -113,14 +113,14 @@ package object stainless {
 
     val sw = new StringWriter
     e.printStackTrace(new PrintWriter(sw))
-    new PrintWriter("stainless-debug.txt") { write(sw.toString); close }
+    new PrintWriter("stainless-stack-trace.txt") { write(sw.toString); close }
 
-    ctx.reporter.error("Debug output is available in the file `stainless-debug.txt`, you may report your issue on https://github.com/epfl-lara/stainless/issues")
+    ctx.reporter.error("Debug output is available in the file `stainless-stack-trace.txt`, you may report your issue on https://github.com/epfl-lara/stainless/issues")
 
-    if (ctx.options.findOptionOrDefault(frontend.optPrintStackTrace))
-      ctx.reporter.error(sw.toString)
+    if (ctx.reporter.debugSections.contains(frontend.DebugSectionFrontend))
+      ctx.reporter.debug(sw.toString)(frontend.DebugSectionFrontend)
     else
-      ctx.reporter.error("You may use the option --print-trace to have the stack trace displayed in the output.")
+      ctx.reporter.error("You may use --debug=frontend to have the stack trace displayed in the output.")
 
     System.exit(2)
     ??? // unreachable


### PR DESCRIPTION
* Move printing of symbols to `--debug=frontend`
* Move printing of trace to `--debug=frontend`
* Move `stainless-debug.txt` to `stainless-stack-trace.txt` (do you think we should even keep this file, since we have `--debug=frontend`?)