### PR TITLE
Make unapply patterns work again in some benchmark

### DIFF
--- a/core/src/main/scala/stainless/ast/Expressions.scala
+++ b/core/src/main/scala/stainless/ast/Expressions.scala
@@ -166,7 +166,7 @@ trait Expressions extends inox.ast.Expressions with Types { self: Trees =>
       .filter(_.params.size == 1)
       .getOrElse(throw extraction.MalformedStainlessCode(up, "Invalid unapply accessor"))
     val unapp = up.getFunction
-    val tpMap = s.instantiation(fd.params.head.tpe, unapp.returnType)
+    val tpMap = s.instantiation(fd.params.head.tpe.getType, unapp.returnType.getType)
       .getOrElse(throw extraction.MalformedStainlessCode(up, "Unapply pattern failed type instantiation"))
     fd.typed(fd.typeArgs map tpMap).applied(Seq(unapplied))
   }

--- a/core/src/main/scala/stainless/ast/TypeOps.scala
+++ b/core/src/main/scala/stainless/ast/TypeOps.scala
@@ -12,9 +12,9 @@ trait TypeOps extends inox.ast.TypeOps {
     lookupFunction(id)
       .filter(_.params.size == 1)
       .flatMap { fd =>
-        instantiation(fd.params.head.tpe, inType)
+        instantiation(fd.params.head.tpe.getType, inType.getType)
           .filter(tpMap => fd.typeArgs forall (tpMap contains _))
-          .map(typeOps.instantiateType(fd.returnType, _))
+          .map(typeOps.instantiateType(fd.returnType.getType, _))
       }
 
   def patternIsTyped(in: Type, pat: Pattern): Boolean = {

--- a/frontends/benchmarks/verification/valid/Count.scala
+++ b/frontends/benchmarks/verification/valid/Count.scala
@@ -8,7 +8,7 @@ object Count {
   def count1(p: BigInt => Boolean, l: List[BigInt]): BigInt = {
     l match {
       case Nil() => BigInt(0)
-      case Cons(h,t) => (if (p(l.head)) BigInt(1) else BigInt(0)) + count1(p, l.tail)
+      case h::t => (if (p(l.head)) BigInt(1) else BigInt(0)) + count1(p, l.tail)
     }
   }//ensuring(res => res == count2(p, l))
 


### PR DESCRIPTION
Seems to solve #1024 at least in Count.scala, need to check others benchmarks changed.