### PR TITLE
Experiment: Less duplication, more aggressive let simplification 

### DIFF
--- a/core/src/main/scala/stainless/ast/Deconstructors.scala
+++ b/core/src/main/scala/stainless/ast/Deconstructors.scala
@@ -199,7 +199,8 @@ trait TreeDeconstructor extends inox.ast.TreeDeconstructor {
     case s.RecursiveType(id, tps, e) => (Seq(id), Seq(), Seq(e), tps, Seq(), (ids, _, es, ntps, _) => t.RecursiveType(ids(0), ntps, es(0)))
     case s.ValueType(tpe) => (Seq(), Seq(), Seq(), Seq(tpe), Seq(), (_, _, _, tps, _) => t.ValueType(tps(0)))
     case s.AnnotatedType(tpe, flags) =>
-      (Seq(), Seq(), Seq(), Seq(tpe), flags, (_, _, _, tps, flags) => t.AnnotatedType(tps(0), flags))
+      (Seq(), Seq(), Seq(), Seq(tpe), flags,
+        (_, _, _, tps, flags) => if (flags.nonEmpty) t.AnnotatedType(tps(0), flags) else tps(0))
     case _ => super.deconstruct(tpe)
   }
 

--- a/core/src/main/scala/stainless/verification/AssertionInjector.scala
+++ b/core/src/main/scala/stainless/verification/AssertionInjector.scala
@@ -54,21 +54,34 @@ trait AssertionInjector extends transformers.TreeTransformer {
         ti
       ).copiedFrom(i), transform(v)).copiedFrom(e)
 
-    // case sel @ s.ADTSelector(expr, _) =>
-    //   t.Assert(
-    //     t.IsConstructor(transform(expr), sel.constructor.id).copiedFrom(e),
-    //     Some("Cast error"),
-    //     super.transform(e)
-    //   ).copiedFrom(e)
-
     case sel @ s.ADTSelector(expr, _) =>
-      let("recv" :: expr.getType, transform(expr)) { recv =>
+      def isIndexedType(tpe: s.Type) =
+        tpe match {
+          case _: s.RecursiveType => true
+          case _ => false
+        }
+      val hasIndexedType = expr match {
+        case v: s.Variable => isIndexedType(v.tpe)
+        case fi: s.FunctionInvocation => isIndexedType(fi.tfd.returnType)
+        case _ => false
+      }
+
+      // NOTE(gsps): Keeping the old, code-duplicating behavior here, since index annotations on
+      //   types are not propagated through `expr.getType`, breaking the Streams example.
+      if (hasIndexedType)
         t.Assert(
-          t.IsConstructor(recv, sel.constructor.id).copiedFrom(e),
+          t.IsConstructor(transform(expr), sel.constructor.id).copiedFrom(e),
           Some("Cast error"),
-          super.transform(sel.copy(adt = recv).copiedFrom(e))
+          super.transform(e)
         ).copiedFrom(e)
-      }.copiedFrom(e)
+      else
+        let("recv" :: expr.getType, transform(expr)) { recv =>
+          t.Assert(
+            t.IsConstructor(recv, sel.constructor.id).copiedFrom(e),
+            Some("Cast error"),
+            super.transform(sel.copy(adt = recv).copiedFrom(e))
+          ).copiedFrom(e)
+        }.copiedFrom(e)
 
     case BVTyped(true, size, e0 @ s.Plus(lhs0, rhs0)) if checkOverflow =>
       val lhs = transform(lhs0)


### PR DESCRIPTION
This PR adds let-bindings in favor of duplicating code in two more places (match desugaring and assertions for ADT field selections). Conversely, it also adds an additional let-simplifications step in `InoxEncoder`, as encoded functions would so far not benefit from such simplifications and end up in queries to solvers.