### PR TITLE
Add Induct case object for `@induct` annotation

### DIFF
--- a/core/src/main/scala/stainless/extraction/termination/InductElimination.scala
+++ b/core/src/main/scala/stainless/extraction/termination/InductElimination.scala
@@ -35,7 +35,7 @@ trait InductElimination
 
     // @induct on the function refers to induction on the first parameter for which `canInductOn` returns true
     val firstInductionParam =
-      if (fd.flags.exists(_.name == "induct")) {
+      if (fd.flags.contains(Induct)) {
         fd.params.find(vd => canInductOn(vd.getType)) match {
           case Some(vd) => Seq(vd)
           case None =>
@@ -51,7 +51,7 @@ trait InductElimination
     val inductionParams =
       firstInductionParam ++
         fd.params.filter { vd =>
-          !firstInductionParam.contains(vd) && vd.flags.exists(_.name == "induct")
+          !firstInductionParam.contains(vd) && vd.flags.contains(Induct)
         }
 
     if (inductionParams.isEmpty) {

--- a/core/src/main/scala/stainless/extraction/termination/InductElimination.scala
+++ b/core/src/main/scala/stainless/extraction/termination/InductElimination.scala
@@ -163,7 +163,7 @@ trait InductElimination
     val typeCheckerEnabled = context.options.findOptionOrDefault(verification.optTypeChecker)
 
     val newSpecs =
-      if (inductionParams.isEmpty || !typeCheckerEnabled) specs
+      if (inductionParams.isEmpty) specs
       else specs.filterNot(_.isInstanceOf[Measure]) ++ newMeasure
 
     val fullBody = reconstructSpecs(newSpecs, inductionBody, fd.returnType)

--- a/core/src/main/scala/stainless/extraction/termination/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/termination/Trees.scala
@@ -6,6 +6,13 @@ package termination
 
 trait Trees extends extraction.Trees { self =>
 
+  case object Induct extends Flag("induct", Seq())
+
+  override def extractFlag(name: String, args: Seq[Expr]): Flag = (name, args) match {
+    case ("induct", Seq()) => Induct
+    case _ => super.extractFlag(name, args)
+  }
+
   override def getDeconstructor(
       that: inox.ast.Trees
   ): inox.ast.TreeDeconstructor { val s: self.type; val t: that.type } = that match {
@@ -26,4 +33,9 @@ trait Printer extends extraction.Printer {
 trait TreeDeconstructor extends extraction.TreeDeconstructor {
   protected val s: Trees
   protected val t: Trees
+
+  override def deconstruct(f: s.Flag): DeconstructedFlag = f match {
+    case s.Induct => (Seq(), Seq(), Seq(), (_, _, _) => t.Induct)
+    case _ => super.deconstruct(f)
+  }
 }

--- a/core/src/main/scala/stainless/extraction/trace/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/trace/Trees.scala
@@ -6,11 +6,9 @@ package trace
 
 trait Trees extends termination.Trees { self =>
 
-  //case object Induct extends Flag("induct", Seq())
   case object TraceInduct extends Flag("traceInduct", Seq())
 
   override def extractFlag(name: String, args: Seq[Expr]): Flag = (name, args) match {
-    //case ("induct", Seq()) => Induct
     case ("traceInduct", Seq()) => TraceInduct
     case _ => super.extractFlag(name, args)
   }
@@ -34,7 +32,6 @@ trait TreeDeconstructor extends termination.TreeDeconstructor {
   protected val t: Trees
 
   override def deconstruct(f: s.Flag): DeconstructedFlag = f match {
-    //case s.Induct => (Seq(), Seq(), Seq(), (_, _, _) => t.Induct)
     case s.TraceInduct => (Seq(), Seq(), Seq(), (_, _, _) => t.TraceInduct)
     case _ => super.deconstruct(f)
   }


### PR DESCRIPTION
- Add a proper case object to represent the `@induct` annotation
- Remove `@induct` flag on the function and its parameters after `InductElimination` and ensure well-formedness
- Always replace existing measure with measure computed from `@induct` params, even when the type-checker is disabled