### PR TITLE
Watch files manually without WatchService

### DIFF
--- a/core/src/main/scala/stainless/utils/FileWatcher.scala
+++ b/core/src/main/scala/stainless/utils/FileWatcher.scala
@@ -3,7 +3,6 @@
 package stainless.utils
 
 import java.io.{ File, PrintWriter }
-import java.nio.file.{ FileSystems, Path, StandardWatchEventKinds }
 import java.util.concurrent.TimeUnit
 
 import scala.collection.JavaConverters._
@@ -20,80 +19,58 @@ import scala.concurrent.Future
 class FileWatcher(ctx: inox.Context, files: Set[File], action: () => Unit) {
 
   def run(): Unit = {
-    // Watch each individual file for modification through their parent directories
-    // (because a WatchService cannot observe files directly..., also we need to keep
-    // track of the modification time because we sometimes receive several events
-    // for the same file...)
-    val watcher = FileSystems.getDefault.newWatchService()
     val times = MutableMap[File, Long]() ++ (files map { f => f -> f.lastModified })
-    val dirs: Set[Path] = files map { _.getParentFile.toPath }
-    dirs foreach { _.register(watcher, StandardWatchEventKinds.ENTRY_MODIFY) }
 
     ctx.reporter.info(s"\n\nWaiting for source changes... (or press Enter to reload)\n\n")
 
-    val kbd_In: BufferedSource = Source.stdin
-    var keyPressed = false
-
-    Future {
-      while (true) {
-        kbd_In.next()
-        keyPressed = true
-      }
-    }(stainless.multiThreadedExecutionContext)
 
     var loop = true
-
     val interruptible = new inox.utils.Interruptible {
       override def interrupt(): Unit = { loop = false }
     }
     ctx.interruptManager.registerForInterrupts(interruptible)
 
+    val keyboard: BufferedSource = Source.stdin
+    Future {
+      while (loop) {
+        keyboard.next()
+        ctx.reporter.info(s"Detected Enter key press")
+        ctx.interruptManager.unregisterForInterrupts(interruptible)
+        action()
+        ctx.interruptManager.registerForInterrupts(interruptible)
+        ctx.reporter.info(s"\n\nWaiting for source changes... (or press Enter to reload)\n\n")
+      }
+    } (stainless.multiThreadedExecutionContext)
+
     while (loop) {
       // Wait for further changes, filtering out everything that is not of interest
+      Thread.sleep(500)
 
-      val key = watcher.poll(500, TimeUnit.MILLISECONDS)
-      if (key != null) {
-        val events = key.pollEvents()
-        val relativeDir = key.watchable.asInstanceOf[Path]
-        val notifications = events.asScala map { _.context } collect {
-          case p: Path => relativeDir.resolve(p).toFile
-        }
-        val modified = notifications filter files
+      // Update the timestamps while looking for things to process.
+      // Note that timestamps are not 100% perfect filters: the files could have the same content.
+      // But it's very lightweight and the rest of the pipeline should be able to handle similar
+      // content anyway.
+      var proceed = false
+      for {
+        f <- files
+        if f.lastModified > times(f)
+      } {
+        proceed = true
+        times(f) = f.lastModified
+      }
 
-        // Update the timestamps while looking for things to process.
-        // Note that timestamps are not 100% perfect filters: the files could have the same content.
-        // But it's very lightweight and the rest of the pipeline should be able to handle similar
-        // content anyway.
-        var proceed = false
-        for {
-          f <- modified
-          if f.lastModified > times(f)
-        } {
-          proceed = true
-          times(f) = f.lastModified
-        }
-
-        if (proceed || keyPressed) {
-          keyPressed = false
-          if (proceed)
-            ctx.reporter.info(s"Detected file modifications: ${modified mkString ", "}")
-          else
-            ctx.reporter.info(s"Detected Enter key press")
-          // Wait a little bit to avoid reading incomplete files from disk
-          Thread.sleep(100)
-          ctx.interruptManager.unregisterForInterrupts(interruptible)
-          action()
-          ctx.interruptManager.registerForInterrupts(interruptible)
-          ctx.reporter.info(s"\n\nWaiting for source changes... (or press Enter to reload)\n\n")
-        }
-
-        val valid = key.reset()
-        if (!valid) ctx.reporter.error(s"Watcher is no longer valid for $relativeDir!")
+      if (proceed) {
+        ctx.reporter.info(s"Detected file modifications")
+        // Wait a little bit to avoid reading incomplete files from disk
+        Thread.sleep(100)
+        ctx.interruptManager.unregisterForInterrupts(interruptible)
+        action()
+        ctx.interruptManager.registerForInterrupts(interruptible)
+        ctx.reporter.info(s"\n\nWaiting for source changes... (or press Enter to reload)\n\n")
       }
     }
 
     ctx.interruptManager.unregisterForInterrupts(interruptible)
-    watcher.close()
   }
 
 }


### PR DESCRIPTION
The `WatchService` doesn't seem to work when using a Windows IDE on a Windows file while running Stainless from Windows Subsystem for Linux. This PR removes the `WatchService` and watches the files' timestamps every 500ms. (The PR also fixes an issue with the `Enter` key which was not taken into account).