### PR TITLE
Compute targets of a fresh LetVar

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -521,11 +521,10 @@ trait EffectsAnalyzer extends oo.CachingPhase {
 
       // A `LetVar` can be fresh if `vd` is only assigned fresh values both
       // here and in all subsequent Assign statements.
-      case LetVar(vd, expr, b) if rec(expr, bindings) =>
-        !exprOps.exists {
-          case Assignment(v, e) if v.toVal == vd => !rec(e, bindings + vd)
-          case _ => false
-        }(b) &&
+      case LetVar(vd, expr, b) if rec(expr, bindings) && !exprOps.exists {
+        case Assignment(v, e) if v.toVal == vd => !rec(e, bindings + vd)
+        case _ => false
+      }(b) =>
         rec(b, bindings + vd)
 
       // Otherwise, we don't add `vd` as a fresh binding, because it might be reassigned

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsChecker.scala
@@ -252,69 +252,6 @@ trait EffectsChecker { self: EffectsAnalyzer =>
       }
     }
 
-    /* A fresh expression is an expression that is newly created
-     * and does not share memory with existing values and variables.
-     *
-     * If the expression is made of existing immutable variables (Int or
-     * immutable case classes), it is considered fresh as we consider all
-     * non mutable objects to have a value-copy semantics.
-     *
-     * It turns out that an expression of non-mutable type is always fresh,
-     * as it can not contains reference to a mutable object, by definition
-     */
-    def isExpressionFresh(expr: Expr): Boolean = {
-      def rec(expr: Expr, bindings: Set[ValDef]): Boolean = !isMutableType(expr.getType) || (expr match {
-        case v: Variable => bindings(v.toVal)
-        case ADT(_, _, args) => args.forall(rec(_, bindings))
-
-        case FiniteArray(elems, _) => elems.forall(rec(_, bindings))
-        case LargeArray(elems, default, _, _) => elems.forall(p => rec(p._2, bindings)) && rec(default, bindings)
-
-        // We assume `old(.)` is fresh here, although such cases will probably be
-        // rejected later in `ImperativeCleanup`.
-        case Old(_) => true
-
-        case fi @ FunctionInvocation(id, _, _) if !symbols.isRecursive(id) =>
-            BodyWithSpecs(symbols.simplifyLets(fi.inlined))
-              .bodyOpt
-              .forall(isExpressionFresh)
-
-        // other function invocations always return a fresh expression, by hypothesis (global assumption)
-        case (_: FunctionInvocation | _: ApplyLetRec | _: Application) => true
-
-        //ArrayUpdated returns a mutable array, which by definition is a clone of the original
-        case ArrayUpdated(IsTyped(_, ArrayType(base)), _, _) => !isMutableType(base)
-
-        //MutableMapDuplicate returns a fresh duplicate by definition
-        case MutableMapDuplicate(IsTyped(_, MutableMapType(from, to))) =>
-          !isMutableType(from) && !isMutableType(to)
-
-        // snapshots & fresh copies are fresh
-        case Snapshot(_) => true
-        case FreshCopy(_) => true
-
-        // For `Let`, it is safe to add `vd` as a fresh binding because we disallow
-        // `FieldAssignments` with non-fresh expressions in `check(fd: FunAbstraction)` above.
-        // See discussion on: https://github.com/epfl-lara/stainless/pull/985#discussion_r614583479
-        case Let(vd, e, b) => rec(e, bindings) && rec(b, bindings + vd)
-
-        // We don't add `vd` as a fresh binding, because it might be reassigned to a non-fresh
-        // expression in a `Block` appearing in `b` (see link above)
-        case LetVar(vd, e, b) => rec(b, bindings)
-
-        case Block(_, e) => rec(e, bindings)
-
-        case IfExpr(_, e1, e2) => rec(e1, bindings) && rec(e2, bindings)
-        case MatchExpr(_, cases) => cases.forall(cse => rec(cse.rhs, bindings))
-
-        //any other expression is conservately assumed to be non-fresh if
-        //any sub-expression is non-fresh
-        case Operator(args, _) => args.forall(rec(_, bindings))
-      })
-
-      rec(expr, Set.empty)
-    }
-
     try {
       // We only check the bodies of functions which are not accessors
       if (!isAccessor(Outer(fd)))


### PR DESCRIPTION
A new solution for the problem in https://github.com/epfl-lara/stainless/pull/1033/files#diff-94338a6a254a8818b64bec4aca058a1097dadc8a142418a53fa842b44024e7ecR9-R13. The previous solution was: https://github.com/epfl-lara/stainless/pull/1033/files#diff-8e88ff59f4e5533bd8fa25ed53c11010adbe901f39faa5647962bb39fdf45548R395-R39 which is not generally correct.

