### PR TITLE
Fixed errors in docs

### DIFF
--- a/core/src/sphinx/laws.rst
+++ b/core/src/sphinx/laws.rst
@@ -78,7 +78,7 @@ satisfy for the datatype to form a valid monoid.
 
 Stainless will then ensure that the implementation of ``Monoid`` for the ``BigInt`` type satisfy
 those laws. In this case, the above definition of ``bigIntAdditiveMonoid`` will generate the
-following verification conditions:::
+following verification conditions::
 
      ┌───────────────────┐
    ╔═╡ stainless summary ╞══════════════════════════════════════════════════════════════════════╗
@@ -323,7 +323,7 @@ amended to exercise at once all the features described above.
      }
 
      @law
-     def law_leftIdentity(x: A): Boolean = {
+     def law_rightIdentity(x: A): Boolean = {
        append(x, empty) == x
      }
 


### PR DESCRIPTION
Hello! I found a couple of things that can be fixed in laws docs:
1) In the _"typeclasses"_ section, there was a `:::`, so on the site `::` is seeing. Changing it for `::` should be enough.
2) In the _"under the hood"_ section, the `law_leftIdentity` is defined twice, being one of them the `law_rightIdentity` implementation