### PR TITLE
Add fresh copy primitive

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -392,7 +392,8 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       } yield target
 
     case fi: FunctionInvocation if !symbols.isRecursive(fi.id) =>
-      BodyWithSpecs(symbols.simplifyLets(fi.inlined))
+      if (fi.tfd.flags.contains(IsPure)) Set.empty
+      else BodyWithSpecs(symbols.simplifyLets(fi.inlined))
         .bodyOpt
         .map(getTargets(_, path))
         .getOrElse(Set.empty)

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -405,6 +405,7 @@ trait EffectsAnalyzer extends oo.CachingPhase {
     case AsInstanceOf(e, _) => getTargets(e, path)
     case Old(_) => Set.empty
     case Snapshot(_) => Set.empty
+    case FreshCopy(_) => Set.empty
 
     case ArrayLength(_) => Set.empty
 

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -289,8 +289,9 @@ trait EffectsChecker { self: EffectsAnalyzer =>
         case MutableMapDuplicate(IsTyped(_, MutableMapType(from, to))) =>
           !isMutableType(from) && !isMutableType(to)
 
-        // snapshots are fresh
-        case Snapshot(e) => true
+        // snapshots & freshCopies are fresh
+        case Snapshot(_) => true
+        case FreshCopy(_) => true
 
         // For `Let`, it is safe to add `vd` as a fresh binding because we disallow
         // `FieldAssignments` with non-fresh expressions in `check(fd: FunAbstraction)` above.

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -289,7 +289,7 @@ trait EffectsChecker { self: EffectsAnalyzer =>
         case MutableMapDuplicate(IsTyped(_, MutableMapType(from, to))) =>
           !isMutableType(from) && !isMutableType(to)
 
-        // snapshots & freshCopies are fresh
+        // snapshots & fresh copies are fresh
         case Snapshot(_) => true
         case FreshCopy(_) => true
 

--- a/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
@@ -45,6 +45,7 @@ trait GhostChecker { self: EffectsAnalyzer =>
       case Decreases(_, body) => isGhostExpression(body)
 
       case Snapshot(e) => true
+      case FreshCopy(_) => false
 
       case FunInvocation(id, _, args, _) =>
         val fun = lookupFunction(id).map(Outer(_)).getOrElse(analysis.local(id))

--- a/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
@@ -44,8 +44,8 @@ trait GhostChecker { self: EffectsAnalyzer =>
       // Measures are also considered ghost, as they are never executed
       case Decreases(_, body) => isGhostExpression(body)
 
-      case Snapshot(e) => true
-      case FreshCopy(_) => false
+      case Snapshot(_) => true
+      case FreshCopy(e) => isGhostExpression(e)
 
       case FunInvocation(id, _, args, _) =>
         val fun = lookupFunction(id).map(Outer(_)).getOrElse(analysis.local(id))

--- a/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ImperativeCodeElimination.scala
@@ -63,6 +63,7 @@ trait ImperativeCodeElimination
           (UnitLiteral(), scope, rhsFun + (v -> newVd.toVariable))
 
         case Snapshot(e) => toFunction(e)
+        case FreshCopy(e) => toFunction(e)
 
         case ite @ IfExpr(cond, tExpr, eExpr) =>
           val (cRes, cScope, cFun) = toFunction(cond)
@@ -373,6 +374,7 @@ trait ImperativeCodeElimination
       case (e: LetVar) => true
       case (e: Old) => true
       case (e: Snapshot) => true
+      case (e: FreshCopy) => true
       case _ => false
     }
 

--- a/core/src/main/scala/stainless/extraction/imperative/ReturnElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ReturnElimination.scala
@@ -411,7 +411,7 @@ trait ReturnElimination
           }
           processBlockExpressions(es :+ last)
 
-        case (_: s.Lambda | _: s.Forall | _: s.Old | _: s.Snapshot | _: s.Choose) =>
+        case (_: s.Lambda | _: s.Forall | _: s.Old | _: s.Snapshot | _: s.FreshCopy | _: s.Choose) =>
           SimpleWhileTransformer.transform(expr)
 
         case _ if exprHasReturn(expr) =>

--- a/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
@@ -70,6 +70,9 @@ trait TransformerWithType extends oo.TransformerWithType {
     case s.Snapshot(e) =>
       t.Snapshot(transform(e, tpe)).copiedFrom(expr)
 
+    case s.FreshCopy(e) =>
+      t.FreshCopy(transform(e, tpe)).copiedFrom(expr)
+
     case s.BoolBitwiseAnd(lhs, rhs) =>
       t.BoolBitwiseAnd(transform(lhs, s.BooleanType()), transform(rhs, s.BooleanType())).copiedFrom(expr)
 

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -134,6 +134,11 @@ trait Trees extends oo.Trees with Definitions { self =>
     protected def computeType(implicit s: Symbols): Type = e.getType
   }
 
+  /** copy primitive, like `Snapshot` but usable outside of the ghost context. Mostly to work-around anti-aliasing. */
+  case class FreshCopy(e: Expr) extends Expr with CachingTyped {
+    protected def computeType(implicit s: Symbols): Type = e.getType
+  }
+
   /** $encodingof `a & b` for Boolean; desuggared to { val l = lhs; val r = rhs; l && r } when removing imperative style. */
   case class BoolBitwiseAnd(lhs: Expr, rhs: Expr) extends Expr with CachingTyped {
     protected def computeType(implicit s: Symbols): Type =
@@ -265,6 +270,9 @@ trait Printer extends oo.Printer {
     case Snapshot(e) =>
       p"snapshot($e)"
 
+    case FreshCopy(e) =>
+      p"freshCopy($e)"
+
     case BoolBitwiseAnd(lhs, rhs) => optP {
       p"$lhs & $rhs"
     }
@@ -364,6 +372,9 @@ trait TreeDeconstructor extends oo.TreeDeconstructor {
 
     case s.Snapshot(e) =>
       (Seq(), Seq(), Seq(e), Seq(), Seq(), (_, _, es, _, _) => t.Snapshot(es.head))
+
+    case s.FreshCopy(e) =>
+      (Seq(), Seq(), Seq(e), Seq(), Seq(), (_, _, es, _, _) => t.FreshCopy(es.head))
 
     case _ => super.deconstruct(e)
   }

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -96,7 +96,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
   /** An extension to the set of registered classes in the `StainlessSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 180 to 259.
+    * The new identifiers in the mapping range from 180 to 260.
     *
     * NEXT ID: 261
     */

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -98,7 +98,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
     *
     * The new identifiers in the mapping range from 180 to 259.
     *
-    * NEXT ID: 260
+    * NEXT ID: 261
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -142,6 +142,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       classSerializer[MutableMapUpdated]      (252),
       classSerializer[MutableMapDuplicate]    (253),
       classSerializer[Swap]                   (259),
+      classSerializer[FreshCopy]              (260),
 
       // Object-oriented trees
       classSerializer[ClassConstructor] (200),

--- a/frontends/benchmarks/imperative/invalid/FreshCopy.scala
+++ b/frontends/benchmarks/imperative/invalid/FreshCopy.scala
@@ -1,0 +1,14 @@
+import stainless.lang._
+
+case class HasVar(var x: Int)
+
+trait FreshCopy {
+  var h: HasVar
+
+  def f() = {
+    require(h.x == 123)
+    val freshH = h // call to freshCopy is missing
+    h.x = 456
+    assert(freshH.x == 123)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/FreshCopy.scala
+++ b/frontends/benchmarks/imperative/valid/FreshCopy.scala
@@ -1,16 +1,23 @@
 import stainless.lang._
-import stainless.lang.StaticChecks._
-import stainless.annotation._
 
-case class HasVar(var x: Int)
+case class Inner(var int: Int)
+case class Outer(var inner: Inner)
 
 trait FreshCopy {
-  var h: HasVar
+  val o: Outer = Outer(Inner(123))
 
   def f() = {
-    require(h.x == 123)
-    val freshH = freshCopy(h)
-    h.x = 456
-    assert(freshH.x == 123)
+    require(o.inner.int == 123)
+
+    val fresh = freshCopy(o)
+    o.inner.int  = 456
+    assert(fresh.inner.int == 123)
+    assert(o.inner.int == 456)
+
+    val fresh2 = freshCopy(o)
+    o.inner = Inner(789)
+    assert(fresh.inner.int == 123)
+    assert(fresh2.inner.int == 456)
+    assert(o.inner.int == 789)
   }
 }

--- a/frontends/benchmarks/imperative/valid/FreshCopy.scala
+++ b/frontends/benchmarks/imperative/valid/FreshCopy.scala
@@ -1,0 +1,16 @@
+import stainless.lang._
+import stainless.lang.StaticChecks._
+import stainless.annotation._
+
+case class HasVar(var x: Int)
+
+trait FreshCopy {
+  var h: HasVar
+
+  def f() = {
+    require(h.x == 123)
+    val freshH = freshCopy(h)
+    h.x = 456
+    assert(freshH.x == 123)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/FreshCopy2.scala
+++ b/frontends/benchmarks/imperative/valid/FreshCopy2.scala
@@ -1,0 +1,31 @@
+import stainless.lang._
+import stainless.annotation._
+
+case class Container[@mutable T](var t: T)
+
+trait FreshCopy2 {
+  def f() = {
+    var c = Container(Container(Container(123)))
+
+    val fresh = freshCopy(c)
+    c.t = Container(Container(456))
+    assert(fresh.t.t.t == 123)
+
+    var fresh2 = freshCopy(c.t.t)
+    c.t.t.t = 789
+    assert(fresh.t.t.t == 123)
+    assert(fresh2.t == 456)
+    assert(c.t.t.t == 789)
+
+    var fresh3 = freshCopy(fresh2)
+    fresh2.t = -111
+    assert(fresh.t.t.t == 123)
+    assert(fresh2.t == -111)
+    assert(fresh3.t == 456)
+
+    fresh3 = Container(-222)
+    assert(fresh.t.t.t == 123)
+    assert(fresh2.t == -111)
+    assert(fresh3.t == -222)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/FreshCopy3.scala
+++ b/frontends/benchmarks/imperative/valid/FreshCopy3.scala
@@ -1,0 +1,29 @@
+import stainless.lang._
+import stainless.annotation._
+
+sealed case class S(var field: Int)
+
+object FreshCopy2 {
+
+  @pure
+  def setField(arg: S): S = {
+    var v = freshCopy(arg)
+    v.field = 456
+    v
+  }
+
+  def main() = {
+    val s  = S(123)
+    val s2 = setField(s)
+    assert(s.field == 123)
+    assert(s2.field == 456)
+
+    s.field = 789
+    assert(s.field == 789)
+    assert(s2.field == 456)
+
+    s2.field = 1000
+    assert(s.field == 789)
+    assert(s2.field == 1000)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/FreshCopy3.scala
+++ b/frontends/benchmarks/imperative/valid/FreshCopy3.scala
@@ -3,7 +3,7 @@ import stainless.annotation._
 
 sealed case class S(var field: Int)
 
-object FreshCopy2 {
+object FreshCopy3 {
 
   @pure
   def setField(arg: S): S = {

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -86,6 +86,9 @@ package object lang {
   @ignore @ghost
   def snapshot[T](value: T): T = value
 
+  @ignore
+  def freshCopy[T](value: T): T = value
+
   @library
   @partialEval
   def partialEval[A](x: A): A = x

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -86,8 +86,9 @@ package object lang {
   @ignore @ghost
   def snapshot[T](value: T): T = value
 
+  /** @note for internal and testing use only */
   @ignore
-  def freshCopy[T](value: T): T = value
+  def freshCopy[T](value: T): T = (??? : T)
 
   @library
   @partialEval

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -826,7 +826,16 @@ trait ASTExtractors {
 
     object ExSnapshotExpression {
       def unapply(tree: Apply) : Option[Tree] = tree match {
-        case a @ Apply(TypeApply(ExSymbol("stainless", "lang", "snapshot"), List(tpe)), List(arg)) =>
+        case Apply(TypeApply(ExSymbol("stainless", "lang", "snapshot"), List(_)), List(arg)) =>
+          Some(arg)
+        case _ =>
+          None
+      }
+    }
+
+    object ExFreshCopyExpression {
+      def unapply(tree: Apply) : Option[Tree] = tree match {
+        case Apply(TypeApply(ExSymbol("stainless", "lang", "freshCopy"), List(_)), List(arg)) =>
           Some(arg)
         case _ =>
           None

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -1049,6 +1049,8 @@ trait CodeExtraction extends ASTExtractors {
 
     case ExSnapshotExpression(t) => xt.Snapshot(extractTree(t))
 
+    case ExFreshCopyExpression(t) => xt.FreshCopy(extractTree(t))
+
     case ExErrorExpression(str, tpt) =>
       xt.Error(extractType(tpt), str)
 


### PR DESCRIPTION
This PR adds a new primitive operation (as a tree) to Stainless. The new operation called `freshCopy` (naming ist still wip, your suggestion is welcome) is an exact duplicate of `snapshot` except that it can be used outside of the `@ghost` context.

There is no Scala code extraction for the primitive for now, because it is used via the Rust frontend. There, it solves a problem with AntiAliasing https://github.com/epfl-lara/rust-stainless/issues/154.

