### PR TITLE
Transform nothing typed expressions to errors in type encoding

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -165,7 +165,7 @@ trait TypeEncoding
       case (e, s.NothingType(), t2) if !isObject(t2) =>
         t.Error(scope.transform(t2), e match {
           case t.Error(_, descr) => descr
-          case _ => s"Expression of type Nothing: ${e.asString}"
+          case _ => s"Expression of type Nothing: ${e.toString}"
         })
 
       case (_, t1, t2) if isObject(t1) && !isObject(t2) => unwrap(e, t2)

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -161,6 +161,13 @@ trait TypeEncoding
     ((e, t1, t2) match {
       case (_, t1, t2) if erasedBy(t1) == erasedBy(t2) => e
       case (_, t1, t2) if isObject(t1) && isObject(t2) => e
+
+      case (e, s.NothingType(), t2) if !isObject(t2) =>
+        t.Error(scope.transform(t2), e match {
+          case t.Error(_, descr) => descr
+          case _ => "expression of type Nothing"
+        })
+
       case (_, t1, t2) if isObject(t1) && !isObject(t2) => unwrap(e, t2)
       case (_, t1, t2) if !isObject(t1) && isObject(t2) => wrap(e, t1)
 

--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -165,7 +165,7 @@ trait TypeEncoding
       case (e, s.NothingType(), t2) if !isObject(t2) =>
         t.Error(scope.transform(t2), e match {
           case t.Error(_, descr) => descr
-          case _ => "expression of type Nothing"
+          case _ => s"Expression of type Nothing: ${e.asString}"
         })
 
       case (_, t1, t2) if isObject(t1) && !isObject(t2) => unwrap(e, t2)

--- a/frontends/benchmarks/verification/valid/NothingTypeEncoding.scala
+++ b/frontends/benchmarks/verification/valid/NothingTypeEncoding.scala
@@ -1,5 +1,7 @@
 import stainless._
 import stainless.lang._
+import stainless.annotation._
+import stainless.io.StdOut
 
 object NothingTypeEncoding {
   sealed abstract class List[T]
@@ -18,10 +20,27 @@ object NothingTypeEncoding {
     }
   }
 
-  /* Commented out because this will fail (not crash) verification.
   def bar: Nothing = ???
-  // This is transformed to: error[T]
-  def foo[T]: T = bar
-   */
+
+  def eternal: Nothing = {
+    while (true) {
+      StdOut.println("never stop")
+    }
+    def boom: Nothing = error[Nothing]("boom")
+    boom
+  }
+
+  def foo[T](t: T, arg: Int): T = {
+    require(arg > 0)
+    if (arg == 0) {
+      def boom2: Nothing = error[Nothing]("boom indeed")
+      boom2
+    }
+    else if (arg < 0) bar
+    else t
+  }
+
+
+
 }
 

--- a/frontends/benchmarks/verification/valid/NothingTypeEncoding.scala
+++ b/frontends/benchmarks/verification/valid/NothingTypeEncoding.scala
@@ -22,25 +22,14 @@ object NothingTypeEncoding {
 
   def bar: Nothing = ???
 
-  def eternal: Nothing = {
-    while (true) {
-      StdOut.println("never stop")
-    }
-    def boom: Nothing = error[Nothing]("boom")
-    boom
-  }
-
   def foo[T](t: T, arg: Int): T = {
     require(arg > 0)
     if (arg == 0) {
-      def boom2: Nothing = error[Nothing]("boom indeed")
-      boom2
+      def boom: Nothing = error[Nothing]("boom indeed")
+      boom
     }
     else if (arg < 0) bar
     else t
   }
-
-
-
 }
 

--- a/frontends/benchmarks/verification/valid/NothingTypeEncoding.scala
+++ b/frontends/benchmarks/verification/valid/NothingTypeEncoding.scala
@@ -1,0 +1,27 @@
+import stainless._
+import stainless.lang._
+
+object NothingTypeEncoding {
+  sealed abstract class List[T]
+  case class Nil[T]() extends List[T]
+  case class Cons[T](head: T, tail: List[T]) extends List[T]
+
+  // This should work as expected
+  def first[T](self: List[T]): T = {
+    require(self match {
+      case Nil() => false
+      case _ => true
+    })
+    self match {
+      case Cons(v, _) => v
+      case _ => error[Nothing]("Empty list")
+    }
+  }
+
+  /* Commented out because this will fail (not crash) verification.
+  def bar: Nothing = ???
+  // This is transformed to: error[T]
+  def foo[T]: T = bar
+   */
+}
+


### PR DESCRIPTION
Closes #945.

This was the suggested solution by @samarion (if I understood him correctly).
Expressions of type `Nothing` are transform to `error[ExpectedType]` to avoid 
introducing a type predicate. The drawback of the solution is that we lose the 
expression itself, and hence all its effects.
﻿
