### PR TITLE
Fix issue #917 about allowed illegal aliasing

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -350,7 +350,7 @@ trait EffectsAnalyzer extends oo.CachingPhase {
           .map(rec(_, path))
           .getOrElse(Set.empty)
 
-      case fi: FunctionInvocation => throw MalformedStainlessCode(expr, s"Couldn't compute effect targets in: $expr")
+      case fi: FunctionInvocation => Set.empty
       case (_: ApplyLetRec | _: Application) => Set.empty
       case (_: FiniteArray | _: LargeArray | _: ArrayUpdated | _: MutableMapUpdated) => Set.empty
       case IsInstanceOf(e, _) => rec(e, path)

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -350,7 +350,7 @@ trait EffectsAnalyzer extends oo.CachingPhase {
           .map(rec(_, path))
           .getOrElse(Set.empty)
 
-      case fi: FunctionInvocation => Set.empty
+      case fi: FunctionInvocation => throw MalformedStainlessCode(expr, s"Couldn't compute effect targets in: $expr")
       case (_: ApplyLetRec | _: Application) => Set.empty
       case (_: FiniteArray | _: LargeArray | _: ArrayUpdated | _: MutableMapUpdated) => Set.empty
       case IsInstanceOf(e, _) => rec(e, path)

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -41,6 +41,10 @@ trait EffectsChecker { self: EffectsAnalyzer =>
       checkEffectsLocations(fd)
       checkPurity(fd)
 
+      // Recursive functions must return fresh results so that no aliasing is possible
+      if (symbols.isRecursive(fd.id) && !exprOps.withoutSpecs(fd.fullBody).forall(isExpressionFresh))
+        throw ImperativeEliminationException(fd, "Illegal recursive functions returning non-fresh result")
+
       exprOps.withoutSpecs(fd.fullBody).foreach { bd =>
 
         object traverser extends SelfTreeTraverser {

--- a/frontends/benchmarks/imperative/valid/MutableListFill.scala
+++ b/frontends/benchmarks/imperative/valid/MutableListFill.scala
@@ -1,0 +1,11 @@
+
+object MutableListFill {
+  sealed abstract class MutableList
+  case class MutableCons(var head: Int, tail: MutableList) extends MutableList
+  case class MutableNil() extends MutableList
+
+  // This function is recursive but returns fresh results, so it is valid
+  def fill(size: Int, value: Int): MutableList =
+    if (size <= 0) MutableNil()
+    else MutableCons(value, fill(size - 1, value))
+}


### PR DESCRIPTION
This fixes issue #917 and stops stainless when aliasing occurs from a recursive function, since Stainless doesn't support that.