### PR TITLE
Recommend using Z3 4.8.8

### DIFF
--- a/bin/package-standalone.sh
+++ b/bin/package-standalone.sh
@@ -14,7 +14,7 @@ if [[ $(git diff --stat) != '' ]]; then
 fi
 
 SCALA_VERSION="2.12"
-Z3_VERSION="4.8.6"
+Z3_VERSION="4.8.8"
 
 SBT_PACKAGE="sbt stainless-scalac-standalone/assembly"
 STAINLESS_JAR_PATH="./frontends/stainless-scalac-standalone/target/scala-$SCALA_VERSION/stainless-scalac-standalone-$STAINLESS_VERSION.jar"

--- a/core/src/sphinx/installation.rst
+++ b/core/src/sphinx/installation.rst
@@ -206,7 +206,7 @@ If no external SMT solvers (such as Z3 or CVC4) are found, Stainless will use th
 To improve performance, we highly recommend that you install the following two additional external SMT solvers as binaries for your platform:
 
 * CVC4 1.7, http://cvc4.cs.stanford.edu
-* Z3 4.8.6, https://github.com/Z3Prover/z3
+* Z3 4.8.8, https://github.com/Z3Prover/z3
 
 You can enable these solvers using ``--solvers=smt-z3`` and ``--solvers=smt-cvc4`` flags.
 
@@ -218,10 +218,10 @@ You can use multiple solvers in portfolio mode, as with the options ``--timeout=
 
 For final verification runs of highly critical software, we recommend that (instead of the portfolio mode) you obtain several solvers and their versions, then try a single solver at a time and ensure that each verification run succeeds (thus applying N-version programming to SMT solver implementations).
 
-Install Z3 4.8.6 (Linux & macOS)
+Install Z3 4.8.8 (Linux & macOS)
 ********************************
 
-1. Download Z3 4.8.6 from https://github.com/Z3Prover/z3/releases/tag/z3-4.8.6
+1. Download Z3 4.8.8 from https://github.com/Z3Prover/z3/releases/tag/z3-4.8.8
 2. Unzip the downloaded archive
 3. Copy the ``z3`` binary found in the ``bin/`` directory of the inflated archive to a directory in your ``$PATH``, eg., ``/usr/local/bin``.
 4. Make sure ``z3`` can be found, by opening a new terminal window and typing:
@@ -234,7 +234,7 @@ Install Z3 4.8.6 (Linux & macOS)
 
 .. code-block:: text
 
-  Z3 version 4.8.6 - 64 bit`
+  Z3 version 4.8.8 - 64 bit`
 
 
 Install CVC 1.7 (Linux)


### PR DESCRIPTION
I changed the larabot version to z3 4.8.8 to see if the pull requests is accepted by larabot, will revert to 4.8.6 if it fails.