### PR TITLE
Replace file-based verification cache with SwayDB

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -155,7 +155,7 @@ lazy val assemblySettings: Seq[Setting[_]] = {
 lazy val libFilesFile = "libfiles.txt" // file storing list of library file names
 
 lazy val regenFilesFile = false
-  
+
 lazy val libraryFiles: Seq[(String, File)] = {
   val libFiles = ((root.base / "frontends" / "library") ** "*.scala").get
   val dropCount = (libFiles.head.getPath indexOfSlice "library") + ("library".size + 1 /* for separator */)
@@ -203,7 +203,7 @@ lazy val commonFrontendSettings: Seq[Setting[_]] = Defaults.itSettings ++ Seq(
           |
           |  val extraClasspath = \"\"\"${removeSlashU(extraClasspath.value)}\"\"\"
           |  val extraCompilerArguments = List("-classpath", \"\"\"${removeSlashU(extraClasspath.value)}\"\"\")
-          | 
+          |
           |  val defaultPaths = List(${removeSlashU(libraryFiles.map(_._1).mkString("\"\"\"", "\"\"\",\n \"\"\"", "\"\"\""))})
           |  val libPaths = try {
           |    val source = scala.io.Source.fromFile(\"${libFilesFile}\")
@@ -243,7 +243,10 @@ lazy val `stainless-core` = (project in file("core"))
   .disablePlugins(AssemblyPlugin)
   .enablePlugins(BuildInfoPlugin)
   //.enablePlugins(SphinxPlugin)
-  .settings(name := "stainless-core")
+  .settings(
+    name := "stainless-core",
+    libraryDependencies += "io.swaydb" %% "swaydb" % "0.16.2",
+  )
   .settings(commonSettings, publishMavenSettings)
   //.settings(site.settings)
   .dependsOn(inox % "compile->compile;test->test")

--- a/core/src/main/scala/stainless/utils/Caches.scala
+++ b/core/src/main/scala/stainless/utils/Caches.scala
@@ -31,37 +31,22 @@ object Caches {
   }
 
   /**
-   * Get the cache file after creating the cache directory.
+   * Get the cache directory, and create it if necessary.
    *
-   * The cache file itself is not created. Return None when the switch if off.
+   * Return None when the switch if off.
    */
-  def getCacheFile(ctx: inox.Context, optCacheSwitch: inox.FlagOptionDef, filename: String): Option[File] = {
+  def getCacheDir(ctx: inox.Context, optCacheSwitch: inox.FlagOptionDef): Option[File] = {
     val cacheEnabled = ctx.options findOptionOrDefault optCacheSwitch
-    if (cacheEnabled) Some(getCacheFile(ctx, filename)) else None
+    if (cacheEnabled) Some(getCacheDir(ctx)) else None
   }
 
   /**
-   * Get the cache file after creating the cache directory and its subdirectory [[subdir]].
-   *
-   * The cache file itself is not created. Return None when the switch if off.
+   * Get the cache directory, creating it if necessary.
    */
-  def getCacheFile(ctx: inox.Context, optCacheSwitch: inox.FlagOptionDef, subdir: String, filename: String): Option[File] =
-    getCacheFile(ctx, optCacheSwitch, subdir) map { getSubFile(_, filename) }
-
-  /**
-   * Get the cache file after creating the cache directory.
-   *
-   * The cache file itself is not created.
-   */
-  def getCacheFile(ctx: inox.Context, filename: String): File = {
+  def getCacheDir(ctx: inox.Context): File = {
     val cacheDir = ctx.options.findOptionOrDefault(optCacheDir).getAbsoluteFile
-    getSubFile(cacheDir, filename)
-  }
-
-  private def getSubFile(dir: File, filename: String): File = {
-    dir.mkdirs()
-    assert(dir.isDirectory, s"Not a directory: ${dir.getAbsolutePath}")
-    new File(dir, filename)
+    cacheDir.mkdirs()
+    cacheDir
   }
 }
 


### PR DESCRIPTION
Closes: #297

This is just a quick and dirty draft PR to replace our hand-rolled VC cache database with [SwayDB](https://github.com/simerplaha/SwayDB).

It currently uses a terrible reflection-based hack to work around `SerializableResult`'s constructor being inaccessible, and might therefore require some changes in Inox to get rid of it.