### PR TITLE
Fix 893 + minor fixes

### DIFF
--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -341,7 +341,6 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
     }
 
     expr match {
-      case Let(i, e, b) => withPath(b, path withBinding (i -> e))
       case Require(pre, b) => withShared(path, Seq(b, pre), spec, expr.getPos)
       case Ensuring(Require(pre, b), post) => withShared(path, Seq(b, pre, post), spec, expr.getPos)
       case Ensuring(b, post) => withShared(path, Seq(b, BooleanLiteral(true).copiedFrom(expr), post), spec, expr.getPos)

--- a/core/src/main/scala/stainless/ast/SymbolOps.scala
+++ b/core/src/main/scala/stainless/ast/SymbolOps.scala
@@ -330,7 +330,7 @@ trait SymbolOps extends inox.ast.SymbolOps { self: TypeOps =>
       val speccedWithPre =
         specced.withSpec(
           specced.getSpec(PreconditionKind).map(pre =>
-            Precondition(And(pre.expr, cond).setPos(pre.expr))
+            Precondition(And(cond, pre.expr).setPos(pre.expr))
           ).getOrElse(
             Precondition(cond)
           )

--- a/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
+++ b/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
@@ -52,7 +52,6 @@ trait FunctionClosure
       val tpFresh = outer.tparams map { _.freshen }
       val tparamsMap = outer.typeArgs.zip(tpFresh map {_.tp}).toMap
 
-      val oldInst = new typeOps.TypeInstantiator(tparams.map(td => td.tp -> td.tp).toMap)
       val inst = new typeOps.TypeInstantiator(tparamsMap)
 
       val (paramSubst, freshVals) = (params ++ free)
@@ -66,7 +65,7 @@ trait FunctionClosure
       val freeMap = freshVals.toMap
       val freshParams = freshVals.filterNot(p => reqPC.bindings exists (_._1.id == p._1.id)).map(_._2)
 
-      val oldInstBody = oldInst.transform(withPath(fullBody, reqPC))
+      val oldBody = withPath(fullBody, reqPC)
 
       object bodyTransformer extends SelfTreeTransformer {
         override val s: self.s.type = self.s
@@ -94,7 +93,7 @@ trait FunctionClosure
         }
       }
 
-      val newBody = bodyTransformer.transform(oldInstBody)
+      val newBody = bodyTransformer.transform(oldBody)
 
       val newFd = new s.FunDef(
         id,

--- a/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
+++ b/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
@@ -68,8 +68,6 @@ trait FunctionClosure
       val oldBody = withPath(fullBody, reqPC)
 
       object bodyTransformer extends SelfTreeTransformer {
-        override val s: self.s.type = self.s
-
         override def transform(e: Expr): Expr = e match {
           case v: Variable if freeMap.contains(v.toVal) =>
             freeMap(v.toVal).toVariable.copiedFrom(v)

--- a/core/src/main/scala/stainless/termination/Strenghtener.scala
+++ b/core/src/main/scala/stainless/termination/Strenghtener.scala
@@ -82,9 +82,6 @@ trait Strengthener { self: OrderingRelation =>
         // @nv: one must also check that variablesOf(formula) is non-empty as
         //      we may proceed to invalid strenghtening otherwise
 
-        println("THE FORMULA")
-        println(formula.asString)
-
         if (exprOps.variablesOf(formula).nonEmpty &&
             api.solveVALID(formula).contains(true)) {
           strengthenedPost(fd.id) = Some(postcondition)

--- a/core/src/main/scala/stainless/verification/AssertionInjector.scala
+++ b/core/src/main/scala/stainless/verification/AssertionInjector.scala
@@ -193,8 +193,6 @@ trait AssertionInjector extends transformers.TreeTransformer {
       // Ensure the operation doesn't shift more bits than there are.
       t.Assert(range, Some("Shift semantics"), newE).copiedFrom(e)
 
-    case e: s.Ensuring => super.transform(e.toAssert)
-
     case _ => super.transform(e)
   }
 
@@ -247,19 +245,12 @@ object AssertionInjector {
       t.NoSymbols
         .withFunctions(syms.functions.values.toSeq.map { fd =>
           injector.wrapping(fd.flags.contains(s.Wrapping)) {
-            val (specs, body) = s.exprOps.deconstructSpecs(fd.fullBody)(syms)
-            val newSpecs = specs.map(_.map(injector.transform(_)))
-            val newBody = body map injector.transform
-
-            val resultType = injector.transform(fd.returnType)
-            val fullBody = t.exprOps.reconstructSpecs(newSpecs, newBody, resultType).copiedFrom(fd.fullBody)
-
             new t.FunDef(
               fd.id,
               fd.tparams map injector.transform,
               fd.params map injector.transform,
-              resultType,
-              fullBody,
+              injector.transform(fd.returnType),
+              injector.transform(fd.fullBody),
               fd.flags map injector.transform
             ).copiedFrom(fd)
           }

--- a/core/src/main/scala/stainless/verification/ChooseInjector.scala
+++ b/core/src/main/scala/stainless/verification/ChooseInjector.scala
@@ -8,13 +8,15 @@ trait ChooseInjector extends inox.transformers.SymbolTransformer {
   val s: trees.type = trees
   val t: trees.type = trees
   import trees._
+  import exprOps._
 
   override def transform(symbols: Symbols): Symbols = {
     t.NoSymbols
       .withSorts(symbols.sorts.values.toSeq)
       .withFunctions(symbols.functions.values.toSeq.map { fd =>
-        lazy val (specs, body) = exprOps.deconstructSpecs(fd.fullBody)(symbols)
-        lazy val post = exprOps.postconditionOf(fd.fullBody)
+
+        val specced = BodyWithSpecs(fd.fullBody)
+        val post = specced.getSpec(PostconditionKind).map(s => s.expr)
 
         def injectChooses(e: Expr): Expr = e match {
           case NoTree(tpe) =>
@@ -40,15 +42,17 @@ trait ChooseInjector extends inox.transformers.SymbolTransformer {
         }
 
         val newBody = if ((fd.flags contains Extern) || (fd.flags contains Opaque)) {
-          val Lambda(Seq(vd), post) = fd.postOrTrue(symbols)
+          val Lambda(Seq(vd), post) = specced.getSpec(PostconditionKind).map(post => post.expr).getOrElse {
+            Lambda(Seq(ValDef.fresh("res", fd.returnType)), BooleanLiteral(true))
+          }
 
-          fd.precondition(symbols) match {
+          specced.getSpec(PreconditionKind).map(s => s.expr) match {
             case Some(pre) => Require(pre, Choose(vd, post))
             case None => Choose(vd, post)
           }
         } else {
-          val newBody = injectChooses(body.getOrElse(NoTree(fd.returnType)))
-          exprOps.reconstructSpecs(specs, Some(newBody), fd.returnType)
+          val newBody = injectChooses(specced.bodyOpt.getOrElse(NoTree(fd.returnType)))
+          specced.withBody(newBody).reconstructed
         }
 
         fd.copy(fullBody = newBody)

--- a/core/src/main/scala/stainless/verification/TypeCheckerContext.scala
+++ b/core/src/main/scala/stainless/verification/TypeCheckerContext.scala
@@ -70,9 +70,8 @@ object TypeCheckerContext {
       if (vds.size != es.size)
         ctx.reporter.internalError("Function `freshBindWithValues` expects sequences with the same size")
       vds.zip(es).foldLeft((this, new Freshener(Map()))) {
-        case((tcAcc, freshener), (vd,e)) =>
-          val freshVd = freshener.transform(vd)
-          val (newTc, newId) = tcAcc.freshBindWithValue(freshVd, e)
+        case ((tcAcc, freshener), (vd, e)) =>
+          val (newTc, newId) = tcAcc.freshBindWithValue(freshener.transform(vd), freshener.transform(e))
           if (freshener.contains(vd.id)) {
             ctx.reporter.internalError(s"Substitution should not contain ${vd.id.asString}")
           }

--- a/frontends/benchmarks/imperative/valid/Array7.scala
+++ b/frontends/benchmarks/imperative/valid/Array7.scala
@@ -9,10 +9,9 @@ object Array7 {
     val a2 = Array.fill(a.length)(0)
     var i = 0
     (while(i < a.length) {
-      decreases(a.length - i)
       a2(i) = a(i)
       i = i + 1
-    }) invariant(a.length == a2.length && 0 <= i && i <= a.length && (if(i > 0) a2(0) == a(0) else true))
+    }) invariant(a.length == a2.length && i >= 0 && (if(i > 0) a2(0) == a(0) else true))
     a2
   } ensuring(_(0) == a(0))
 

--- a/frontends/benchmarks/imperative/valid/Array7.scala
+++ b/frontends/benchmarks/imperative/valid/Array7.scala
@@ -9,9 +9,10 @@ object Array7 {
     val a2 = Array.fill(a.length)(0)
     var i = 0
     (while(i < a.length) {
+      decreases(a.length - i)
       a2(i) = a(i)
       i = i + 1
-    }) invariant(a.length == a2.length && i >= 0 && (if(i > 0) a2(0) == a(0) else true))
+    }) invariant(a.length == a2.length && 0 <= i && i <= a.length && (if(i > 0) a2(0) == a(0) else true))
     a2
   } ensuring(_(0) == a(0))
 

--- a/frontends/benchmarks/imperative/valid/While4.scala
+++ b/frontends/benchmarks/imperative/valid/While4.scala
@@ -1,0 +1,39 @@
+import stainless.lang._
+import stainless.math._
+
+import While4._
+
+object While4 {
+  val sizeLimit: Int = 1000000
+}
+
+case class While4[T](array: Array[T], lessThan: (T, T) => Boolean) {
+  require(array.size < sizeLimit)
+
+  def insert(elem: T): Unit = {
+    var l: Int = -1
+    var h: Int = array.size
+    val n: Int = array.size
+
+    (while (l + 1 != h) {
+      decreases(max(0, h - l))
+
+      val m = (l + h) >> 1
+
+      if (lessThan(elem, array(m))) {
+        h = m
+      } else {
+        l = m
+      }
+
+    }) invariant (-1 <= l && l < h && h <= n && array.size == n)
+
+    var i = n - 1
+    (while (i > h) {
+      decreases(i)
+      array(i) = array(i-1)
+      i = i - 1
+    }) invariant (0 <= h && h <= i && i <= n-1 && array.size == n)
+
+  }
+}


### PR DESCRIPTION
* Fix issue #893 (wrong type parameters substitutions in function closures)     
* Remove Let case in withPath to avoid introducing unnecessary specs below lets
* Fix issue where the same unique identifier appears twice in a formula (because of shared lets in specs)