### PR TITLE
Add support for GenC @export annotation on types

### DIFF
--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -26,6 +26,7 @@ import scala.language.existentials
 package object extraction {
 
   val phases: Seq[(String, String)] = Seq(
+    "UserFiltering"             -> "Removes all the library functions not used by the user",
     "Preprocessing"             -> "A preprocessing phase before the pipeline",
     "PartialFunctions"          -> "Lift partial function preconditions",
     "XlangLowering"             -> "Lowering phase at the end of xlang phases",

--- a/core/src/main/scala/stainless/genc/CAST.scala
+++ b/core/src/main/scala/stainless/genc/CAST.scala
@@ -48,7 +48,7 @@ object CAST { // C Abstract Syntax Tree
 
   // Manually defined function through the cCode.function annotation have a string
   // for signature+body instead of the usual Stmt AST exclusively for the body
-  case class Fun(id: Id, returnType: Type, params: Seq[Var], body: Either[Block, String], export: Boolean) extends Def
+  case class Fun(id: Id, returnType: Type, params: Seq[Var], body: Either[Block, String], isExported: Boolean) extends Def
 
   case class Id(name: String) extends Def {
     // TODO add check on name's domain for conformance
@@ -69,19 +69,20 @@ object CAST { // C Abstract Syntax Tree
   abstract class DataType extends Type {
     val id: Id
     val fields: Seq[Var]
+    val isExported: Boolean
   }
 
-  case class TypeDef(orig: Id, alias: Id) extends Type
+  case class TypeDef(orig: Id, alias: Id, isExported: Boolean) extends Type
   case class Primitive(pt: PrimitiveType) extends Type
   case class Pointer(base: Type) extends Type
 
   case class FunType(ret: Type, params: Seq[Type]) extends Type
 
-  case class Struct(id: Id, fields: Seq[Var]) extends DataType {
+  case class Struct(id: Id, fields: Seq[Var], isExported: Boolean) extends DataType {
     require(fields.nonEmpty)
   }
 
-  case class Union(id: Id, fields: Seq[Var]) extends DataType {
+  case class Union(id: Id, fields: Seq[Var], isExported: Boolean) extends DataType {
     require(fields.nonEmpty)
   }
 

--- a/core/src/main/scala/stainless/genc/CPrinter.scala
+++ b/core/src/main/scala/stainless/genc/CPrinter.scala
@@ -60,7 +60,7 @@ class CPrinter(
               sep = "\n\n")
              }
             |${nary(
-              functions.filter(!_.export) map FunDecl,
+              functions.filter(!_.isExported) map FunDecl,
               opening = separator("function declarations"),
               closing = "\n\n",
               sep = "\n")
@@ -105,7 +105,7 @@ class CPrinter(
               sep = "\n\n")
              }
             |${nary(
-              functions.filter(_.export) map FunDecl,
+              functions.filter(_.isExported) map FunDecl,
               opening = separator("function declarations"),
               sep = "\n")
              }
@@ -129,7 +129,7 @@ class CPrinter(
 
     case Var(id, typ) => c"${TypeId(typ, id)}"
 
-    case TypeDef(orig, _) => c"$orig"
+    case TypeDef(orig, _, _) => c"$orig"
 
     case Primitive(pt) => pt match {
       case CharType => c"char"
@@ -155,9 +155,9 @@ class CPrinter(
 
     case Pointer(base) => c"$base*"
 
-    case Struct(id, _) => c"$id"
+    case Struct(id, _, _) => c"$id"
 
-    case Union(id, _) => c"$id"
+    case Union(id, _, _) => c"$id"
 
     case Enum(id, _) => c"$id"
 
@@ -272,7 +272,7 @@ class CPrinter(
 
     case FunDecl(f) => c"${FunSign(f)};"
 
-    case TypeDefDecl(TypeDef(original, alias)) => c"typedef $alias $original;"
+    case TypeDefDecl(TypeDef(original, alias, _)) => c"typedef $alias $original;"
 
     case EnumDef(Enum(id, literals)) =>
       c"""|typedef enum {

--- a/core/src/main/scala/stainless/genc/ir/ClassLifter.scala
+++ b/core/src/main/scala/stainless/genc/ir/ClassLifter.scala
@@ -36,7 +36,7 @@ final class ClassLifter(val ctx: inox.Context) extends Transformer(NIR, LIR) {
     val params = fd.params map lift
 
     // Handle recursive functions
-    val newer = to.FunDef(id, returnType, ctx, params, null, fd.export)
+    val newer = to.FunDef(id, returnType, ctx, params, null, fd.isExported)
     registerFunction(fd, newer)
 
     newer.body = rec(fd.body)(lift)
@@ -70,7 +70,7 @@ final class ClassLifter(val ctx: inox.Context) extends Transformer(NIR, LIR) {
       vd
     }
 
-    val cd = to.ClassDef(id, parent, fields, isAbstract)
+    val cd = to.ClassDef(id, parent, fields, isAbstract, cd0.isExported)
 
     // Actually register the classes/arrays now that we have the corresponding ClassDef
     valFieldsToRegister foreach { case (id, ct) =>

--- a/core/src/main/scala/stainless/genc/ir/IRPrinter.scala
+++ b/core/src/main/scala/stainless/genc/ir/IRPrinter.scala
@@ -120,7 +120,7 @@ final class IRPrinter[S <: IR](val ir: S) {
     case ClassType(clazz) => clazz.id
     case ArrayType(base) => "Array[" + rec(base) + "]"
     case ReferenceType(t) => "Ref[" + rec(t) + "]"
-    case TypeDefType(original, alias, _) => "typedef " + original + " -> " + alias
+    case TypeDefType(original, alias, _, _) => "typedef " + original + " -> " + alias
     case DroppedType => "DROPPED"
     case NoType => "NO-TYPE"
   }

--- a/core/src/main/scala/stainless/genc/ir/Referentiator.scala
+++ b/core/src/main/scala/stainless/genc/ir/Referentiator.scala
@@ -93,7 +93,7 @@ final class Referentiator(val ctx: inox.Context) extends Transformer(LIR, RIR) {
     val newEnv = env.withParams(((fd.ctx ++ fd.params) zip (ctx ++ params)).toMap)
 
     // Handle recursive functions
-    val newer = to.FunDef(id, returnType, ctx, params, null, fd.export)
+    val newer = to.FunDef(id, returnType, ctx, params, null, fd.isExported)
 
     // Don't traverse nor register the body if we are looking ahead. It would be useless and wrong, resp.
     if (lookingAhead) {

--- a/core/src/main/scala/stainless/genc/ir/Transformer.scala
+++ b/core/src/main/scala/stainless/genc/ir/Transformer.scala
@@ -58,7 +58,7 @@ abstract class Transformer[From <: IR, To <: IR](final val from: From, final val
   protected final def rec(fd: FunDef)(implicit env: Env): to.FunDef = funCache.getOrElse(fd, recImpl(fd))
 
   protected def recImpl(fd: FunDef)(implicit env: Env): to.FunDef = {
-    val newer = to.FunDef(fd.id, rec(fd.returnType), fd.ctx map rec, fd.params map rec, null, fd.export)
+    val newer = to.FunDef(fd.id, rec(fd.returnType), fd.ctx map rec, fd.params map rec, null, fd.isExported)
     registerFunction(fd, newer)
     newer.body = rec(fd.body)
     newer
@@ -90,7 +90,7 @@ abstract class Transformer[From <: IR, To <: IR](final val from: From, final val
   }
 
   protected def recImpl(cd: ClassDef, parent: Option[to.ClassDef])(implicit env: Env): to.ClassDef =
-    to.ClassDef(cd.id, parent, cd.fields map rec, cd.isAbstract)
+    to.ClassDef(cd.id, parent, cd.fields map rec, cd.isAbstract, cd.isExported)
 
   protected def rec(vd: ValDef)(implicit env: Env): to.ValDef = to.ValDef(vd.id, rec(vd.typ), vd.isVar)
 
@@ -156,7 +156,7 @@ abstract class Transformer[From <: IR, To <: IR](final val from: From, final val
     case ClassType(clazz) => to.ClassType(rec(clazz))
     case ArrayType(base) => to.ArrayType(rec(base))
     case ReferenceType(t) => to.ReferenceType(rec(t))
-    case TypeDefType(original, alias, include) => to.TypeDefType(original, alias, include)
+    case TypeDefType(original, alias, include, export) => to.TypeDefType(original, alias, include, export)
     case DroppedType => to.DroppedType
     case NoType => to.NoType
   }

--- a/core/src/main/scala/stainless/genc/ir/Visitor.scala
+++ b/core/src/main/scala/stainless/genc/ir/Visitor.scala
@@ -127,7 +127,7 @@ abstract class Visitor[S <: IR](final val ir: S) {
       case ClassType(clazz) => rec(clazz)
       case ArrayType(base) => rec(base)
       case ReferenceType(t) => rec(t)
-      case TypeDefType(original, alias, include) => ()
+      case TypeDefType(original, alias, include, _) => ()
       case DroppedType => ()
       case NoType => ()
     }

--- a/core/src/main/scala/stainless/genc/phases/ExtraOps.scala
+++ b/core/src/main/scala/stainless/genc/phases/ExtraOps.scala
@@ -76,6 +76,7 @@ private[genc] object ExtraOps {
   implicit class ClassDefOps(val cd: ClassDef) {
     def isManuallyTyped = hasAnnotation(manualTypeAnnotation)
     def isDropped       = hasAnnotation(droppedAnnotation)
+    def isExported      = hasAnnotation("export")
 
     def extAnnotations: Map[String, Seq[Any]] = cd.flags.collect {
       case Annotation(s, args) => s -> args

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -40,8 +40,8 @@ private[genc] object Scala2IRPhase extends LeonPipeline[(Dependencies, FunCtxDB)
     impl.run()
 
     val ir = CIR.Prog(
-      impl.funCache.values.toSeq,
-      impl.classCache.values.toSeq
+      impl.funCache.values.toList,
+      impl.classCache.values.toList
     )
 
     ctx.reporter.debug("RESULTING CIR:\n" + ir.toString())
@@ -67,12 +67,12 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
       df match {
         case fd: FunDef if fd.isExported =>
           rec(Outer(fd), Seq())(Map.empty, (Map.empty, Map.empty))
+        case cd: ClassDef if cd.isExported =>
+          rec(cd.typed.toType)(Map.empty)
         case _ =>
       }
     }
   }
-
-  // def apply(entryPoint: FunDef): CIR.FunDef = rec(Outer(entryPoint), entryPoint.tparams.map(_.tp))(Map.empty, (Map.empty, Map.empty))
 
   /****************************************************************************************************
    *                                                       Caches                                     *
@@ -83,7 +83,9 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
   // instantiation of the outer function we have only one TypedFunDef for the inner function.
   val funCache = MutableMap[(FunAbstraction, Seq[Type], TypeMapping), CIR.FunDef]()
 
-  val classCache = MutableMap[ClassType, CIR.ClassDef]()
+  // The `classCache` might be queried with a generic class type, which is why we keep the concrete
+  // type mapping in the cache key
+  val classCache = MutableMap[(ClassType, TypeMapping), CIR.ClassDef]()
 
 
 
@@ -102,7 +104,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
     typeOps.instantiateType(typ, tm)
 
   // Here, when contexts are translated, there might remain some generic types. We use `tm` to make them disapear.
-  private def convertVarInfoToArg(vi: VarInfo)(implicit tm: TypeMapping) = CIR.ValDef(rec(vi.vd), rec(vi.typ), vi.isVar)
+  private def convertVarInfoToArg(vi: VarInfo)(implicit tm: TypeMapping) = CIR.ValDef(rec(vi.vd.id), rec(vi.typ), vi.isVar)
   private def convertVarInfoToParam(vi: VarInfo)(implicit tm: TypeMapping) = CIR.Binding(convertVarInfoToArg(vi))
 
   // Extract the ValDef from the known one
@@ -127,7 +129,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
 
   private def buildLet(x: ValDef, e: Expr, body: Expr, isVar: Boolean)
                       (implicit env: Env, tm: TypeMapping): CIR.Expr = {
-    val vd = CIR.ValDef(rec(x), rec(x.tpe), isVar)
+    val vd = CIR.ValDef(rec(x.id), rec(x.tpe), isVar)
     val decl = CIR.DeclInit(vd, rec(e))
     val newValDefEnv = env._1 + ((x, instantiate(x.tpe, tm)) -> vd)
     val rest = rec(body)((newValDefEnv, env._2), tm)
@@ -145,8 +147,10 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
     rec(fa.id, withUnique = !exported) + (if (tps.nonEmpty) buildIdPostfix(tps) else buildIdFromTypeMapping(tm))
   }
 
-  private def buildId(ct: ClassType)(implicit tm: TypeMapping): CIR.Id =
-    rec(ct.tcd.id) + buildIdPostfix(ct.tps)
+  private def buildId(ct: ClassType)(implicit tm: TypeMapping): CIR.Id = {
+    val exported = ct.tcd.cd.isExported
+    rec(ct.tcd.id, withUnique = !exported) + buildIdPostfix(ct.tps)
+  }
 
   private def buildIdPostfix(tps: Seq[Type])(implicit tm: TypeMapping): CIR.Id = if (tps.isEmpty) "" else {
     "_" + (tps filterNot { _ == Untyped } map rec map CIR.repId mkString "_")
@@ -233,7 +237,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
       val types = bases map rec
       val fields = types.zipWithIndex map { case (typ, i) => CIR.ValDef("_" + (i+1), typ, isVar = false) }
       val id = "Tuple" + buildIdPostfix(bases)
-      CIR.ClassDef(id, None, fields, isAbstract = false)
+      CIR.ClassDef(id, None, fields, isAbstract = false, isExported = false)
 
     case _ => ctx.reporter.fatalError(typ.getPos, s"Unexpected ${typ.getClass} instead of TupleType")
   }
@@ -267,7 +271,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
 
     def withTmp(typ: Type, value: Expr, env: Env): (Variable, Some[CIR.DeclInit], Env) = {
       val tmp0 = ValDef.fresh("tmp", typ)
-      val tmpId = rec(tmp0)
+      val tmpId = rec(tmp0.id)
       val tmpTyp = rec(typ)
       val tmp = CIR.ValDef(tmpId, tmpTyp, isVar = false)
       val pre = CIR.DeclInit(tmp, rec(value)(env, tm))
@@ -415,10 +419,6 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
     else id.name
   }
 
-  private def rec(vd: ValDef): CIR.Id = {
-    vd.id.uniqueNameDelimited("_")
-  }
-
   // Try first to fetch the function from cache to handle recursive funcitons.
   private def rec(fa: FunAbstraction, tps: Seq[Type])(implicit tm0: TypeMapping, env: Env): CIR.FunDef = {
     val cacheKey = (fa, tps, tm0)
@@ -465,6 +465,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
 
     // Build a partial function without body in order to support recursive functions
     val fun = CIR.FunDef(id, returnType, funCtx, params, null, export)
+
     funCache.update(cacheKey, fun) // Register with the callee TypeMapping, *not* the newer
 
     // Now proceed with the body
@@ -518,7 +519,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
         CIR.DroppedType
       } else if (cd.isManuallyTyped) {
         val typeDef = cd.getManualType
-        CIR.TypeDefType(cd.id.name, typeDef.alias, typeDef.include)
+        CIR.TypeDefType(cd.id.name, typeDef.alias, typeDef.include, cd.isExported)
       } else {
         CIR.ClassType(rec(ct))
       }
@@ -535,6 +536,8 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
   }
 
   private def rec(ct: ClassType)(implicit tm: TypeMapping): CIR.ClassDef = {
+    val cacheKey = (ct, tm)
+    classCache.getOrElseUpdate(cacheKey, {
     // Convert the whole class hierarchy to register all siblings, in a top down fasion, that way
     // each children class in the the CIR hierarchy get registered to its parent and we can keep track
     // of all of them.
@@ -552,12 +555,17 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
       if (cd.isCaseObject)
         ctx.reporter.fatalError(ct.getPos, s"Case objects (${ct.id.asString}) are not convertible to ClassDef in GenC")
 
+      // disable name mangling for fields of exported classes
+      val mangling = !cd.isExported
+
       // Use the class definition id, not the typed one as they might not match.
       val nonGhostFields = tcd.fields.filter(!_.flags.contains(Ghost))
       val fieldTypes = nonGhostFields.map(_.tpe) map rec
-      val fields = (nonGhostFields zip fieldTypes) map { case (vd, typ) => CIR.ValDef(rec(vd), typ, vd.flags.contains(IsVar)) }
+      val fields = (nonGhostFields zip fieldTypes) map { case (vd, typ) =>
+        CIR.ValDef(rec(vd.id, withUnique = mangling), typ, vd.flags.contains(IsVar))
+      }
 
-      val clazz = CIR.ClassDef(id, parent, fields, cd.isAbstract)
+      val clazz = CIR.ClassDef(id, parent, fields, cd.isAbstract, cd.isExported)
 
       val newAcc = acc + (ct -> clazz)
 
@@ -569,6 +577,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
     val translation = recTopDown(syms.getClass(root(ct.id)).typed(ct.tps).toType, None, Map.empty)
 
     translation(ct)
+    })
   }
 
   private def rec(e: Expr)(implicit env: Env, tm0: TypeMapping): CIR.Expr = e match {
@@ -616,15 +625,18 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
     case FieldAssignment(obj, fieldId0, expr) =>
       // The fieldId might actually not be the correct one;
       // it's global counter might differ from the one in the class definition.
-      val fieldId = obj.getType match {
+      obj.getType match {
         case ct: ClassType =>
           val fields = ct.tcd.fields
           val optFieldId = fields collectFirst { case field if field.id.name == fieldId0.name => field.id }
-          optFieldId getOrElse { ctx.reporter.fatalError(e.getPos, s"No corresponding field for $fieldId0 in class $ct") }
+          val fieldId = optFieldId getOrElse {
+            ctx.reporter.fatalError(e.getPos, s"No corresponding field for $fieldId0 in class $ct")
+          }
+          CIR.Assign(CIR.FieldAccess(rec(obj), rec(fieldId, withUnique = !ct.tcd.cd.isExported)), rec(expr))
 
-        case typ => ctx.reporter.fatalError(e.getPos, s"Unexpected type $typ. Only class type are expected to update fields")
+        case typ =>
+          ctx.reporter.fatalError(e.getPos, s"Unexpected type $typ. Only class type are expected to update fields")
       }
-      CIR.Assign(CIR.FieldAccess(rec(obj), rec(fieldId)), rec(expr))
 
     case LetRec(lfds, body) =>
       // We don't have to traverse the nested function now because we already have their contexts
@@ -698,7 +710,9 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
 
       CIR.Construct(ct2, args2)
 
-    case ClassSelector(obj, fieldId) => CIR.FieldAccess(rec(obj), rec(fieldId))
+    case ClassSelector(obj, fieldId) =>
+      val cd = obj.getType.asInstanceOf[ClassType].tcd.cd
+      CIR.FieldAccess(rec(obj), rec(fieldId, withUnique = !cd.isExported))
 
     case tuple @ Tuple(args0) =>
       val clazz = tuple2Class(tuple.getType)

--- a/frontends/benchmarks/genc/TwoOptions.scala
+++ b/frontends/benchmarks/genc/TwoOptions.scala
@@ -1,0 +1,20 @@
+/* Copyright 2009-2021 EPFL, Lausanne */
+
+import stainless.lang._
+import stainless.annotation._
+
+object TwoOptions {
+
+  @export
+  def twoOptions: Unit = {
+    var opt1: Option[Long] = None()
+    val opt2: Option[Int] = None()
+    opt1.isEmpty
+    opt2.isEmpty
+  }
+
+  @export
+  def main() = {
+  }
+
+}

--- a/frontends/scalac/src/it/scala/stainless/GencSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/GencSuite.scala
@@ -33,7 +33,7 @@ class GenCSuite extends FunSuite with inox.ResourceUtils with InputUtils {
 
   for (file <- files) {
     val cFile = file.replace(".scala", ".c")
-    test(s"stainless --genc --genc-ouptut=$cFile $file") {
+    test(s"stainless --genc --genc-output=$cFile $file") {
       runMainWithArgs(Array(file) :+ "--genc" :+ s"--genc-output=$cFile")
       assert(Files.exists(Paths.get(cFile)))
       val gccCompile = s"gcc $cFile"

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -36,7 +36,9 @@ trait ASTExtractors {
   def getAnnotations(sym: Symbol, ignoreOwner: Boolean = false): Seq[(String, Seq[Tree])] = {
     val actualSymbol = sym.accessedOrSelf.orElse(sym)
     val selfs = actualSymbol.annotations
-    val owners = if (ignoreOwner) Set.empty else actualSymbol.owner.annotations
+    val owners =
+      if (ignoreOwner) Set.empty
+      else actualSymbol.owner.annotations.filter(annot => annot.toString != "stainless.annotation.export")
     val companions = if (actualSymbol.isSynthetic) actualSymbol.companionSymbol.annotations else Set.empty
     (for {
       a <- (selfs ++ owners ++ companions)


### PR DESCRIPTION
Fix https://github.com/epfl-lara/stainless/issues/1007

@deiruch Should we also prevent name mangling for `val`'s and `var`'s of `@export`'ed classes?