### PR TITLE
Change order of type-checker rules to generate one VC per branch

### DIFF
--- a/core/src/main/scala/stainless/verification/TypeChecker.scala
+++ b/core/src/main/scala/stainless/verification/TypeChecker.scala
@@ -1072,13 +1072,6 @@ trait TypeChecker {
       case (ADT(id, tps, args), Top()) => checkTypes(tc, args, Top())
       case (_, Top()) => inferType(tc, e)._2 // We ignore the inferred type but keep the VCs
 
-      case (e, TrueBoolean()) =>
-        checkType(tc.withVCKind(VCKind.CheckType), e, BooleanType()) ++ buildVC(tc, e)
-
-      case (e, RefinementType(vd, prop)) =>
-        val (tc2, freshener) = tc.freshBindWithValues(Seq(vd), Seq(e))
-        checkType(tc.withVCKind(VCKind.CheckType), e, vd.tpe) ++ checkType(tc2, freshener.transform(prop), TrueBoolean())
-
       case (Tuple(es), TupleType(tps)) =>
         checkTypes(tc, es, tps)
 
@@ -1116,6 +1109,13 @@ trait TypeChecker {
         checkType(tc.setPos(b).withVCKind(VCKind.CheckType), b, BooleanType()) ++
         checkType(tc.withTruth(b).setPos(e1), e1, tpe) ++
         checkType(tc.withTruth(Not(b)).setPos(e2), e2, tpe)
+
+      case (e, TrueBoolean()) =>
+        checkType(tc.withVCKind(VCKind.CheckType), e, BooleanType()) ++ buildVC(tc, e)
+
+      case (e, RefinementType(vd, prop)) =>
+        val (tc2, freshener) = tc.freshBindWithValues(Seq(vd), Seq(e))
+        checkType(tc.withVCKind(VCKind.CheckType), e, vd.tpe) ++ checkType(tc2, freshener.transform(prop), TrueBoolean())
 
       case (UncheckedExpr(e), tpe) =>
         val (inferredType, tr) = inferType(tc.withEmitVCs(false), e)

--- a/frontends/scalac/src/it/scala/stainless/verification/TypeCheckerSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/TypeCheckerSuite.scala
@@ -31,14 +31,14 @@ trait TypeCheckerSuite extends ComponentTestSuite {
     // unknown/timeout VC but counter-example not found
     case "verification/invalid/BadConcRope"           => Ignore
 
-    // Unstable
-    case "verification/invalid/BigIntMonoidLaws" => Ignore
-    case "verification/invalid/BigIntRing" => Ignore
-
     // Lemmas used in one equation can leak in other equations due to https://github.com/epfl-lara/inox/issues/139
     case "verification/invalid/Equations1" => Ignore
     case "verification/invalid/Equations2" => Ignore
     case "verification/invalid/Equations3" => Ignore
+
+    // Unstable
+    case "verification/valid/BigIntMonoidLaws" => Ignore
+    case "verification/valid/BigIntRing" => Ignore
 
     // Not compatible with typechecker
     case "verification/valid/Countable2" => Ignore

--- a/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -31,8 +31,8 @@ trait VerificationSuite extends ComponentTestSuite {
     case "verification/invalid/ForallAssoc" => Ignore
 
     // Unstable
-    case "verification/invalid/BigIntMonoidLaws" => Ignore
-    case "verification/invalid/BigIntRing" => Ignore
+    case "verification/valid/BigIntMonoidLaws" => Ignore
+    case "verification/valid/BigIntRing" => Ignore
 
     // Z3 4.8.10 and CVC4 1.8 time out but can't find a counter-example
     case "verification/invalid/BadConcRope" => Ignore


### PR DESCRIPTION
I don't remember if there was a particular reason the refinement type checks were that high?