### PR TITLE
Remove the tuple rule that duplicates VCs

### DIFF
--- a/core/src/main/scala/stainless/verification/TypeChecker.scala
+++ b/core/src/main/scala/stainless/verification/TypeChecker.scala
@@ -1106,8 +1106,13 @@ trait TypeChecker {
         val (inferredType, vcs) = inferType(tc, e)
         if (tpe == stripRefinementsAndAnnotations(inferredType))
           vcs
-        else
-          reporter.fatalError(e.getPos, s"Inferred type ${inferredType.asString} for ${e.asString}, which does not match ${tpe.asString}")
+        else {
+          val vd = ValDef.fresh("x", inferredType)
+          isSubtype(tc.setPos(e),
+            RefinementType(vd, Equals(vd.toVariable, e)),
+            tpe
+          )
+        }
     }
     reporter.debug(s"\n${tc0.indent}Checked that: ${e.asString} (${e.getPos})")
     reporter.debug(s"${tc0.indent}has type: ${tpe.asString}")
@@ -1117,14 +1122,32 @@ trait TypeChecker {
   }
 
   /** The `isSubtype` function simply calls `checkType` */
-  def isSubtype(tc0: TypingContext, t1: Type, t2: Type): TyperResult = {
-    reporter.debug(s"\n${tc0.indent}Checking that: ${t1.asString}")
-    reporter.debug(s"${tc0.indent}is a subtype of: ${t2.asString}")
+  def isSubtype(tc0: TypingContext, tp1: Type, tp2: Type): TyperResult = {
+    reporter.debug(s"\n${tc0.indent}Checking that: ${tp1.asString}")
+    reporter.debug(s"${tc0.indent}is a subtype of: ${tp2.asString}")
     reporter.debug(s"${tc0.indent}in context:")
     reporter.debug(tc0.asString(tc0.indent))
     val tc = tc0.inc
-    val vd = ValDef.fresh("__subtypeCheck", t1)
-    checkType(tc.bind(vd), vd.toVariable, t2).root(IsSubtype(tc, t1, t2))
+    if (tp1 == tp2) TyperResult.valid
+    else (tp1, tp2) match {
+      case (TupleType(tps1), TupleType(tps2)) =>
+        TyperResult(tps1.zip(tps2).map {
+          case (ty1, ty2) => isSubtype(tc, ty1, ty2)
+        })
+
+      case (RefinementType(vd1, prop1), RefinementType(vd2, prop2)) if (vd1.tpe == vd2.tpe) =>
+        buildVC(tc.bind(vd1).withTruth(prop1), renameVar(prop2, vd2.id, vd1.id))
+
+      case (RefinementType(vd, prop), _) =>
+        isSubtype(tc, vd.tpe, tp2)
+
+      case (_, RefinementType(vd, prop)) if vd.tpe == tp1 =>
+        buildVC(tc, prop)
+
+      // TODO: implement other subtyping rules
+      case (_, _) =>
+        reporter.fatalError(tc.getPos, s"Could not check that ${tp1.asString} is a subtype of ${tp2.asString}")
+    }
   }
 
   /** The `areEqualTypes` checks the subtyping relation in both directions */


### PR DESCRIPTION
This removes the rule that duplicates trees for checking `TupleType` and `SigmaType` and instead adds some subtyping rules. (Some more rules need to be added, for instance for `SigmaType`'s and `PiType`'s)
