### PR TITLE
Revert let equality to implication

### DIFF
--- a/core/src/main/scala/stainless/verification/TypeChecker.scala
+++ b/core/src/main/scala/stainless/verification/TypeChecker.scala
@@ -965,7 +965,7 @@ trait TypeChecker {
     l.foldRight(e) { case (v, acc) =>
       v.tpe match {
         case LetEquality(e1: Variable, e2) =>
-          let(e1.toVal, e2, acc)
+          implies(Equals(e1, e2), acc)
         case Truth(t) =>
           implies(t, acc)
         case RefinementType(vd, pred) =>

--- a/frontends/scalac/src/it/scala/stainless/verification/TypeCheckerSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/TypeCheckerSuite.scala
@@ -27,11 +27,18 @@ trait TypeCheckerSuite extends ComponentTestSuite {
     case "verification/invalid/SpecWithExtern"        => Ignore
     case "verification/invalid/BinarySearchTreeQuant" => Ignore
     case "verification/invalid/ForallAssoc"           => Ignore
+
+    // unknown/timeout VC but counter-example not found
     case "verification/invalid/BadConcRope"           => Ignore
 
     // Unstable
     case "verification/invalid/BigIntMonoidLaws" => Ignore
     case "verification/invalid/BigIntRing" => Ignore
+
+    // Lemmas used in one equation can leak in other equations due to https://github.com/epfl-lara/inox/issues/139
+    case "verification/invalid/Equations1" => Ignore
+    case "verification/invalid/Equations2" => Ignore
+    case "verification/invalid/Equations3" => Ignore
 
     // Not compatible with typechecker
     case "verification/valid/Countable2" => Ignore


### PR DESCRIPTION
cc: @romac 

Copied from channel discussion:

> I found an issue in the type-checker with the `letWitness` thing, where we bind `let x: T = e in body` as  `x: T  ; letWitness :  { letWitness : Unit | x = e }` in the type-checking context.
When `T` is a refinement type `{ x: _ | P(x) }`, the VC we generate looks like `P(x) ==> let x = e in cond` which is not good because the `let` comes after the usage of `x`.
If we change the order in the context to `letWitness :  { letWitness : Unit | x = e } ; x: T`, that's not good either because that makes the type-checking context not well-formed (it refers to `x` before `x` is bound).

> I was wondering whether we could come back to `P(x) ==> (x == e) ==> cond` in the VC generation, which was changed here: https://github.com/epfl-lara/stainless/commit/44a118e63111918822d3b8f8b8f4f81471132c8a
The VC in the commit message `(a == 1 && b == 2) ==> (a == b)` should still be considered as invalid because it's not true for all values of `a` and `b`