### PR TITLE
Minor type-checker improvements

### DIFF
--- a/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/BatchedCallBack.scala
@@ -59,7 +59,7 @@ class BatchedCallBack(components: Seq[Component])(implicit val context: inox.Con
       .withFunctions(currentFunctions)
       .withTypeDefs(currentTypeDefs)
 
-    val initialSymbols = LibraryFilter.removeLibraryFlag(allSymbols)
+    val initialSymbols = strictBVCleaner.transform(LibraryFilter.removeLibraryFlag(allSymbols))
 
     def notUserFlag(f: xt.Flag) = f.name == "library" || f == xt.Synthetic
 

--- a/core/src/main/scala/stainless/frontend/SplitCallBack.scala
+++ b/core/src/main/scala/stainless/frontend/SplitCallBack.scala
@@ -67,7 +67,7 @@ class SplitCallBack(components: Seq[Component])(override implicit val context: i
   final override def endExtractions(): Unit = {
     reporter.terminateIfFatal()
 
-    symbols = LibraryFilter.removeLibraryFlag(symbols)
+    symbols = strictBVCleaner.transform(LibraryFilter.removeLibraryFlag(symbols))
 
     processSymbols(symbols)
 

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -2,6 +2,9 @@
 
 package stainless
 
+import stainless.extraction.xlang.{trees => xt}
+import scala.language.existentials
+
 package object frontend {
 
   /** An exception thrown when non-purescala compatible code is encountered. */
@@ -76,5 +79,21 @@ package object frontend {
     activeComponents.contains(genc.GenCComponent) ||
     !ctx.options.findOptionOrDefault(optKeep).isEmpty
   }
+
+
+  // removes the `StrictBV` flag used in `CodeExtraction`
+  val strictBVCleaner = extraction.oo.SymbolTransformer(new transformers.TreeTransformer {
+    val s: xt.type = xt
+    val t: xt.type = xt
+
+    override def transform(tpe: xt.Type): xt.Type = tpe match {
+      case xt.AnnotatedType(tp, flags) if flags.exists(_ != xt.StrictBV) =>
+        xt.AnnotatedType(transform(tp), flags.filter(_ != xt.StrictBV))
+      case xt.AnnotatedType(tp, flags) =>
+        transform(tp)
+      case _ =>
+        super.transform(tpe)
+    }
+  })
 }
 

--- a/core/src/main/scala/stainless/verification/CoqEncoder.scala
+++ b/core/src/main/scala/stainless/verification/CoqEncoder.scala
@@ -316,7 +316,6 @@ trait CoqEncoder {
     val ttparams = root.tparams.map(p => (CoqIdentifier(p.id), TypeSort))
     val tparams = root.tparams.map(t => CoqIdentifier(t.id))
     val element = rawIdentifier("src")
-    // println(a.invariant)
     NormalDefinition(
       refinedIdentifier(constructor.id),
       ttparams,

--- a/core/src/main/scala/stainless/verification/CoqExpression.scala
+++ b/core/src/main/scala/stainless/verification/CoqExpression.scala
@@ -41,7 +41,6 @@ case class CoqMatchTactic(id: CoqIdentifier, cases: Seq[CoqCase]) extends CoqCom
 case class InductiveDefinition(id: CoqIdentifier, params: Seq[(CoqIdentifier,CoqExpression)], cases: Seq[InductiveCase]) extends CoqCommand {
   val paramString = params.map { case (arg,ty) => s"(${arg.coqString}: ${ty.coqString}) " }.mkString
   override def coqString = {
-    // println("Translating: " + id.coqString)
    s"Inductive ${id.coqString} ${paramString}:=" +
     cases.map(_.coqString).mkString("\n","\n",".\n")
   }
@@ -59,7 +58,6 @@ case class InductiveDefinition(id: CoqIdentifier, params: Seq[(CoqIdentifier,Coq
 case class NormalDefinition(id: CoqIdentifier, params: Seq[(CoqIdentifier,CoqExpression)], returnType: CoqExpression, body: CoqExpression) extends CoqCommand {
   val paramString = params.map { case (arg,ty) => s"(${arg.coqString}: ${ty.coqString}) " }.mkString
   override def coqString = {
-    // println("Translating: " + id.coqString)
     s"Definition ${id.coqString} ${paramString}: ${returnType.coqString} :=\n" +
       body.coqString + ".\n\nFail Next Obligation.\n"
   }

--- a/core/src/main/scala/stainless/verification/TypeCheckerContext.scala
+++ b/core/src/main/scala/stainless/verification/TypeCheckerContext.scala
@@ -169,7 +169,7 @@ object TypeCheckerContext {
       currentADT = None,
       currentMeasure = None,
       measureType = None,
-      vcKind = VCKind.Assert,
+      vcKind = VCKind.NoKind,
       checkSAT = false,
       emitVCs = true,
     )

--- a/core/src/main/scala/stainless/verification/TypeCheckerContext.scala
+++ b/core/src/main/scala/stainless/verification/TypeCheckerContext.scala
@@ -169,7 +169,7 @@ object TypeCheckerContext {
       currentADT = None,
       currentMeasure = None,
       measureType = None,
-      vcKind = VCKind.NoKind,
+      vcKind = VCKind.CheckType,
       checkSAT = false,
       emitVCs = true,
     )

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -19,7 +19,7 @@ object VCKind {
     override def underlying = k.underlying
   }
 
-  case object NoKind                        extends VCKind("unknown origin", "")
+  case object CheckType                     extends VCKind("type-checking", "types")
   case object Precondition                  extends VCKind("precondition", "precond.")
   case object Postcondition                 extends VCKind("postcondition", "postcond.")
   case object Assert                        extends VCKind("body assertion", "assert.")

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -19,6 +19,7 @@ object VCKind {
     override def underlying = k.underlying
   }
 
+  case object NoKind                        extends VCKind("unknown origin", "")
   case object Precondition                  extends VCKind("precondition", "precond.")
   case object Postcondition                 extends VCKind("postcondition", "postcond.")
   case object Assert                        extends VCKind("body assertion", "assert.")
@@ -39,6 +40,8 @@ object VCKind {
   case object Choose                        extends VCKind("choose satisfiability", "choose")
   case object Law                           extends VCKind("law", "law")
   case object InvariantSat                  extends VCKind("invariant satisfiability", "inv. sat")
+  case object RefinementSubtype             extends VCKind("refinements checks for subtyping", "refinements")
+  case object RecursiveSubtype              extends VCKind("recursive types indices checks for subtyping", "rec. types")
   case class  AssertErr(err: String)        extends VCKind("body assertion: " + err, "assert.")
   case object CoqMethod                     extends VCKind("coq function", "coq fun.")
   case class  Error(err: String)            extends VCKind(err, "error")

--- a/frontends/benchmarks/genc/ImageProcessing.scala
+++ b/frontends/benchmarks/genc/ImageProcessing.scala
@@ -662,7 +662,6 @@ object ImageProcessing {
 
       res = clamp(res / scale, 0, 255)
       // StdOut.print("RESULT BYTE: ")
-      // printAsInt(res.toByte)
       res.toByte
     }
 


### PR DESCRIPTION
* More text in tooltips for the HTML derivation
* Safer VCKind assignment (we reset the VCKind when entering the value side of a `Let`)
* Don't generate VCs at all when all conjuncts are marked `@unchecked` (previously a `true` VC was generated)