### PR TITLE
Experiment with `isMutableType` from the imperative phase

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/SymbolOps.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/SymbolOps.scala
@@ -59,7 +59,7 @@ trait SymbolOps extends oo.SymbolOps { self: TypeOps =>
 
   private[this] def isMutableClassType(ct: ClassType, mutableClasses: Set[Identifier], visited: Set[Identifier]): Boolean = {
     mutableClasses.contains(ct.id) || (!visited(ct.id) && ct.tcd.fields.exists { vd =>
-      vd.flags.contains(IsVar) || isRealMutableType(vd.getType, mutableClasses, visited + ct.id)
+      vd.flags.contains(IsVar) || isMutableType(vd.getType, mutableClasses, visited + ct.id)
     })
   }
 
@@ -86,7 +86,7 @@ trait SymbolOps extends oo.SymbolOps { self: TypeOps =>
     !visited(adt.id) &&
     adt.getSort.constructors.exists { cons =>
       cons.fields.exists { vd =>
-        vd.flags.contains(IsVar) || isRealMutableType(vd.getType, mutableClasses, visited + adt.id)
+        vd.flags.contains(IsVar) || isMutableType(vd.getType, mutableClasses, visited + adt.id)
       }
     }
   }


### PR DESCRIPTION
This PR is an experiment that will help me and @gsps understand better how the imperative phase works. In particular, we had a look at the implementation of `isMutableType`, but weren't sure about some details, so we are changing it and seeing if it breaks anything.