### PR TITLE
Catch and fail on mutation of immutable fields

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/Definitions.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Definitions.scala
@@ -7,10 +7,23 @@ package imperative
 trait Definitions extends oo.Trees { self: Trees =>
   override type Symbols >: Null <: AbstractSymbols
 
-  trait AbstractSymbols
-    extends super.AbstractSymbols
-      with SymbolOps
-      with TypeOps { self0: Symbols =>
+  trait AbstractSymbols extends super.AbstractSymbols with SymbolOps with TypeOps {
+    self0: Symbols =>
+
+    override protected def ensureWellFormedFunction(fd: FunDef): Unit = {
+      exprOps.preTraversal {
+        case fa @ self.FieldAssignment(obj, field, _) =>
+          // if the field that is assigned is not '@var', throw
+          if (fa.getField(self0).exists(fieldVd => !fieldVd.flags.contains(IsVar))) {
+            throw NotWellFormedException(
+              fd,
+              Some(s"cannot assign to immutable field '${field.name}' of class '${obj.getType}'")
+            )
+          }
+        case _ => ()
+      }(fd.fullBody)
+
+      super.ensureWellFormedFunction(fd)
+    }
   }
 }
-

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -59,9 +59,7 @@ trait Trees extends oo.Trees with Definitions { self =>
 
     protected def computeType(implicit s: Symbols): Type = {
       getField
-        // check that the assigned field really _is_ mutable
-        .filter(fieldVd => fieldVd.flags.contains(IsVar))
-        .filter(fieldVd => s.isSubtypeOf(value.getType, fieldVd.tpe))
+        .filter(vd => s.isSubtypeOf(value.getType, vd.tpe))
         .map(_ => UnitType())
         .getOrElse(Untyped)
     }

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -44,9 +44,7 @@ trait Trees extends oo.Trees with Definitions { self =>
   /** $encodingof `vd = value` */
   case class Assignment(v: Variable, value: Expr) extends Expr with CachingTyped {
     protected def computeType(implicit s: Symbols): Type =
-      // check that variable really _is_ mutable
-      if (v.flags.contains(IsVar)) checkParamType(value, v.tpe, UnitType())
-      else Untyped
+      checkParamType(value, v.tpe, UnitType())
   }
 
   /** $encodingof `obj.selector = value` */

--- a/frontends/common/src/test/scala/stainless/NonVarMutabilitySuite.scala
+++ b/frontends/common/src/test/scala/stainless/NonVarMutabilitySuite.scala
@@ -2,14 +2,13 @@ package stainless
 
 import org.scalatest.funspec.AnyFunSpec
 import org.scalatest.matchers.should.Matchers._
-
 import extraction.xlang.{trees => xt}
 
 class NonVarMutabilitySuite extends AnyFunSpec with InputUtils {
 
   implicit val ctx = stainless.TestContext.empty
 
-  describe("Mutation of non-var annotated field") {
+  describe("Mutation of a field that is not 'var' annotated") {
     val classId   = ast.SymbolIdentifier("ImmutableClass")
     val fieldId   = ast.SymbolIdentifier("field")
     val classType = xt.ClassType(classId, Seq())
@@ -44,10 +43,8 @@ class NonVarMutabilitySuite extends AnyFunSpec with InputUtils {
     )
     val symbols = xt.NoSymbols.withClasses(classes).withFunctions(functions)
 
-    it("should fails") {
-      the[Exception] thrownBy (
-        extraction.pipeline.extract(symbols)
-      ) should have message "Illegal aliasing: var0"
+    it("should fail with a type error") {
+      a[symbols.TypeErrorException] should be thrownBy symbols.ensureWellFormed
     }
   }
 }

--- a/frontends/common/src/test/scala/stainless/NonVarMutabilitySuite.scala
+++ b/frontends/common/src/test/scala/stainless/NonVarMutabilitySuite.scala
@@ -43,8 +43,11 @@ class NonVarMutabilitySuite extends AnyFunSpec with InputUtils {
     )
     val symbols = xt.NoSymbols.withClasses(classes).withFunctions(functions)
 
-    it("should fail with a type error") {
-      a[symbols.TypeErrorException] should be thrownBy symbols.ensureWellFormed
+    it("should fail with not well formed exception") {
+      val exception = the[xt.NotWellFormedException] thrownBy symbols.ensureWellFormed
+      exception.getMessage should include(
+        "cannot assign to immutable field 'field' of class 'ImmutableClass'"
+      )
     }
   }
 }

--- a/frontends/common/src/test/scala/stainless/NonVarMutabilitySuite.scala
+++ b/frontends/common/src/test/scala/stainless/NonVarMutabilitySuite.scala
@@ -1,0 +1,53 @@
+package stainless
+
+import org.scalatest.funspec.AnyFunSpec
+import org.scalatest.matchers.should.Matchers._
+
+import extraction.xlang.{trees => xt}
+
+class NonVarMutabilitySuite extends AnyFunSpec with InputUtils {
+
+  implicit val ctx = stainless.TestContext.empty
+
+  describe("Mutation of non-var annotated field") {
+    val classId   = ast.SymbolIdentifier("ImmutableClass")
+    val fieldId   = ast.SymbolIdentifier("field")
+    val classType = xt.ClassType(classId, Seq())
+    val param     = xt.ValDef(ast.SymbolIdentifier("var0"), classType, Seq())
+    val varAlias  = xt.ValDef(ast.SymbolIdentifier("a"), classType, Seq(xt.IsVar))
+
+    val classes = Seq(
+      new xt.ClassDef(
+        classId,
+        Seq(),
+        Seq(),
+        Seq(xt.ValDef(fieldId, xt.BooleanType())),
+        Seq(xt.IsSealed)
+      )
+    )
+    val functions = Seq(
+      new xt.FunDef(
+        ast.SymbolIdentifier("setFalse"),
+        Seq(),
+        Seq(param),
+        classType,
+        xt.LetVar(
+          varAlias,
+          param.toVariable,
+          xt.Block(
+            Seq(xt.FieldAssignment(varAlias.toVariable, fieldId, xt.BooleanLiteral(false))),
+            varAlias.toVariable
+          )
+        ),
+        Seq()
+      )
+    )
+    val symbols = xt.NoSymbols.withClasses(classes).withFunctions(functions)
+
+    it("should fails") {
+      the[Exception] thrownBy (
+        extraction.pipeline.extract(symbols)
+      ) should have message "Illegal aliasing: var0"
+    }
+  }
+}


### PR DESCRIPTION
Closes #1014.

The original solution suggested by @samarion (thanks!) was that `getType` of `FieldAssignment` returns `Untyped` if the field is not annotated as `@var`. 

That approach was dropped in favour of an actual `ensureWellFormedFunction` check, as suggested by @romac. 
