### PR TITLE
Fix unapplyAccessor not instantiating with refinement type

### DIFF
--- a/core/src/main/scala/stainless/ast/Expressions.scala
+++ b/core/src/main/scala/stainless/ast/Expressions.scala
@@ -166,7 +166,7 @@ trait Expressions extends inox.ast.Expressions with Types { self: Trees =>
       .filter(_.params.size == 1)
       .getOrElse(throw extraction.MalformedStainlessCode(up, "Invalid unapply accessor"))
     val unapp = up.getFunction
-    val tpMap = s.instantiation(fd.params.head.getType, unapp.returnType)
+    val tpMap = s.instantiation(fd.params.head.tpe, unapp.returnType)
       .getOrElse(throw extraction.MalformedStainlessCode(up, "Unapply pattern failed type instantiation"))
     fd.typed(fd.typeArgs map tpMap).applied(Seq(unapplied))
   }

--- a/core/src/main/scala/stainless/ast/Expressions.scala
+++ b/core/src/main/scala/stainless/ast/Expressions.scala
@@ -193,7 +193,7 @@ trait Expressions extends inox.ast.Expressions with Types { self: Trees =>
       getUnapplied(unapplyScrut(scrut, this).copiedFrom(this))
 
     def subTypes(in: Type)(implicit s: Symbols): Seq[Type] =
-      unwrapTupleType(s.unapplyAccessorResultType(getGet, getFunction.getType).get, subPatterns.size)
+      unwrapTupleType(s.unapplyAccessorResultType(getGet, getFunction.returnType).get, subPatterns.size)
   }
 
   /** Symbolic I/O examples as a match/case.

--- a/core/src/main/scala/stainless/ast/Expressions.scala
+++ b/core/src/main/scala/stainless/ast/Expressions.scala
@@ -166,7 +166,7 @@ trait Expressions extends inox.ast.Expressions with Types { self: Trees =>
       .filter(_.params.size == 1)
       .getOrElse(throw extraction.MalformedStainlessCode(up, "Invalid unapply accessor"))
     val unapp = up.getFunction
-    val tpMap = s.instantiation(fd.params.head.getType, unapp.getType)
+    val tpMap = s.instantiation(fd.params.head.getType, unapp.returnType)
       .getOrElse(throw extraction.MalformedStainlessCode(up, "Unapply pattern failed type instantiation"))
     fd.typed(fd.typeArgs map tpMap).applied(Seq(unapplied))
   }

--- a/core/src/main/scala/stainless/ast/TypeOps.scala
+++ b/core/src/main/scala/stainless/ast/TypeOps.scala
@@ -12,9 +12,9 @@ trait TypeOps extends inox.ast.TypeOps {
     lookupFunction(id)
       .filter(_.params.size == 1)
       .flatMap { fd =>
-        instantiation(fd.params.head.getType, inType)
+        instantiation(fd.params.head.tpe, inType)
           .filter(tpMap => fd.typeArgs forall (tpMap contains _))
-          .map(typeOps.instantiateType(fd.getType, _))
+          .map(typeOps.instantiateType(fd.returnType, _))
       }
 
   def patternIsTyped(in: Type, pat: Pattern): Boolean = pat match {
@@ -40,7 +40,7 @@ trait TypeOps extends inox.ast.TypeOps {
     case TuplePattern(ob, subs) => in match {
       case TupleType(tps) =>
         tps.size == subs.size &&
-        ob.forall(vd => isSubtypeOf(vd.getType, in)) && 
+        ob.forall(vd => isSubtypeOf(vd.getType, in)) &&
         ((tps zip subs) forall (patternIsTyped(_, _)).tupled)
       case _ => false
     }
@@ -50,8 +50,8 @@ trait TypeOps extends inox.ast.TypeOps {
       lookupFunction(id).exists(_.tparams.size == tps.size) && {
         val unapp = up.getFunction
         unapp.params.nonEmpty &&
-        ob.forall(vd => isSubtypeOf(unapp.params.last.getType, vd.getType))
-        (recs zip unapp.params.init).forall { case (r, vd) => isSubtypeOf(r.getType, vd.getType) } &&
+        ob.forall(vd => isSubtypeOf(unapp.params.last.tpe, vd.tpe)) &&
+        (recs zip unapp.params.init).forall { case (r, vd) => isSubtypeOf(r.getType, vd.tpe) } &&
         unapp.flags
           .collectFirst { case IsUnapply(isEmpty, get) => (isEmpty, get) }
           .exists { case (isEmpty, get) =>

--- a/core/src/main/scala/stainless/ast/TypeOps.scala
+++ b/core/src/main/scala/stainless/ast/TypeOps.scala
@@ -50,8 +50,8 @@ trait TypeOps extends inox.ast.TypeOps {
       lookupFunction(id).exists(_.tparams.size == tps.size) && {
         val unapp = up.getFunction
         unapp.params.nonEmpty &&
-        ob.forall(vd => isSubtypeOf(unapp.params.last.tpe, vd.tpe)) &&
-        (recs zip unapp.params.init).forall { case (r, vd) => isSubtypeOf(r.getType, vd.tpe) } &&
+        ob.forall(vd => isSubtypeOf(unapp.params.last.getType, vd.getType)) &&
+        (recs zip unapp.params.init).forall { case (r, vd) => isSubtypeOf(r.getType, vd.getType) } &&
         unapp.flags
           .collectFirst { case IsUnapply(isEmpty, get) => (isEmpty, get) }
           .exists { case (isEmpty, get) =>

--- a/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
+++ b/core/src/main/scala/stainless/extraction/utils/SyntheticSorts.scala
@@ -12,14 +12,14 @@ trait SyntheticSorts extends ExtractionCaches { self: CachingPhase =>
 
     private[this] val syntheticOption: t.ADTSort = {
       val Seq(option, some, none) =
-        Seq("Option", "Some", "None").map(name => ast.SymbolIdentifier("stainless.lang." + name))
+        Seq("Option", "Some", "None").map(name => ast.SymbolIdentifier("stainless.internal." + name))
       val value = FreshIdentifier("value")
       mkSort(option)("A") { case Seq(aT) => Seq((some, Seq(t.ValDef(value, aT))), (none, Seq())) }
     }
 
     private[this] val syntheticIsEmpty: s.Symbols => t.FunDef = {
       def createFunction(option: Identifier, none: Identifier): t.FunDef = {
-        val isEmpty = ast.SymbolIdentifier("stainless.lang.Option.isEmpty")
+        val isEmpty = ast.SymbolIdentifier("stainless.internal.Option.isEmpty")
         mkFunDef(isEmpty, t.Unchecked, t.Synthetic)("A") {
           case Seq(aT) => (Seq("x" :: T(option)(aT)), t.BooleanType(), { case Seq(v) => v is none })
         }
@@ -30,7 +30,7 @@ trait SyntheticSorts extends ExtractionCaches { self: CachingPhase =>
         syntheticOption.constructors.find(_.fields.isEmpty).get.id)
 
       val cache = new SimpleCache[s.ADTSort, t.FunDef]
-      (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
+      (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.internal.Option") match {
         case Some(sort) => cache.cached(sort) {
           createFunction(sort.id, sort.constructors.find(_.fields.isEmpty).get.id)
         }
@@ -40,7 +40,7 @@ trait SyntheticSorts extends ExtractionCaches { self: CachingPhase =>
 
     private[this] val syntheticGet: s.Symbols => t.FunDef = {
       def createFunction(option: Identifier, some: Identifier, value: Identifier): t.FunDef = {
-        val get = ast.SymbolIdentifier("stainless.lang.Option.get")
+        val get = ast.SymbolIdentifier("stainless.internal.Option.get")
         mkFunDef(get, t.Unchecked, t.Synthetic)("A") {
           case Seq(aT) => (Seq("x" :: T(option)(aT)), aT, {
             case Seq(v) => t.Require(v is some, v.getField(value))
@@ -54,7 +54,7 @@ trait SyntheticSorts extends ExtractionCaches { self: CachingPhase =>
       }
 
       val cache = new SimpleCache[s.ADTSort, t.FunDef]
-      (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
+      (symbols: s.Symbols) => symbols.lookup.get[s.ADTSort]("stainless.internal.Option") match {
         case Some(sort) => cache.cached(sort) {
           val some = sort.constructors.find(_.fields.nonEmpty).get
           createFunction(sort.id, some.id, some.fields.head.id)
@@ -64,7 +64,7 @@ trait SyntheticSorts extends ExtractionCaches { self: CachingPhase =>
     }
 
     private[this] def optionSort(implicit symbols: s.Symbols): inox.ast.Trees#ADTSort =
-      symbols.lookup.get[s.ADTSort]("stainless.lang.Option").getOrElse(syntheticOption)
+      symbols.lookup.get[s.ADTSort]("stainless.internal.Option").getOrElse(syntheticOption)
 
     def option(implicit symbols: s.Symbols): Identifier = optionSort.id
     def some(implicit symbols: s.Symbols): Identifier = optionSort.constructors.find(_.fields.nonEmpty).get.id
@@ -73,29 +73,29 @@ trait SyntheticSorts extends ExtractionCaches { self: CachingPhase =>
     def value(implicit symbols: s.Symbols): Identifier = optionSort.constructors.flatMap(_.fields).head.id
 
     def isEmpty(implicit symbols: s.Symbols): Identifier =
-      symbols.lookup.get[s.FunDef]("stainless.lang.Option.isEmpty").getOrElse(syntheticIsEmpty(symbols)).id
+      symbols.lookup.get[s.FunDef]("stainless.internal.Option.isEmpty").getOrElse(syntheticIsEmpty(symbols)).id
     def get(implicit symbols: s.Symbols): Identifier =
-      symbols.lookup.get[s.FunDef]("stainless.lang.Option.get").getOrElse(syntheticGet(symbols)).id
+      symbols.lookup.get[s.FunDef]("stainless.internal.Option.get").getOrElse(syntheticGet(symbols)).id
 
     def sorts(implicit symbols: s.Symbols): Seq[t.ADTSort] =
-      symbols.lookup.get[s.ADTSort]("stainless.lang.Option") match {
+      symbols.lookup.get[s.ADTSort]("stainless.internal.Option") match {
         case Some(_) => Seq()
         case None => Seq(syntheticOption)
       }
 
     def functions(implicit symbols: s.Symbols): Seq[t.FunDef] =
-      (symbols.lookup.get[s.FunDef]("stainless.lang.Option.isEmpty") match {
+      (symbols.lookup.get[s.FunDef]("stainless.internal.Option.isEmpty") match {
         case Some(_) => Seq()
         case None => Seq(syntheticIsEmpty(symbols))
-      }) ++ (symbols.lookup.get[s.FunDef]("stainless.lang.Option.get") match {
+      }) ++ (symbols.lookup.get[s.FunDef]("stainless.internal.Option.get") match {
         case Some(_) => Seq()
         case None => Seq(syntheticGet(symbols))
       })
 
     def key(implicit symbols: s.Symbols): CacheKey = new SeqKey(
-      symbols.lookup.get[s.ADTSort]("stainless.lang.Option").map(SortKey(_)).toSeq ++
-      symbols.lookup.get[s.FunDef]("stainless.lang.Option.isEmpty").map(FunctionKey(_)) ++
-      symbols.lookup.get[s.FunDef]("stainless.lang.Option.get").map(FunctionKey(_))
+      symbols.lookup.get[s.ADTSort]("stainless.internal.Option").map(SortKey(_)).toSeq ++
+      symbols.lookup.get[s.FunDef]("stainless.internal.Option.isEmpty").map(FunctionKey(_)) ++
+      symbols.lookup.get[s.FunDef]("stainless.internal.Option.get").map(FunctionKey(_))
     )
   }
 }

--- a/frontends/benchmarks/verification/valid/AdtSpecializationUnapply.scala
+++ b/frontends/benchmarks/verification/valid/AdtSpecializationUnapply.scala
@@ -1,0 +1,13 @@
+object AdtSpecializationUnapply {
+  sealed trait A
+  sealed trait B extends A { val x: BigInt }
+  case class C(x: BigInt) extends B
+  case class D(x: BigInt) extends B
+  case class E(b: Boolean) extends A
+
+  def f(a: A): BigInt = a match {
+    // Will be translated to an unapply that essentially checks `b is C || b is D`
+    case b: B => b.x
+    case _ => 0
+  }
+}

--- a/frontends/benchmarks/verification/valid/AdtSpecializationUnapply2.scala
+++ b/frontends/benchmarks/verification/valid/AdtSpecializationUnapply2.scala
@@ -1,0 +1,18 @@
+import stainless.lang.Option
+
+object AdtSpecializationUnapply {
+  sealed trait Root
+  sealed trait B extends Root { val x: BigInt }
+  case class C(x: BigInt) extends B
+  case class D(x: BigInt) extends B
+
+  def keepIsEmpty(o: Option[BigInt]) =
+    o.isEmpty
+
+  def f(a: Root): BigInt =
+    a match {
+      // Will be translated to an unapply that essentially checks `b is C || b is D`
+      case b: B => b.x
+      case _ => 0
+    }
+}

--- a/frontends/benchmarks/verification/valid/AdtSpecializationUnapply2.scala
+++ b/frontends/benchmarks/verification/valid/AdtSpecializationUnapply2.scala
@@ -1,6 +1,6 @@
 import stainless.lang.Option
 
-object AdtSpecializationUnapply {
+object AdtSpecializationUnapply2 {
   sealed trait Root
   sealed trait B extends Root { val x: BigInt }
   case class C(x: BigInt) extends B


### PR DESCRIPTION
This PR fixes an issue I ran into when trying to add support for some synthesized unapplies. The bug can also be triggered on master though, and I [included a test case](https://github.com/epfl-lara/stainless/compare/fix-unapplyAccessor-inst?expand=1#diff-2160f6987b6b86c1669d115880f761c0) demonstrating the underlying issue through ADT specialization. The suggested fix is minimal, but I'd be happy to hear whether @samarion sees any problem with it.

As to why the given test case fails:

Initially, AdtSpecialization creates an unapply for `B` whose return type is `Option[{v: A | v is C || v is D}]`. However, during `matchToIfThenElse` we end up instantiating `isEmpty` and `get` with `A` rather than the refinement type. That is, we end up with `isEmpty[A](ourUnapplyForB(a))`.

Later, in the type checker (the stainless backend), we try to the check the argument passed in `isEmpty[A](ourUnapplyForB(a))`. For some reason, typer insists on proving *equality* between `Option[{v: A | v is C || v is D}]` (the result of `ourUnapplyForB(a)`) and `Option[A]` (the expected type for isEmpty's argument). (*Edit: Actually, I might only have seen the equality check between the respective type arguments to `Option[_]`. That would make more sense, as our `Option` is invariant.*)

Why did we instantiate `isEmpty` with `A` rather than the refinement type? In [`unapplyAccessor` helper](https://github.com/epfl-lara/stainless/blob/6e421baca37c97b9bd227ecbf0643505b6156292/core/src/main/scala/stainless/ast/Expressions.scala#L169) we call `TypedFunDef#getType`, which returns the non-dependent version of the result type. Replacing it with the original (`TypedFunDef#returnType`) fixes the immediate issue. (Edit: If anything, I should probably also replace the `fd.params.head.getType` by `fd.params.head.tpe`?)
