### PR TITLE
ArrayLength requires Int type during TypeEncoding

### DIFF
--- a/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
+++ b/core/src/main/scala/stainless/extraction/oo/TypeEncoding.scala
@@ -1142,6 +1142,7 @@ trait TypeEncoding
           case s.Tuple(es) => tplSizes += es.size; super.traverse(expr)
           case s.Lambda(params, _) => funSizes += params.size; super.traverse(expr)
           case s.BVLiteral(signed, _, size) => bvSizes += (signed -> size); super.traverse(expr)
+          case s.ArrayLength(_) => bvSizes += (true -> 32); super.traverse(expr)
           case _ => super.traverse(expr)
         }
       }


### PR DESCRIPTION
Fix https://github.com/epfl-lara/stainless/issues/1044 (thanks @samarion).
I cannot add the example from the issue because the mismatch in types is now caught before.