### PR TITLE
Bug fixes and minor improvements

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -348,7 +348,10 @@ trait ImperativeCodeElimination
 
         //TODO: no support for true mutual recursion
         case LetRec(fds, b) =>
-          toFunction(LetRec(Seq(fds.head), LetRec(fds.tail, b)))
+          if (fds.isEmpty)
+            toFunction(b)
+          else
+            toFunction(LetRec(Seq(fds.head), LetRec(fds.tail, b)))
 
         //TODO: handle vars in scope, just like LetRec
         case ld @ Lambda(params, body) =>

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -309,7 +309,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
       case Assert(_, _, body) => scrutRec(body)
       case Assume(_, body) => scrutRec(body)
 
-      case _: FunctionInvocation | _: ADT | _: LetVar | _: Let | _: Tuple | _: IfExpr =>
+      case _: Application | _: FunctionInvocation | _: ADT | _: LetVar | _: Let | _: Tuple | _: IfExpr =>
         withTmp(scrutinee0.getType, scrutinee0, env)
 
       case e => ctx.reporter.fatalError(e.getPos, s"scrutinee ${e.asString} (${e.getClass}) is not supported by GenC")

--- a/core/src/main/scala/stainless/verification/TypeChecker.scala
+++ b/core/src/main/scala/stainless/verification/TypeChecker.scala
@@ -1182,6 +1182,16 @@ trait TypeChecker {
       case (SetType(base1), SetType(base2)) =>
         areEqualTypes(tc, base1, base2)
 
+      case (BagType(base1), BagType(base2)) =>
+        areEqualTypes(tc, base1, base2)
+
+      case (MapType(from1, to1), MapType(from2, to2)) =>
+        areEqualTypes(tc, from1, from2) ++
+        areEqualTypes(tc, to1, to2)
+
+      case (ArrayType(base1), ArrayType(base2)) =>
+        areEqualTypes(tc, base1, base2)
+
       case (_, _) =>
         reporter.fatalError(tc.getPos, s"Could not check that ${tp1.asString} is a subtype of ${tp2.asString}")
     }


### PR DESCRIPTION
* Fix issue where application in scrutinee crashed GenC                    
* Add positions to error messages in GenC
* Swap order of arguments in FunctionClosure for dependent types
* Fix head of empty list issue in ImperativeCodeElimination
* Add some subtyping rules for arrays, bags, maps (without assuming covariance)