### PR TITLE
More principled measure inference for chain processor

### DIFF
--- a/core/src/main/scala/stainless/termination/Strengthener.scala
+++ b/core/src/main/scala/stainless/termination/Strengthener.scala
@@ -147,7 +147,7 @@ trait Strengthener { self: OrderingRelation =>
         v -> ((soft, hard))
       }
 
-      val formulaMap = allFormulas.view.groupBy(_._1).mapValues(_.map(_._2).unzip).toMap
+      val formulaMap = allFormulas.groupBy(_._1).mapValues(_.map(_._2).unzip).toMap
 
       val constraints = for ((v, (weakFormulas, strongFormulas)) <- formulaMap) yield v -> {
         if (api.solveVALID(andJoin(weakFormulas.toSeq)).contains(true)) {

--- a/core/src/main/scala/stainless/termination/StructuralSize.scala
+++ b/core/src/main/scala/stainless/termination/StructuralSize.scala
@@ -76,16 +76,21 @@ trait StructuralSize { self: SolverProvider =>
 
     val sameSizeExprs = for ((arg1, arg2) <- s1 zip s2) yield Equals(sizeOfOneExpr(arg1), sizeOfOneExpr(arg2))
 
-    val lessBecauseLessAtFirstDifferentPos =
-      orJoin(for (firstDifferent <- 0 until scala.math.min(s1.length, s2.length)) yield and(
-          andJoin(sameSizeExprs.take(firstDifferent)),
-          LessThan(sizeOfOneExpr(s1(firstDifferent)), sizeOfOneExpr(s2(firstDifferent)))
-      ))
+    val lessBecauseLessAtFirstDifferentPos = {
+      orJoin(
+        for (firstDifferent <- 0 until scala.math.min(s1.length, s2.length)) yield {
+          val firstPartEqual = andJoin(sameSizeExprs.take(firstDifferent))
+          val lastDifferent  = LessThan(sizeOfOneExpr(s1(firstDifferent)), sizeOfOneExpr(s2(firstDifferent)))
+          and(firstPartEqual, lastDifferent)
+        }
+      )
+    }
 
-    if (s1.length > s2.length || (s1.length == s2.length && !strict)) {
-      or(andJoin(sameSizeExprs), lessBecauseLessAtFirstDifferentPos)
-    } else {
+    // Strict case applies when the first tuple is longer.
+    if(strict || s1.length > s2.length) {
       lessBecauseLessAtFirstDifferentPos
+    } else {
+      or(andJoin(sameSizeExprs), lessBecauseLessAtFirstDifferentPos)
     }
   }
 }

--- a/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/termination/TerminationSuite.scala
@@ -55,10 +55,6 @@ class TerminationSuite extends ComponentTestSuite {
     case "verification/valid/MergeSort"          => Ignore
     case "verification/valid/MergeSort2"         => Ignore
 
-    // Fails due to a bug in ChainProcessor (https://github.com/epfl-lara/stainless/issues/726)
-    case "verification/valid/Nested14" => Ignore
-    case "verification/valid/Nested16" => Ignore
-
     case _ => super.filter(ctx, name)
   }
 


### PR DESCRIPTION
This solves #726. The problem is caused because we consider lexicographic ordering to give (j,j) < j and thus, measures given are (j,j,0) and (j,0). 

I changed this order and added a version of chain processor inference that handles the example. The version should infer correct measures for chain processor in the case without unfolding. 