### PR TITLE
More checks of argument aliasing

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -186,6 +186,12 @@ trait MainHelpers extends inox.MainHelpers { self =>
       def watchRunCycle() = try {
         baseRunCycle()
       } catch {
+        case e @ extraction.MalformedStainlessCode(tree, msg) =>
+          reporter.debug(e)(frontend.DebugSectionStack)
+          ctx.reporter.error(tree.getPos, msg)
+          reporter.error("There was an error during the watch cycle")
+          reporter.reset()
+          compiler = newCompiler()
         case e: Throwable =>
           reporter.debug(e)(frontend.DebugSectionStack)
           reporter.error("There was an error during the watch cycle")

--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -453,7 +453,8 @@ trait AntiAliasing
           case fi @ FunctionInvocation(id, tps, args) =>
             val fd = Outer(fi.tfd.fd)
             val rewrittenArgs = args.map(exprOps.replaceFromSymbols(env.rewritings, _))
-            checkAliasing(fi, rewrittenArgs)
+            if (!fi.tfd.fd.flags.exists(_.name == "accessor"))
+              checkAliasing(fi, rewrittenArgs)
 
             val nfi = FunctionInvocation(
               id, tps, rewrittenArgs.map(transform(_, env))

--- a/core/src/main/scala/stainless/package.scala
+++ b/core/src/main/scala/stainless/package.scala
@@ -109,6 +109,11 @@ package object stainless {
   }
 
   def topLevelErrorHandler(e: Throwable)(implicit ctx: inox.Context): Nothing = {
+    e match {
+      case extraction.MalformedStainlessCode(tree, msg) => ctx.reporter.error(tree.getPos, msg)
+      case _ => ()
+    }
+
     ctx.reporter.error(s"Stainless terminated with an error.")
 
     val sw = new StringWriter

--- a/frontends/benchmarks/extraction/invalid/ArgumentAliasing.scala
+++ b/frontends/benchmarks/extraction/invalid/ArgumentAliasing.scala
@@ -1,0 +1,16 @@
+object Test {
+  case class IntRef(var x:Int)
+  def f = IntRef(42)
+
+  def g(d1: IntRef, d2: IntRef) = {
+    val x1 = d1.x
+    d2.x = 33
+    assert(d1.x==x1)
+  }
+
+  def mytest:Unit = {
+    val c1 = f
+    val c2 = c1
+    g(c1, c2)
+  }
+}


### PR DESCRIPTION
For issue https://github.com/epfl-lara/stainless/issues/947

@samarion I tried your suggestion of using `Try(getTargets(e)).toOption.getOrElse(exprOps.variablesOf(arg).map(v => Target(v, None, Path.empty))))` to identify aliases. Did you then want to check whether a target of one argument is a prefix of a target of another argument?

For issue #947, this doesn't seem to work because the targets of `c1` are `Some(Target(c1, None, <empty>))` and the targets of `c2` are `Some(Target(c1, None, <empty>))`. Should `getTargets` on `c2` also return `c1`?

We might have the same issue with `getTargets` returns `None`, because `variablesOf` will not capture the transitive dependencies.