### PR TITLE
Fix TypeEncoding losing side-effects when wrapping Unit-typed expression

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -122,7 +122,7 @@ trait TypeEncoding
     case s.CharType() => C(char)(e)
     case s.RealType() => C(real)(e)
     case s.StringType() => C(str)(e)
-    case s.UnitType() => t.ADT(unit, Seq(), Seq())
+    case s.UnitType() => let(("u" :: t.UnitType()).copiedFrom(e), e) { _ => t.ADT(unit, Seq(), Seq()).copiedFrom(e) }
   }).copiedFrom(e)
 
   private[this] def unwrap(e: t.Expr, tpe: s.Type)(implicit scope: Scope): t.Expr = (tpe match {


### PR DESCRIPTION
TypeEncoding may drop `Unit`-typed expressions when wrapping them in an adaptation to `Object`:

```scala
object TypeEncodingEatsTrees {
  def foo(b: Boolean): Unit = {
    if (b) {
      true
    } else {
      assert(false)
      ()
    }

    ()
  }
}
```

The problematic transformation step:

```scala
-------------Functions-------------
def foo(b: Boolean): Unit = {
  val t: Any = if (b) {
    true
  } else {
    assert(false)
    ()
  }
  val res: Any = t
  val tmp: Any = res
  ()
}


Symbols after TypeEncoding

-------------Functions-------------
def foo(b: Boolean): Unit = {
  val t: Object = if (b) {
    Boolean(true)
  } else {
    Unit()
  }
  val res: Object = t
  val tmp: Object = res
  ()
}
```

What's needed is a fix for `wrap` that's analogous to the changes to `unwrap` in #818. Could've noticed that right away, my bad.