### PR TITLE
tips on --no-colors and emacs

### DIFF
--- a/core/src/sphinx/installation.rst
+++ b/core/src/sphinx/installation.rst
@@ -388,6 +388,56 @@ was originally developed to support Python documentation.
 
 The documentation resides in the ``core/src/sphinx/`` directory and can be built using the provided ``Makefile``. To do this, in a Linux shell,
 type ``make html``, and open in your web browser the generated top-level local HTML file, by default stored in 
-``src/sphinx/_build/html/index.html``. Also, you can open the ``*.rst`` documentation files in a text editor, as they are human-readable in their source form as well.
+``core/src/sphinx/_build/html/index.html``. Also, you can open the ``*.rst`` documentation files in a text editor, as they are human-readable in their source form as well.
 
 Note for project maintainers: to build documentation on GitHub Pages, use ``make gh-pages`` in the same Makefile, or adapt it to you needs.
+
+Using IDEs with --no-colors option. Emacs illustration
+------------------------------------------------------
+
+Using command line option ``--no-colors`` asks stainless to produce clear 7-bit ASCII output with error messages in a standardized format:
+
+.. code-block:: bash
+
+  FileName.scala:LineNo:ColNo: text of the error message
+
+This helps IDEs to pick up line numbers and show error location in the source file.
+
+In ``emacs`` editor, you can invoke ``ansi-term`` and ``compilation-shell-minor-mode``. Then, run
+
+.. code-block:: bash
+
+  stainless --no-colors <InputFilesAndOptions>
+
+You may also consider using the ``--watch`` option.
+  
+You should now be able to click on a message for verification condition to jump to the appropriate position in the appropriate file, as well as to use emacs commands ``previous-error`` and ``next-error`` to navigate through errors and other verification-condition outcomes.
+
+Here is a very simple illustration that introduces an interactive ``comp-ansi-term`` command that creates new window with ansi-term and minor compilation mode:
+
+.. code-block:: lisp
+
+  (setq comp-terminal-current-number 1)
+  (defun create-numbered-comp-terminal ()
+    (ansi-term "/bin/bash")
+    (rename-buffer (concat "q" (number-to-string comp-terminal-current-number)) 1)
+    (setq comp-terminal-current-number (+ comp-terminal-current-number 1))
+    (compilation-shell-minor-mode)
+  )
+  (defun comp-ansi-term (arg)
+    "Run ansi-term with bash and compilation-shell-minor-mode in buffer named q_N for increasing N" (interactive "P")
+    (create-numbered-comp-terminal)
+    (split-window-vertically)
+    (previous-buffer)
+    (other-window 1)
+  )
+
+The following globally binds the above command to the F3 key and binds F7 and F8 to commands for navigating reports:
+
+.. code-block:: lisp
+
+  (global-set-key [f3] 'comp-ansi-term)
+  (global-set-key [f7] 'previous-error)
+  (global-set-key [f8] 'next-error)
+
+For more information, please consult the documentation for ``emacs``.


### PR DESCRIPTION
Documentation: advice on using --no-colors inside installation tips. Also concrete illustration with emacs commands.