### PR TITLE
No cast correctness check when there is only one constructor

### DIFF
--- a/core/src/main/scala/stainless/verification/AssertionInjector.scala
+++ b/core/src/main/scala/stainless/verification/AssertionInjector.scala
@@ -78,11 +78,14 @@ trait AssertionInjector extends transformers.TreeTransformer {
 
     case sel @ s.ADTSelector(expr, selector) =>
       val newExpr = transform(expr)
-      t.Assert(
-        t.IsConstructor(newExpr, sel.constructor.id).copiedFrom(e),
-        Some("Cast error"),
-        t.ADTSelector(newExpr, selector)
-      ).copiedFrom(e)
+      if (sel.constructor.sort.constructors.size == 1) t.ADTSelector(newExpr, selector).copiedFrom(e)
+      else {
+        t.Assert(
+          t.IsConstructor(newExpr, sel.constructor.id).copiedFrom(e),
+          Some("Cast error"),
+          t.ADTSelector(newExpr, selector)
+        ).copiedFrom(e)
+      }
 
     case BVTyped(true, size, e0 @ s.Plus(lhs0, rhs0)) if checkOverflow =>
       bindIfCannotDuplicate(lhs0, "lhs") { lhsx =>


### PR DESCRIPTION
Fix https://github.com/epfl-lara/stainless/issues/994