### PR TITLE
Fix all case object flags in NoxtFrontend

### DIFF
--- a/frontends/stainless-noxt/src/main/scala/stainless/frontends/noxt/NoxtFrontend.scala
+++ b/frontends/stainless-noxt/src/main/scala/stainless/frontends/noxt/NoxtFrontend.scala
@@ -69,40 +69,43 @@ object NoxtFrontend {
       case _ => super.transform(pat)
     }
 
+
+    val flagsByName = Seq(
+      xt.IsAbstract,
+      xt.IsCaseObject,
+      xt.Erasable,
+      xt.Extern,
+      xt.Final,
+      xt.Ghost,
+      xt.Ignore,
+      xt.Inline,
+      xt.InlineInvariant,
+      xt.InlineOnce,
+      xt.IsInvariant,
+      xt.Law,
+      xt.Lazy,
+      xt.Library,
+      xt.IsMutable,
+      xt.Opaque,
+      xt.PartialEval,
+      xt.Private,
+      xt.IsPure,
+      xt.IsSealed,
+      xt.StrictBV,
+      xt.Synthetic,
+      xt.Template,
+      xt.TraceInduct,
+      xt.Unchecked,
+      xt.ValueClass,
+      xt.IsVar,
+      xt.Wrapping
+    ).map(f => (f.name, f)).toMap
+
     // FIXME: Deserialization doesn't map flags that are implemented as objects to their singleton
     //   instance, but instead creates a new instance, which is matched by nothing.
     //   This is a temporary workaround.
     override def transform(flag: xt.Flag): xt.Flag =
-      Seq(
-        xt.IsAbstract,
-        xt.IsCaseObject,
-        xt.Erasable,
-        xt.Extern,
-        xt.Final,
-        xt.Ghost,
-        xt.Ignore,
-        xt.Inline,
-        xt.InlineInvariant,
-        xt.InlineOnce,
-        xt.IsInvariant,
-        xt.Law,
-        xt.Lazy,
-        xt.Library,
-        xt.IsMutable,
-        xt.Opaque,
-        xt.PartialEval,
-        xt.Private,
-        xt.IsPure,
-        xt.IsSealed,
-        xt.StrictBV,
-        xt.Synthetic,
-        xt.Template,
-        xt.TraceInduct,
-        xt.Unchecked,
-        xt.ValueClass,
-        xt.IsVar,
-        xt.Wrapping
-      ).map(f => (f.name, f)).toMap.getOrElse(flag.name, super.transform(flag))
+      flagsByName.getOrElse(flag.name, super.transform(flag))
 
     override def transform(oldFd: xt.FunDef): xt.FunDef = {
       val fd = super.transform(oldFd)

--- a/frontends/stainless-noxt/src/main/scala/stainless/frontends/noxt/NoxtFrontend.scala
+++ b/frontends/stainless-noxt/src/main/scala/stainless/frontends/noxt/NoxtFrontend.scala
@@ -72,27 +72,37 @@ object NoxtFrontend {
     // FIXME: Deserialization doesn't map flags that are implemented as objects to their singleton
     //   instance, but instead creates a new instance, which is matched by nothing.
     //   This is a temporary workaround.
-    override def transform(flag: xt.Flag): xt.Flag = flag.name match {
-      case "pure" => xt.IsPure
-      case "mutable" => xt.IsMutable
-      case "var" => xt.IsVar
-      case "law" => xt.Law
-      case "erasable" => xt.Erasable
-      case "inlineInvariant" => xt.InlineInvariant
-      case "ghost" => xt.Ghost
-      case "extern" => xt.Extern
-      case "opaque" => xt.Opaque
-      case "private" => xt.Private
-      case "final" => xt.Final
-      case "unchecked" => xt.Unchecked
-      case "library" => xt.Library
-      case "synthetic" => xt.Synthetic
-      case "partialEval" => xt.PartialEval
-      case "wrapping" => xt.Wrapping
-      case "abstract" => xt.IsAbstract
-      case "caseObject" => xt.IsCaseObject
-      case _ => super.transform(flag)
-    }
+    override def transform(flag: xt.Flag): xt.Flag =
+      Seq(
+        xt.IsAbstract,
+        xt.IsCaseObject,
+        xt.Erasable,
+        xt.Extern,
+        xt.Final,
+        xt.Ghost,
+        xt.Ignore,
+        xt.Inline,
+        xt.InlineInvariant,
+        xt.InlineOnce,
+        xt.IsInvariant,
+        xt.Law,
+        xt.Lazy,
+        xt.Library,
+        xt.IsMutable,
+        xt.Opaque,
+        xt.PartialEval,
+        xt.Private,
+        xt.IsPure,
+        xt.IsSealed,
+        xt.StrictBV,
+        xt.Synthetic,
+        xt.Template,
+        xt.TraceInduct,
+        xt.Unchecked,
+        xt.ValueClass,
+        xt.IsVar,
+        xt.Wrapping
+      ).map(f => (f.name, f)).toMap.getOrElse(flag.name, super.transform(flag))
 
     override def transform(oldFd: xt.FunDef): xt.FunDef = {
       val fd = super.transform(oldFd)


### PR DESCRIPTION
This is a small _maintenance_ PR that finally adds _all_ the flags the Rust frontend could possibly emit to the `FIXME` pattern match in `NoxtFrontend`.

