### PR TITLE
Add dummy function calls for while loops to possibly make them @opaque and @inlineOnce

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -209,7 +209,7 @@ trait EffectsChecker { self: EffectsAnalyzer =>
         if (predEffects.nonEmpty)
           throw ImperativeEliminationException(pred, "Quantifier has effects on: " + predEffects.head.receiver.asString)
 
-      case wh @ While(_, _, Some(invariant)) =>
+      case wh @ While(_, _, Some(invariant), _) =>
         val invEffects = effects(invariant)
         if (invEffects.nonEmpty)
           throw ImperativeEliminationException(invariant, "Loop invariant has effects on: " + invEffects.head.receiver.asString)

--- a/core/src/main/scala/stainless/extraction/imperative/TransformerWithPC.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/TransformerWithPC.scala
@@ -12,9 +12,14 @@ trait TransformerWithPC extends innerfuns.TransformerWithPC {
     case s.LetVar(vd, v, b) =>
       t.LetVar(transform(vd, env), transform(v, env), transform(b, env withBinding (vd -> v))).copiedFrom(e)
 
-    case s.While(cond, body, optInv) =>
+    case s.While(cond, body, optInv, flags) =>
       val bodyEnv = env withCond optInv.map(inv => s.And(inv, cond).copiedFrom(e)).getOrElse(cond)
-      t.While(transform(cond, env), transform(body, bodyEnv), optInv.map(transform(_, env))).copiedFrom(e)
+      t.While(
+        transform(cond, env),
+        transform(body, bodyEnv),
+        optInv.map(transform(_, env)),
+        flags.map(transform(_, env))
+      ).copiedFrom(e)
 
     case _ => super.transform(e, env)
   }

--- a/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
@@ -27,11 +27,12 @@ trait TransformerWithType extends oo.TransformerWithType {
         transform(value, fa.getField.get.getType)
       ).copiedFrom(expr)
 
-    case s.While(cond, body, pred) =>
+    case s.While(cond, body, pred, flags) =>
       t.While(
         transform(cond, s.BooleanType()),
         transform(body),
-        pred map (transform(_, s.BooleanType()))
+        pred map (transform(_, s.BooleanType())),
+        flags map (transform)
       ).copiedFrom(expr)
 
     case s.ArrayUpdate(array, index, value) =>

--- a/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
+++ b/core/src/main/scala/stainless/extraction/xlang/TreeSanitizer.scala
@@ -158,10 +158,11 @@ trait TreeSanitizer { self =>
       case e: Ensuring =>
         errors += MalformedStainlessCode(e, s"Unexpected `ensuring` ($misplacedSpec).")
 
-      case wh @ While(cond, body, optInv) =>
+      case wh @ While(cond, body, optInv, flags) =>
         traverse(cond)
         checkBodyWithSpecs(body, kindsWhitelist = Some(Set(exprOps.MeasureKind)))
         optInv.foreach(traverse)
+        flags.foreach(traverse)
 
       case e: LetRec =>
         // Traverse LocalFunDef independently

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -756,7 +756,7 @@ private class S2IRImpl(val ctx: inox.Context, val ctxDB: FunCtxDB, val deps: Dep
     case IfExpr(cond, thenn, NoTree(_)) => CIR.If(rec(cond), rec(thenn))
     case IfExpr(cond, thenn, elze) => CIR.IfElse(rec(cond), rec(thenn), rec(elze))
 
-    case While(cond, body, _)     => CIR.While(rec(cond), rec(body))
+    case While(cond, body, _, _)     => CIR.While(rec(cond), rec(body))
 
     case LessThan(lhs, rhs)       => buildBinOp(lhs, O.LessThan, rhs)(e.getPos)
     case GreaterThan(lhs, rhs)    => buildBinOp(lhs, O.GreaterThan, rhs)(e.getPos)

--- a/frontends/benchmarks/imperative/invalid/Array3Opaque.scala
+++ b/frontends/benchmarks/imperative/invalid/Array3Opaque.scala
@@ -1,0 +1,18 @@
+/* Copyright 2009-2021 EPFL, Lausanne */
+
+import stainless.lang._
+
+object Array3Opaque {
+
+  def foo(): Int = {
+    val a = Array.fill(5)(3)
+    var i = 0
+    var sum = 0
+    (while(i < a.length) {
+      sum = sum + a(i)
+      i = i + 1
+    }).opaque.inline.invariant(i >= 0)
+    sum
+  } ensuring(_ == 15)
+
+}

--- a/frontends/benchmarks/imperative/valid/Tutorial.scala
+++ b/frontends/benchmarks/imperative/valid/Tutorial.scala
@@ -1,5 +1,5 @@
 import stainless.lang._
-import stainless.lang.StaticChecks._
+import stainless.lang.StaticChecks.WhileDecorations
 
 import SFuns._
 

--- a/frontends/library/stainless/lang/StaticChecks.scala
+++ b/frontends/library/stainless/lang/StaticChecks.scala
@@ -9,6 +9,14 @@ object StaticChecks {
     def ensuring(@ghost cond: (A) => Boolean): A = x
   }
 
+  @library @ignore
+  implicit class WhileDecorations(val u: Unit) {
+    def invariant(@ghost x: Boolean): Unit = {
+      require(x)
+      u
+    }
+  }
+
   @library
   def require(@ghost pred: Boolean): Unit = ()
 

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -72,6 +72,9 @@ package object lang {
       require(x)
       u
     }
+
+    def inline: Unit = { }
+    def opaque: Unit = { }
   }
 
   @ignore

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -1065,11 +1065,11 @@ trait CodeExtraction extends ASTExtractors {
     case a @ ExFieldAssign(sym, lhs@Select(thiss: This, _), rhs) =>
       xt.FieldAssignment(extractTree(thiss), getIdentifier(sym), extractTree(rhs))
 
-    case wh @ ExWhile(cond, body) =>
-      xt.While(extractTree(cond), extractTree(body), None)
-
-    case wh @ ExWhileWithInvariant(cond, body, inv) =>
-      xt.While(extractTree(cond), extractTree(body), Some(extractTree(inv)))
+    case wh @ ExWhile(cond, body, invOpt, inline, opaque) =>
+      val inlineFlag = if (inline) Some(xt.InlineOnce) else None
+      val opaqueFlag = if (opaque) Some(xt.Opaque) else None
+      val flags = inlineFlag.toSeq ++ opaqueFlag
+      xt.While(extractTree(cond), extractTree(body), invOpt.map(extractTree), flags)
 
     case ExBigIntLiteral(n: Literal) =>
       xt.IntegerLiteral(BigInt(n.value.stringValue))


### PR DESCRIPTION
* Add dummy function calls for while loops to possibly make them @opaque and @inlineOnce
* Allow inlining (once) a recursive function in itself (useful in combination with `@opaque` when verifying a recursive function)
* Change test suite to adapt to the new semantics of inlining
* Hide bodies of `@opaque` functions when inlining (because their bodies get replaced by `choose` in `ChooseInjector`, after the `FunctionInlining` phase)