### PR TITLE
Allow deserialization of classdefs.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,9 @@ target
 /.test-history
 /out-classes
 
+# scalafmt
+.scalafmt.conf
+
 # synthesis
 derivation*.dot
 

--- a/frontends/stainless-noxt/src/main/scala/stainless/frontends/noxt/NoxtFrontend.scala
+++ b/frontends/stainless-noxt/src/main/scala/stainless/frontends/noxt/NoxtFrontend.scala
@@ -16,6 +16,10 @@ object NoxtFrontend {
     import scala.collection.mutable.HashMap
     val newIds: HashMap[Identifier, Identifier] = HashMap.empty
 
+    // HACK: keying this by symbol path is a hack to ensure that same symbol
+    // paths get the same symbol.id
+    val newSymbols: HashMap[Seq[String], ast.Symbol] = HashMap.empty
+
     // Since Identifiers in the given deserialized symbols were created externally, we need
     // to avoid Stainless from potentially creating duplicate ids at a later point.
     // We therefore replace replace all the deserialized ids by fresh ones.
@@ -23,9 +27,12 @@ object NoxtFrontend {
       newIds.getOrElseUpdate(id, {
         id match {
           case id: xt.SymbolIdentifier =>
-            new xt.SymbolIdentifier(FreshIdentifier(id.name), ast.Symbol(id.symbol.path))
-          case _ =>
-            FreshIdentifier(id.name)
+            new xt.SymbolIdentifier(
+              FreshIdentifier(id.name),
+              newSymbols.getOrElseUpdate(id.symbol.path, ast.Symbol(id.symbol.path))
+            )
+
+          case _ =>  FreshIdentifier(id.name)
         }
       })
     }


### PR DESCRIPTION
Small changes that allow the ingestion of `ClassDef`s from the rust frontend and, hence, enable type class extraction.
See here for details: https://github.com/epfl-lara/rust-stainless/pull/52.