### PR TITLE
Prevent RefinementLifting from injecting assertions at the spec level

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
+++ b/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
@@ -118,16 +118,18 @@ trait RefinementLifting
 
         case s.RefinementType(ivd, pred) =>
           val nvd = vd.copy(tpe = ivd.tpe)
-          val subst = Map(ivd -> nvd.toVariable)
+          val tmp = nvd.freshen
+          val subst = Map(ivd -> tmp.toVariable)
 
           transform(s.Let(
             nvd,
-            value,
-            s.Assert(
-              s.exprOps.freshenLocals(s.exprOps.replaceFromSymbols(subst, pred)),
-              Some("Inner refinement lifting"),
-              body,
-            ).copiedFrom(e)
+            s.Let(tmp, value,
+              s.Assert(
+                s.exprOps.freshenLocals(s.exprOps.replaceFromSymbols(subst, pred)),
+                Some("Inner refinement lifting"),
+                tmp.toVariable,
+              ).copiedFrom(e)),
+            body
           ).copiedFrom(e))
 
         case _ => super.transform(e)

--- a/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
@@ -127,10 +127,12 @@ trait TreeSanitizer { self =>
             errors += MalformedStainlessCode(fullBody, s"Unexpected `${spec.kind.name}` specification.")
         )
       }
-      specced.specs.groupBy(_.kind).map { case (kind, specs) =>
-        if (specs.length > 1 && kind != exprOps.PreconditionKind)
-          errors += MalformedStainlessCode(fullBody, s"Duplicate `${kind.name}` specification.")
-      }
+      specced.specs
+        .filter(spec => spec.kind != exprOps.PreconditionKind && spec.kind != exprOps.LetKind)
+        .groupBy(_.kind).map { case (kind, specs) =>
+          if (specs.length > 1)
+            errors += MalformedStainlessCode(fullBody, s"Duplicate `${kind.name}` specification.")
+        }
       specced.specs.foreach(s => s.traverse(this))
       specced.bodyOpt.foreach(traverse)
     }

--- a/core/src/main/scala/stainless/verification/TypeChecker.scala
+++ b/core/src/main/scala/stainless/verification/TypeChecker.scala
@@ -953,7 +953,7 @@ trait TypeChecker {
         (RefinementType(vd, pred), trPred ++ trVC)
 
       case _ =>
-        reporter.fatalError(e.getPos, s"Unsupported expression (${e.getClass}):\n${e.asString} \nin context:\n${tc.asString()}")
+        reporter.fatalError(e.getPos, s"The type-checker doesn't support expressions: ${e.getClass}")
     }
 
     reporter.debug(s"\n${tc0.indent}Inferred type: ${t.asString} for ${e.asString}")


### PR DESCRIPTION
Fix #992 

There was an assertion injected by `RefinementLifting` at the spec level (after the `let`, before the `decreases`), which made Stainless think `decreases` was part of the body
