### PR TITLE
Simplest value API + inlined precondition numbering

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -233,7 +233,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 // lazy val inox = RootProject(file("../inox"))
-lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "ec3b77f97da1acf46af21766fb0d845c7f2d9834")
+lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "7e72d941e748df31b966bbb5726ade447673b199")
 //lazy val dotty = ghProject("git://github.com/lampepfl/dotty.git", "b3194406d8e1a28690faee12257b53f9dcf49506")
 
 // Allow integration test to use facilities from regular tests

--- a/core/src/main/scala/stainless/ast/Definitions.scala
+++ b/core/src/main/scala/stainless/ast/Definitions.scala
@@ -83,6 +83,12 @@ trait Definitions extends inox.ast.Definitions { self: Trees =>
     }
 
     val lookup = new Lookup
+
+    override protected def simplestValue(tpe: Type, seen: Set[Type], allowSolver: Boolean, inLambda: Boolean)
+                                        (implicit sem: symbols.Semantics, ctx: inox.Context): Expr = tpe match {
+      case ArrayType(base) => FiniteArray(Seq(), base)
+      case _ => super.simplestValue(tpe, seen, allowSolver, inLambda)
+    }
   }
 
   implicit class StainlessFunDef(fd: FunDef) {


### PR DESCRIPTION
@samarion Is `simplestValue` for arrays ok here? Or do we need to check the base type is non-empty?