### PR TITLE
Bump Inox version (checkAssumptions fix for Z3)

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -233,7 +233,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 // lazy val inox = RootProject(file("../inox"))
-lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "775294883f9037ed4e67651786c621d467a66255")
+lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "ec3b77f97da1acf46af21766fb0d845c7f2d9834")
 //lazy val dotty = ghProject("git://github.com/lampepfl/dotty.git", "b3194406d8e1a28690faee12257b53f9dcf49506")
 
 // Allow integration test to use facilities from regular tests


### PR DESCRIPTION
That should make the non-incremental Z3 solvers work better.