### PR TITLE
Use Enter key to force watch mode to reload

### DIFF
--- a/core/src/main/scala/stainless/package.scala
+++ b/core/src/main/scala/stainless/package.scala
@@ -144,7 +144,7 @@ package object stainless {
 
   private lazy val multiThreadedExecutor: java.util.concurrent.ExecutorService =
     nParallel.map(Executors.newFixedThreadPool(_)).getOrElse(ForkJoinTasks.defaultForkJoinPool)
-  private lazy val multiThreadedExecutionContext: ExecutionContext =
+  lazy val multiThreadedExecutionContext: ExecutionContext =
     ExecutionContext.fromExecutor(multiThreadedExecutor)
 
   implicit def executionContext(implicit ctx: inox.Context): ExecutionContext =

--- a/core/src/main/scala/stainless/utils/FileWatcher.scala
+++ b/core/src/main/scala/stainless/utils/FileWatcher.scala
@@ -29,7 +29,7 @@ class FileWatcher(ctx: inox.Context, files: Set[File], action: () => Unit) {
     val dirs: Set[Path] = files map { _.getParentFile.toPath }
     dirs foreach { _.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY) }
 
-    ctx.reporter.info(s"\n\nWaiting for source changes...\n\n")
+    ctx.reporter.info(s"\n\nWaiting for source changes... (or press Enter to reload)\n\n")
 
     val kbd_In: BufferedSource = Source.stdin
     var keyPressed = false
@@ -39,7 +39,7 @@ class FileWatcher(ctx: inox.Context, files: Set[File], action: () => Unit) {
         kbd_In.next()
         keyPressed = true
       }
-    }(stainless.executionContext(ctx))
+    }(stainless.multiThreadedExecutionContext)
 
     var loop = true
 


### PR DESCRIPTION
I'm trying to make it so that pressing Enter force reload in `watch` mode (`watch` mode doesn't seem to work on some file systems, this needs to be fixed separately)

I guess that will only work when parallelism is enabled? Should I pass directly the `multiThreadedExecutionContext` (even when parallelism is disabled?)
