### PR TITLE
Print verification progress but not verification conditions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -233,7 +233,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 // lazy val inox = RootProject(file("../inox"))
-lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "c37411dc0c693142f9bff1a68e617d4bfb5be277")
+lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "22de8d6b6af51fbe09bca2fc26dbdd596de8e3e8")
 //lazy val dotty = ghProject("git://github.com/lampepfl/dotty.git", "b3194406d8e1a28690faee12257b53f9dcf49506")
 
 // Allow integration test to use facilities from regular tests

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -176,6 +176,8 @@ trait MainHelpers extends inox.MainHelpers { self =>
       // For each cycle, passively wait until the compiler has finished
       // & print summary of reports for each component
       def baseRunCycle(): Unit = timers.cycle.run {
+        // reset the global VC counters for displaying progress
+        verification.VerificationChecker.reset()
         compiler.run()
         compiler.join()
 

--- a/core/src/main/scala/stainless/Reporter.scala
+++ b/core/src/main/scala/stainless/Reporter.scala
@@ -11,15 +11,41 @@ abstract class ReportMessage {
 }
 
 class DefaultReporter(debugSections: Set[DebugSection]) extends inox.DefaultReporter(debugSections) {
-  override def emit(msg: Message): Unit = msg.msg match {
-    case rm: ReportMessage if rm.sbtPluginOnly => ()
-    case _ => super.emit(msg)
+  var printingProgress = false
+
+  override def emit(msg: Message): Unit = synchronized {
+    if (printingProgress) {
+      println()
+      printingProgress = false
+    }
+    msg.msg match {
+      case rm: ReportMessage if rm.sbtPluginOnly => ()
+      case _ => super.emit(msg)
+    }
+  }
+
+  override def onCompilerProgress(current: Int, total: Int): Unit = synchronized {
+    printingProgress = true
+    print("\r" + severityToPrefix(INFO) + s" Verified: $current / $total")
   }
 }
 
 class PlainTextReporter(debugSections: Set[DebugSection]) extends inox.PlainTextReporter(debugSections) {
-  override def emit(msg: Message): Unit = msg.msg match {
-    case rm: ReportMessage if rm.sbtPluginOnly => ()
-    case _ => super.emit(msg)
+  var printingProgress = false
+
+  override def emit(msg: Message): Unit = synchronized {
+    if (printingProgress) {
+      println()
+      printingProgress = false
+    }
+    msg.msg match {
+      case rm: ReportMessage if rm.sbtPluginOnly => ()
+      case _ => super.emit(msg)
+    }
+  }
+
+  override def onCompilerProgress(current: Int, total: Int): Unit = synchronized {
+    printingProgress = true
+    print(s"\rVerified: $current / $total")
   }
 }

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -96,9 +96,9 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
   /** An extension to the set of registered classes in the `StainlessSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 180 to 258.
+    * The new identifiers in the mapping range from 180 to 259.
     *
-    * NEXT ID: 259
+    * NEXT ID: 260
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -141,6 +141,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       classSerializer[MutableMapUpdate]       (251),
       classSerializer[MutableMapUpdated]      (252),
       classSerializer[MutableMapDuplicate]    (253),
+      classSerializer[Swap]                   (259),
 
       // Object-oriented trees
       classSerializer[ClassConstructor] (200),

--- a/core/src/main/scala/stainless/verification/VerificationCache.scala
+++ b/core/src/main/scala/stainless/verification/VerificationCache.scala
@@ -40,7 +40,7 @@ trait VerificationCache extends VerificationChecker { self =>
   private lazy val vccache = CacheLoader.get(context)
 
   override def checkVC(vc: VC, origVC: VC, sf: SolverFactory { val program: self.program.type }) = {
-    reporter.info(s" - Checking cache: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")
+    reporter.debug(s" - Checking cache: '${vc.kind}' VC for ${vc.fd} @${vc.getPos}...")(DebugSectionVerification)
 
     // NOTE This algorithm is not 100% perfect: it is possible that two equivalent VCs in
     //      the same program are both computed concurrently (contains return false twice),
@@ -56,9 +56,9 @@ trait VerificationCache extends VerificationChecker { self =>
       val key = serializer.serialize((vc.satisfiability, canonicalSymbols, canonicalExpr))
 
       if (vccache contains key) {
+        reporter.debug(s"Cache hit: '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}...")(DebugSectionVerification)
         implicit val debugSection = DebugSectionCacheHit
         reporter.synchronized {
-          reporter.info(s"Cache hit: '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}...")
           reporter.debug("The following VC has already been verified:")
           debugVC(vc, origVC)
           reporter.debug("--------------")
@@ -66,7 +66,7 @@ trait VerificationCache extends VerificationChecker { self =>
         VCResult(VCStatus.ValidFromCache, None, None)
       } else {
         reporter.synchronized {
-          reporter.info(s"Cache miss: '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}...")
+          reporter.debug(s"Cache miss: '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}...")
           reporter.ifDebug { debug =>
             implicit val debugSection = DebugSectionCacheMiss
             implicit val printerOpts = new PrinterOptions(printUniqueIds = true, printTypes = true, symbols = Some(canonicalSymbols))

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -76,8 +76,6 @@ trait VerificationChecker { self =>
 
   def verify(vcs: Seq[VC], stopWhen: VCResult => Boolean = defaultStop): Future[Map[VC, VCResult]] = {
     try {
-      if (!vcs.isEmpty)
-        reporter.debug("Checking Verification Conditions...")
       checkVCs(vcs, stopWhen)
     } finally {
       factoryCache.values.foreach(_.shutdown())
@@ -88,7 +86,13 @@ trait VerificationChecker { self =>
   private lazy val unknownResult: VCResult = VCResult(VCStatus.Unknown, None, None)
 
   def checkVCs(vcs: Seq[VC], stopWhen: VCResult => Boolean = defaultStop): Future[Map[VC, VCResult]] = {
+    if (!VerificationChecker.startedVerification) reporter.info("Starting verification...")
+    VerificationChecker.startedVerification = true
+
     @volatile var stop = false
+
+    VerificationChecker.total += vcs.length
+    reporter.onCompilerProgress(VerificationChecker.verified, VerificationChecker.total)
 
     val initMap: Map[VC, VCResult] = vcs.map(vc => vc -> unknownResult).toMap
 
@@ -107,6 +111,8 @@ trait VerificationChecker { self =>
           val res = checkVC(simplifiedVC, vc, sf)
 
           val shouldStop = stopWhen(res)
+          if (res.isValid) VerificationChecker.verified += 1
+          reporter.onCompilerProgress(VerificationChecker.verified, VerificationChecker.total)
 
           interruptManager.synchronized { // Make sure that we only interrupt the manager once.
             if (shouldStop && !stop && !interruptManager.isInterrupted) {
@@ -219,7 +225,7 @@ trait VerificationChecker { self =>
       val cond = vc.condition
 
       reporter.synchronized {
-        reporter.info(s" - Now solving '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}...")
+        reporter.debug(s" - Now solving '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}...")
         debugVC(vc, origVC)
         reporter.debug("Solving with: " + s.name)
       }
@@ -278,16 +284,19 @@ trait VerificationChecker { self =>
       }
 
       val vcResultMsg = VCResultMessage(vc, vcres)
-      reporter.info(vcResultMsg)
+      reporter.debug(vcResultMsg)
 
       reporter.synchronized {
-        reporter.info(s" - Result for '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}:")
+        val descr = s" - Result for '${vc.kind}' VC for ${vc.fd.asString} @${vc.getPos}:"
 
         vcres.status match {
           case VCStatus.Valid =>
-            reporter.info(" => VALID")
+            reporter.debug(descr)
+            reporter.debug(" => VALID")
 
           case VCStatus.Invalid(reason) =>
+            reporter.warning(descr)
+            reporter.warning(prettify(vc.condition).asString)
             reporter.warning(vc.getPos, " => INVALID")
             reason match {
               case VCStatus.CounterExample(cex) =>
@@ -299,6 +308,8 @@ trait VerificationChecker { self =>
             }
 
           case status =>
+            reporter.warning(descr)
+            reporter.warning(prettify(vc.condition).asString)
             reporter.warning(vc.getPos, " => " + status.name.toUpperCase)
         }
       }
@@ -331,6 +342,22 @@ trait VerificationChecker { self =>
 }
 
 object VerificationChecker {
+  // number of verified VCs (incremented when a VC is verified)
+  var verified: Int = 0
+  // total number of VCs (we add to that counter when entering `checkVCs`)
+  // this is cumulative across different subprograms (for `SplitCallBack`)
+  var total: Int = 0
+
+  // flag to remember whether we have shown "Starting verification" message to the user
+  var startedVerification = false
+
+  // reset the counters before each watch cycle
+  def reset(): Unit = {
+    verified = 0
+    total = 0
+    startedVerification = false
+  }
+
   def verify(p: StainlessProgram, ctx: inox.Context)
             (vcs: Seq[VC[p.trees.type]]): Future[Map[VC[p.trees.type], VCResult[p.Model]]] = {
     class Checker extends VerificationChecker {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -109,8 +109,10 @@ class VerificationRun(override val pipeline: StainlessPipeline)
         debugChooses.debugEncoder(chooseEncoder)
       }
 
-      if (!functions.isEmpty)
-        reporter.debug(s"Generating VCs for those functions: ${functions map { _.uniqueName } mkString ", "}")
+      if (!functions.isEmpty) {
+        reporter.info(s"Generating VCs...")
+        reporter.debug(s"For functions: ${functions map { _.uniqueName } mkString ", "}")
+      }
 
       val vcs = if (context.options.findOptionOrDefault(optTypeChecker))
         context.timers.verification.get("type-checker").run {
@@ -118,6 +120,10 @@ class VerificationRun(override val pipeline: StainlessPipeline)
         }
       else
         VerificationGenerator.gen(assertionEncoder.targetProgram, context)(functions)
+
+      if (!functions.isEmpty) {
+        reporter.info(s"Finished VCs generation")
+      }
 
       val fullEncoder = assertionEncoder andThen chooseEncoder
 

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
@@ -121,12 +121,6 @@ class ScalaCompiler(settings: NSCSettings, ctx: inox.Context, callback: CallBack
     )
     phs foreach { phasesSet += _._1 }
   }
-
-  class Run extends super.Run {
-    override def progress(current: Int, total: Int) {
-      ctx.reporter.onCompilerProgress(current, total)
-    }
-  }
 }
 
 object ScalaCompiler {


### PR DESCRIPTION
Opened this after closing https://github.com/epfl-lara/inox/pull/143

This PR displays a counter `Verified: 60 / 87` that gets updated on the same line.
What do people think? It's not very pretty with the global variables, but it seems to work :)
In  `SplitCallBack`, the denominator will increase with each new subprogram.
When starting a new watch cycle, we reset the counters.