### PR TITLE
Add bindings when computing targets

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -603,6 +603,9 @@ trait AntiAliasing
         case Target(receiver, None, path) =>
           rec(receiver, path.toSeq)
 
+        case Target(receiver, Some(condition), path) if effects(condition).nonEmpty =>
+          throw FatalError(s"Effects are not allowed in condition of effects: ${condition.asString}")
+
         case Target(receiver, Some(condition), path) =>
           Annotated(
             AsInstanceOf(

--- a/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
@@ -43,7 +43,7 @@ trait FunctionInlining extends CachingPhase with IdentitySorts { self =>
         case _ => super.transform(expr)
       }
 
-      // values that can be inlined directly, without being let-bound
+      // function bodies that can be inlined directly, without bindings
       private def isValue(e: Expr): Boolean = e match {
         case UnitLiteral() => true
         case BooleanLiteral(_) => true

--- a/frontends/benchmarks/imperative/valid/Issue1111.scala
+++ b/frontends/benchmarks/imperative/valid/Issue1111.scala
@@ -1,0 +1,28 @@
+import stainless.annotation._
+
+object Issue1111 {
+  sealed abstract class Option[@mutable T]
+  case class None[@mutable T]()               extends Option[T]
+  case class Some[@mutable T](_0: MutCell[T]) extends Option[T]
+
+  sealed case class Tuple2[@mutable T0, @mutable T1](_0: MutCell[T0], _1: MutCell[T1])
+
+  case class MutCell[@mutable T](var value: T)
+
+  def get_mut[@mutable V](self: MutCell[Tuple2[String, V]], key: String): Option[V] =
+    if (self.value._0.value == key) Some[V](self.value._1)
+    else None[V]()
+
+  @pure
+  def main: Unit = {
+    val target = MutCell[Tuple2[String, Int]](
+      Tuple2[String, Int](MutCell[String]("bar"), MutCell[Int](0))
+    )
+    get_mut[Int](target, "foo") match {
+      case Some(v1) =>
+        v1.value = 123 // if this line is commented, all passes
+      case _ =>
+        ()
+    }
+  }
+}

--- a/frontends/benchmarks/imperative/valid/WrappedArray.scala
+++ b/frontends/benchmarks/imperative/valid/WrappedArray.scala
@@ -1,0 +1,23 @@
+object WrappingArray {
+
+  case class A(var x: Int)
+  case class Wrap(ar: Array[A])
+
+  def getA(w: Wrap, i: Int): A = {
+    require(0 <= i && i < w.ar.length)
+    w.ar(i)
+  }
+
+  def reset(a: A): Unit = { a.x = 0 }
+  def set(a: A, v: Int): Unit = { a.x = v }
+
+  def test(w: Wrap, i: Int): Unit = {
+    require(0 < i && i < w.ar.length)
+    reset(getA(w, 0))
+    set(getA(w, i), 100)
+    assert(w.ar(0).x == 0)
+    assert(w.ar(i).x == 100)
+    reset(getA(w, i))
+    assert(w.ar(i).x == 0)
+  }
+}


### PR DESCRIPTION
Fix #1111

I didn't handle the `LetVar` and `Block` cases, but this seems enough to fix #1111, and a similar issue I was having (see file `WrappedArray.scala`, because we were missing let bindings in (array and map) accessors too.