### PR TITLE
Various improvements

### DIFF
--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -83,7 +83,7 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
       RecordRow(id, pos, level, extra, time) <- annotatedRows.sortBy(r => r.id -> r.pos)(ordering)
       if full || level != Level.Normal
       name = if (printUniqueName) id.uniqueName else id.name
-      contents = (name +: extra) ++ Seq(pos.fullString, f"${time / 1000d}%3.3f")
+      contents = (name +: extra) ++ Seq(pos.fullString, f"${time / 1000d}%3.1f")
     } yield Row(contents map { str => Cell(withColor(str, level)) })
   }
 
@@ -111,7 +111,7 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
       f"valid: ${stats.valid}%-4d (${stats.validFromCache} from cache) " +
       f"invalid: ${stats.invalid}%-4d " +
       f"unknown: ${stats.unknown}%-4d " +
-      f"time: ${stats.time/1000d}%7.3f"
+      f"time: ${stats.time/1000d}%7.1f"
 
     var t = Table(withColor(s"$name summary", color))
     t ++= rows

--- a/core/src/main/scala/stainless/frontend/SplitCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/SplitCallBack.scala
@@ -128,36 +128,44 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
 
   private def processSymbols(syms: xt.Symbols): Unit = {
     val ignoreFlags = Set("library", "synthetic")
-    def shouldProcess(id: Identifier): Boolean = {
-      !syms.getFunction(id).flags.exists(f => ignoreFlags contains f.name) &&
-      this.synchronized {
-        val res = toProcess(id)
-        toProcess -= id
-        res
+    def shouldProcess(id: Identifier): Set[Identifier] = {
+      if (syms.getFunction(id).flags.exists(f => ignoreFlags contains f.name))
+        Set()
+      else {
+        val mutuallyRecursiveDeps =
+          syms.dependencies(id)
+            .filter(syms.lookupFunction(_).nonEmpty)
+            .filter(id2 => syms.dependencies(id2).contains(id))
+        this.synchronized {
+          val res = (mutuallyRecursiveDeps + id).filter(toProcess)
+          toProcess -= id
+          toProcess --= mutuallyRecursiveDeps
+          res
+        }
       }
     }
 
-    for (id <- syms.functions.keys if shouldProcess(id)) {
-      processFunction(id, syms)
+    for (id <- syms.functions.keys) {
+      processFunctions(shouldProcess(id), syms)
     }
   }
 
-  private def processFunction(id: Identifier, syms: xt.Symbols): Unit = {
-    val fun = syms.functions(id)
-    val deps = syms.dependencies(id)
+  private def processFunctions(ids: Set[Identifier], syms: xt.Symbols): Unit = {
+    val funs = ids.map(syms.functions)
+    val deps = ids.flatMap(syms.dependencies)
     val clsDeps = syms.classes.values.filter(cd => deps(cd.id)).toSeq
     val funDeps = syms.functions.values.filter(fd => deps(fd.id)).toSeq
     val typeDeps = syms.typeDefs.values.filter(td => deps(td.id)).toSeq
-    val preSyms = xt.NoSymbols.withClasses(clsDeps).withFunctions(fun +: funDeps).withTypeDefs(typeDeps)
+    val preSyms = xt.NoSymbols.withClasses(clsDeps).withFunctions(funDeps ++ funs).withTypeDefs(typeDeps)
     val funSyms = Recovery.recover(preSyms)
 
-    val cf = serialize(Right(fun))(funSyms)
+    val cf = serialize(funs)(funSyms)
 
-    val futureReport = cache.getOrElseUpdate(cf, processFunctionSymbols(id, funSyms))
+    val futureReport = cache.getOrElseUpdate(cf, processFunctionsSymbols(ids, funSyms))
     this.synchronized { tasks += futureReport }
   }
 
-  private def processFunctionSymbols(id: Identifier, syms: xt.Symbols): Future[Report] = {
+  private def processFunctionsSymbols(ids: Set[Identifier], syms: xt.Symbols): Future[Report] = {
     val errors = TreeSanitizer(xt).enforce(symbols)
     if (!errors.isEmpty) {
       reportErrorFooter(symbols)
@@ -179,7 +187,7 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
     // Dispatch a task to the executor service instead of blocking this thread.
     val componentReports: Seq[Future[RunReport]] = {
       runs map { run =>
-        run(id, syms) map { a =>
+        run(ids.toSeq, syms) map { a =>
           RunReport(run)(a.toReport): RunReport
         }
       }
@@ -188,15 +196,8 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
     Future.sequence(componentReports).map(Report)
   }
 
-  private def serialize(node: Either[xt.ClassDef, xt.FunDef])(implicit syms: xt.Symbols): SerializationResult = {
-    def getId(node: Either[xt.ClassDef, xt.FunDef]) = node match {
-      case Left(cd) => cd.id
-      case Right(fd) => fd.id
-    }
-
-    val id = getId(node)
-
-    serializer.serialize(canonization(syms, id))
+  private def serialize(fds: Set[xt.FunDef])(implicit syms: xt.Symbols): SerializationResult = {
+    serializer.serialize(canonization(syms, fds.toSeq.map(_.id).sorted))
   }
 
   private def reportError(pos: inox.utils.Position, msg: String, syms: xt.Symbols): Unit = {

--- a/core/src/main/scala/stainless/termination/MeasureInference.scala
+++ b/core/src/main/scala/stainless/termination/MeasureInference.scala
@@ -40,13 +40,13 @@ trait MeasureInference
 
       override def transform(e: s.Expr): t.Expr = e match {
         case Decreases(v: Variable, body) if v.getType(symbols).isInstanceOf[ADTType] =>
-          t.Decreases(transform(size(v)), transform(body))
+          t.Decreases(transform(size(v)), transform(body)).setPos(e)
 
         case Decreases(Tuple(ts), body) =>
           t.Decreases(t.Tuple(ts.map {
             case v: Variable if v.getType(symbols).isInstanceOf[ADTType] => transform(size(v))
             case e => transform(e)
-          }), transform(body))
+          }), transform(body)).setPos(e)
 
         case _ =>
           super.transform(e)
@@ -59,34 +59,12 @@ trait MeasureInference
       }
     }
 
-    def mutuallyRecursiveWithoutMeasure(id: Identifier): Option[Identifier] = {
-      symbols.dependencies(id).find(id2 =>
-        symbols.lookupFunction(id2).exists(fd2 =>
-          symbols.dependencies(id2).contains(id) &&
-          !fd2.measure(symbols).isEmpty
-        )
-      )
-    }
-
-    def needsMeasure(fd: FunDef): Boolean = {
-      if (symbols.isRecursive(fd.id) && fd.measure(symbols).isEmpty) {
-        mutuallyRecursiveWithoutMeasure(fd.id) match {
-          case None =>
-            true
-          case Some(id) =>
-            reporter.fatalError(fd.getPos,
-              s"""Function ${fd.id} has no measure annotated, but mutually recursive function ${id} has one.
-                 |Please annotated both with a measure, or none for measure inference.""".stripMargin
-            )
-        }
-      } else {
-        false
-      }
-    }
+    def needsMeasure(fd: FunDef): Boolean =
+      symbols.isRecursive(fd.id) && fd.measure(symbols).isEmpty
 
     def inferMeasure(original: FunDef): FunDef = measureCache.get(original) match {
       case Some(measure) =>
-        original.copy(fullBody = exprOps.withMeasure(original.fullBody, Some(measure)))
+        original.copy(fullBody = exprOps.withMeasure(original.fullBody, Some(measure.setPos(original))))
 
       case None => try {
         val guarantee = timers.evaluators.termination.inference.run {
@@ -98,7 +76,7 @@ trait MeasureInference
           case pipeline.Terminates(_, Some(measure)) =>
             reporter.info(s" => Found measure for ${original.id.asString}.")
             measureCache ++= pipeline.measureCache.get
-            original.copy(fullBody = exprOps.withMeasure(original.fullBody, Some(measure)))
+            original.copy(fullBody = exprOps.withMeasure(original.fullBody, Some(measure.setPos(original))))
 
           case pipeline.Terminates(_, None) =>
             reporter.info(s" => No measure needed for ${original.id.asString}.")

--- a/core/src/main/scala/stainless/utils/Canonization.scala
+++ b/core/src/main/scala/stainless/utils/Canonization.scala
@@ -67,6 +67,13 @@ trait Canonization { self =>
     (newSyms, newIdentifier)
   }
 
+  def apply(syms: Symbols, ids: Seq[Identifier]): (Symbols, Seq[Identifier]) = {
+    val transformer = new IdTransformer(syms)
+    val newIdentifiers = ids.map(transformer.transform)
+    val newSyms = NoSymbols.withFunctions(transformer.functions).withSorts(transformer.sorts)
+    (newSyms, newIdentifiers)
+  }
+
   def apply(syms: Symbols): Symbols = {
     import exprOps._
     import syms._
@@ -223,6 +230,18 @@ trait XlangCanonization extends Canonization {
       .withTypeDefs(transformer.typeDefs)
 
     (newSyms, newIdentifier)
+  }
+
+  override def apply(syms: Symbols, ids: Seq[Identifier]): (Symbols, Seq[Identifier]) = {
+    val transformer = new XlangIdTransformer(syms)
+    val newIdentifiers = ids.map(transformer.transform)
+    val newSyms = NoSymbols
+      .withFunctions(transformer.functions)
+      .withSorts(transformer.sorts)
+      .withClasses(transformer.classes)
+      .withTypeDefs(transformer.typeDefs)
+
+    (newSyms, newIdentifiers)
   }
 }
 

--- a/core/src/main/scala/stainless/verification/TypeCheckerDerivation.scala
+++ b/core/src/main/scala/stainless/verification/TypeCheckerDerivation.scala
@@ -14,10 +14,12 @@ object TypeCheckerDerivation {
   sealed abstract class Judgment(val tc: TypingContext) extends inox.utils.Positioned {
     override def getPos = tc.getPos
     def asString(implicit opts: PrinterOptions): String
+    def htmlClass: String
   }
 
   case class IsType(override val tc: TypingContext, t: Type) extends Judgment(tc) {
     override def asString(implicit opts: PrinterOptions) = s"⊢ ${typeColor(shortString(t.asString))} is a type"
+    def htmlClass = "isType"
   }
 
   case class CheckType(override val tc: TypingContext, e: Expr, t: Type) extends Judgment(tc) {
@@ -25,30 +27,37 @@ object TypeCheckerDerivation {
       case TrueBoolean() => s"⊢ ${termColor(shortString(e.asString))} is true"
       case _ => s"⊢ ${termColor(shortString(e.asString))} ⇓ ${typeColor(shortString(t.asString))}"
     }
+    def htmlClass = "checkType"
   }
 
   case class InferType(override val tc: TypingContext, e: Expr, t: Type) extends Judgment(tc) {
     override def asString(implicit opts: PrinterOptions) = s"⊢ ${termColor(shortString(e.asString))} ⇑ ${typeColor(shortString(t.asString))}"
+    def htmlClass = "inferType"
   }
 
   case class IsSubtype(override val tc: TypingContext, t1: Type, t2: Type) extends Judgment(tc) {
     override def asString(implicit opts: PrinterOptions) = s"⊢ ${typeColor(shortString(t1.asString))} <: ${typeColor(shortString(t2.asString))}"
+    def htmlClass = "isSubtype"
   }
 
   case class AreEqualTypes(override val tc: TypingContext, t1: Type, t2: Type) extends Judgment(tc) {
     override def asString(implicit opts: PrinterOptions) = s"⊢ ${typeColor(shortString(t1.asString))} =:= ${typeColor(shortString(t2.asString))}"
+    def htmlClass = "areEqualTypes"
   }
 
   case class JVC(override val tc: TypingContext, e: Expr) extends Judgment(tc) {
     override def asString(implicit opts: PrinterOptions) = s"<span style='font-weight: bold'>⊢ ${termColor(shortString(e.asString))} is true (VC: ${tc.vcKind})</span>"
+    def htmlClass = "vc"
   }
 
   case class OKFunction(id: Identifier) extends Judgment(TypingContext.empty) {
     override def asString(implicit opts: PrinterOptions) = s"⊢ ${termColor(id.asString)} OK"
+    def htmlClass = "okFun"
   }
 
   case class OKADT(id: Identifier) extends Judgment(TypingContext.empty) {
     override def asString(implicit opts: PrinterOptions) = s"⊢ ${typeColor(id.asString)} OK"
+    def htmlClass = "okADT"
   }
 
   case class NodeTree[T](node: T, children: Seq[NodeTree[T]])
@@ -77,7 +86,7 @@ object TypeCheckerDerivation {
   def prettyPrint(t: NodeTree[Judgment], depth: Int)(implicit opts: PrinterOptions): String = {
     val indentation = "  " * depth
     val childrenString = prettyPrint(t.children, depth + 1)
-    indentation + s"<li> <span title='${t.node.getPos.fullString}\n${t.node.tc.asString()}'> ${t.node.asString} </span>\n" +
+    indentation + s"<li> <span class='node ${t.node.htmlClass}' title='${t.node.getPos.fullString}\n${t.node.tc.asString()}'> ${t.node.asString} </span>\n" +
       childrenString +
     indentation + "</li>"
   }
@@ -92,8 +101,101 @@ object TypeCheckerDerivation {
     fw.write("<html lang=\"en\">")
     fw.write("<head>\n")
     fw.write("<meta charset=\"UTF-8\">\n")
+    fw.write("""|<style>
+                |body {
+                |  font-family: "Fira Code", Menlo, Monaco, monospace;
+                |  background-color: white;
+                |  color: black;
+                |}
+                |
+                |.inferType {
+                |  background-color: #f0f0ff
+                |}
+                |
+                |.inferType:hover {
+                |  background-color: #e0e0ee
+                |}
+                |
+                |.checkType {
+                |  background-color: #f0fff0
+                |}
+                |
+                |.checkType:hover {
+                |  background-color: #e0eee0
+                |}
+                |
+                |.areEqualTypes {
+                |  background-color: #feffc2
+                |}
+                |
+                |.areEqualTypes:hover {
+                |  background-color: #dadba7
+                |}
+                |
+                |.isSubType {
+                |  background-color: #fff6eb
+                |}
+                |
+                |.isSubType:hover {
+                |  background-color: #d4d492
+                |}
+                |
+                |.isType {
+                |  background-color: #fff6eb
+                |}
+                |
+                |.isType:hover {
+                |  background-color: #d4d492
+                |}
+                |
+                |.vc {
+                |  background-color: #ffeccf
+                |}
+                |
+                |.vc:hover {
+                |  background-color: #d9c8b0
+                |}
+                |
+                |.okFun {
+                |  background-color: #efd1ff
+                |}
+                |
+                |.okFun:hover {
+                |  background-color: #c9b0d6
+                |}
+                |
+                |.okADT {
+                |  background-color: #efd1ff
+                |}
+                |
+                |.okADT:hover {
+                |  background-color: #c9b0d6
+                |}
+                |
+                |ul {
+                |  list-style-type: none;
+                |  padding-left: 10px;
+                |}
+                |</style>""".stripMargin)
     fw.write("</head>\n\n")
+
     fw.write("<body>\n")
+    fw.write("""<script type="text/javascript" src="https://code.jquery.com/jquery-3.4.1.min.js"></script>""")
+    fw.write("<script>\n")
+    fw.write("""|$(document).ready(function () {
+                |  $('.node').click(function(e) {
+                |    if (!getSelection().toString()) {
+                |      text = $(this).html()
+                |      if (text.startsWith("(Folded) "))
+                |        $(this).html(text.substring(9));
+                |      else
+                |        $(this).html("(Folded) " + text);
+                |      $(this).parent().find("ul").toggle();
+                |    }
+                |  });
+                |});
+                |""".stripMargin)
+    fw.write("</script>\n")
     fw.write(prettyPrint(trees, 0) + "\n")
     fw.write("</body>\n")
     fw.write("</html>")

--- a/core/src/sphinx/gettingstarted.rst
+++ b/core/src/sphinx/gettingstarted.rst
@@ -1,7 +1,10 @@
 .. _gettingstarted:
 
+Verifying and Compiling Examples
+================================
+
 Verifying Examples
-==================
+------------------
 
 Stainless is currently available as either:
 
@@ -81,4 +84,16 @@ and get something like this
   [  Info  ] ║ total: 9    valid: 7    (0 from cache) invalid: 2    unknown: 0    time:   1.218            ║
   [  Info  ] ╚═════════════════════════════════════════════════════════════════════════════════════════════╝
 
+
+Compiling and Executing Examples
+--------------------------------
+
+Scala code written with Stainless library dependencies can be compiled and run using the
+library sources available on the `Stainless github repository <https://github.com/epfl-lara/stainless>`_,
+and ``scalac`` and ``scala`` 2.12.9.
+
+.. code-block:: bash
+
+  scalac -d /some_folder_for_compiled_classes/ $(find /path/to/stainless/frontends/library/stainless/ -name "*.scala") File1.scala File2.scala ...
+  scala -cp /some_folder_for_compiled_classes/ $(find /path/to/stainless/frontends/library/stainless/ -name "*.scala") MainClassName
 

--- a/core/src/sphinx/index.rst
+++ b/core/src/sphinx/index.rst
@@ -15,7 +15,6 @@ Contents:
    installation
    gettingstarted
    tutorial
-   tutorial-integrate
    options
    verification
    laws

--- a/core/src/sphinx/installation.rst
+++ b/core/src/sphinx/installation.rst
@@ -17,7 +17,7 @@ General Requirement
 Use Standalone Release (recommended)
 ------------------------------------
 
-1. Download the latest Stainless release from the `Releases page on GitHub <https://github.com/epfl-lara/stainless/releases>`_, under the **Assets** section. Make sure to pick the appropriate ZIP for your operating system. This release is bundled with Z3 4.7.1.
+1. Download the latest Stainless release from the `Releases page on GitHub <https://github.com/epfl-lara/stainless/releases>`_, under the **Assets** section. Make sure to pick the appropriate ZIP for your operating system. This release is bundled with Z3 4.8.6.
 
 2. Unzip the the file you just downloaded to a directory.
 

--- a/core/src/sphinx/neon.rst
+++ b/core/src/sphinx/neon.rst
@@ -284,16 +284,15 @@ assertions to prove local properties, and use ``check`` to have the property
       assert(b3)   // verification condition: b2 ==> b3 (b1 not visible to the solver)
     }
 
-Similarly, ``assert``'s are not visible when generating verification conditions
-for postconditions, while ``check``'s are. (Note: ``assert`` are visible to
-postconditions in the mode without type checker with ``--type-checker=false``.)
+Similarly, ``assert``'s are not guaranteed to be visible when generating
+verification conditions for postconditions, while ``check``'s are.
 
 .. code-block:: scala
 
     def foo(): Unit = {
       assert(b1) // verification condition: b1
       check(b2)  // verification condition: b1 ==> b2
-    }.ensuring(_ => b3) // verification condition b2 ==> b3 (b1 not visible to the solver)
+    }.ensuring(_ => b3) // verification condition b2 ==> b3 (b1 might not be visible to the solver)
 
 
 .. _induction:

--- a/core/src/sphinx/verification.rst
+++ b/core/src/sphinx/verification.rst
@@ -1,7 +1,7 @@
 .. _verification:
 
-Verification
-============
+Verification conditions
+=======================
 
 Software verification aims at making software safer. In its typical use case,
 it is a tool that takes as input the source code of a program with
@@ -14,8 +14,6 @@ section, we describe the specification language that can be used to declare
 properties of programs, as well as the safety properties automatically checked
 by Stainless. We also discuss how Stainless can be used to prove mathematical theorems.
 
-Verification conditions
------------------------
 
 Given an input program, Stainless generates individual verification conditions
 corresponding to different properties of the program. A program is correct if
@@ -39,7 +37,7 @@ information provided by (explicit or implicit) preconditions to the ``match``
 expression.
 
 Postconditions
-**************
+--------------
 
 One core concept in verification is to check the contract of functions. The most
 important part of a contract is the postcondition. The postcondition specifies
@@ -96,7 +94,7 @@ prove the correctness. We discuss the exact conditions for this in the
 chapter on Stainless's algorithms.
 
 Preconditions
-*************
+-------------
 
 Preconditions are used as part of the contract of functions. They are a way to
 restrict the input to only relevant inputs, without having to implement guards
@@ -154,7 +152,7 @@ a precondition.
    of a function.
 
 Loop invariants
-***************
+---------------
 
 Stainless supports annotations for loop invariants in :doc:`imperative`. To
 simplify the presentation we will assume a single variable :math:`x` is in
@@ -182,7 +180,7 @@ Stainless will prove the points (1) and (2) above. Together, and by induction, t
 that point (3) holds as well.
 
 Decrease annotation in loops
-****************************
+----------------------------
 
 One can also specify that the value of a given expression of numerical type decreases
 at each loop iteration by adding a ``decreases`` measure within the loop body:
@@ -198,7 +196,7 @@ Stainless will then emit a verification condition that checks whether the expres
 is strictly positive and decreases at each iteration.
 
 Array access safety
-*******************
+-------------------
 
 Stainless generates verification conditions for the safety of array accesses. For
 each array variable, Stainless carries along a symbolic information on its length.
@@ -207,7 +205,7 @@ array is strictly smaller than that length. The expression is also checked to
 be positive.
 
 ADT invariants
-**************
+--------------
 
 Stainless lets the user write ADT invariants with the ``require`` keyword.
 Internally, such invariants are extracted as methods (named ``inv``). Whenever,
@@ -245,7 +243,7 @@ supported when ``--type-checker=true`` (which is the case by default).
 
 
 Pattern matching exhaustiveness
-*******************************
+-------------------------------
 
 Stainless verifies that pattern matching is exhaustive. The regular Scala compiler
 only considers the types of expression involved in pattern matching, but Stainless


### PR DESCRIPTION
* Remove check that measure has good type at call site (this was making arguments of recursive functions being type-checked twice, and thus duplicating VCs)
* Add check that mutually recursive functions have the same measure type
* `SplitCallBack` now processes mutually recursive functions together
* Improve HTML output for type-checking derivation
