### PR TITLE
Fix computation of targets in let expressions

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -597,9 +597,8 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       getTargets(b, kind, path).map(_.bind(vd, e))
 
     case Let(vd, e, b) =>
-      val eEffects = getTargets(e, kind, path)
       getTargets(b, kind, path).map(_.bind(vd, e)).flatMap { be =>
-        if (be.receiver == vd.toVariable) eEffects.map(_ append be)
+        if (be.receiver == vd.toVariable) getTargets(e, kind, be.path.path)
         else Set(be)
       }
 
@@ -721,6 +720,7 @@ trait EffectsAnalyzer extends oo.CachingPhase {
 
     def rec(expr: Expr, env: Map[Variable, Effect]): Set[Effect] = expr match {
       case Let(vd, e, b) if symbols.isMutableType(vd.tpe) =>
+
         if ((variablesOf(e) & variablesOf(b)).forall(v => !isMutableType(v.tpe))) {
           val effe = rec(e, env)
           val newEnv = (variablesOf(b) ++ freeVars).map(v => v -> ModifyingEffect(v, Path.empty)).toMap

--- a/core/src/main/scala/stainless/genc/ir/IR.scala
+++ b/core/src/main/scala/stainless/genc/ir/IR.scala
@@ -51,7 +51,7 @@ private[genc] sealed trait IR { ir =>
   // Define a function body as either a regular AST or a manually defined
   // function using @cCode.function
   sealed abstract class FunBody
-  case object FunDropped extends FunBody // for @cCode.drop
+  case class FunDropped(isAccessor: Boolean) extends FunBody // for @cCode.drop; `isAccessor` is true for `val`'s to avoid parentheses
   case class FunBodyAST(body: Expr) extends FunBody
   case class FunBodyManual(includes: Seq[String], body: String) extends FunBody // NOTE `body` is actually the whole function!
 

--- a/core/src/main/scala/stainless/genc/ir/Transformer.scala
+++ b/core/src/main/scala/stainless/genc/ir/Transformer.scala
@@ -77,7 +77,7 @@ abstract class Transformer[From <: IR, To <: IR](final val from: From, final val
   }
 
   protected def rec(fb: FunBody)(implicit env: Env): to.FunBody = (fb: @unchecked) match {
-    case FunDropped => to.FunDropped
+    case FunDropped(isAccessor) => to.FunDropped(isAccessor)
     case FunBodyAST(body) => to.FunBodyAST(rec(body))
     case FunBodyManual(includes, body) => to.FunBodyManual(includes, body)
   }

--- a/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
@@ -99,7 +99,7 @@ private class IR2CImpl(val ctx: inox.Context) {
       includes foreach { i => register(C.Include(i)) }
       Right(body)
 
-    case FunDropped => Right("")
+    case FunDropped(_) => Right("")
   }
 
   private def rec(cd: ClassDef): Unit = {
@@ -224,6 +224,8 @@ private class IR2CImpl(val ctx: inox.Context) {
       C.buildBlock(lenDecl :: bufferDecl :: varDecl :: Nil)
 
     case Decl(vd, Some(value)) => C.Decl(rec(vd.id), rec(vd.getType), Some(rec(value)))
+
+    case App(FunVal(fd), Seq(), Seq()) if fd.body == FunDropped(true) => C.Binding(rec(fd.id))
 
     case App(callable, extra, args) => C.Call(rec(callable), (extra ++ args).map(rec(_)))
 

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -512,7 +512,7 @@ private class S2IRImpl(val context: inox.Context, val ctxDB: FunCtxDB, val deps:
         val impl = fa.getManualDefinition
         CIR.FunBodyManual(impl.includes, impl.code)
       } else if (fa.isDropped) {
-        CIR.FunDropped
+        CIR.FunDropped(fa.flags.exists(_.name == "accessor"))
       } else {
         // Build the new environment from context and parameters
         val ctxKeys: Seq[(ValDef, Type)] = ctxDBAbs map { c => c.vd -> instantiateType(c.typ, tm1) }

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -889,8 +889,6 @@ private class S2IRImpl(val context: inox.Context, val ctxDB: FunCtxDB, val deps:
           if (arrayType.base.containsArray)
             reporter.fatalError(array.getPos, s"VLAs cannot have elements being/containing other array")
 
-          reporter.warning(array.getPos, s"VLAs should be avoid according to MISRA C rules")
-
           val value = rec(default)
           CIR.ArrayAllocVLA(arrayType, length, value)
       }

--- a/frontends/benchmarks/imperative/valid/LetTargets.scala
+++ b/frontends/benchmarks/imperative/valid/LetTargets.scala
@@ -1,0 +1,28 @@
+import stainless.lang._
+import stainless.annotation._
+
+object LetTargets {
+
+  case class A(var x: Int)
+  case class B(as: Array[A])
+  case class C(bs: Array[B])
+  case class D(val c: C)
+
+  @export
+  def reset(d: D): Unit = {
+    require(d.c.bs.length > 0)
+    require(d.c.bs(0).as.length > 0)
+
+    {
+      val b: B = d.c.bs(0)
+      b
+    }.as(0).x = 0
+  }
+
+  def test(d: D): Unit = {
+    require(d.c.bs.length > 0)
+    require(d.c.bs(0).as.length > 0)
+    reset(d)
+    assert(d.c.bs(0).as(0).x == 0)
+  }
+}

--- a/frontends/benchmarks/verification/invalid/InliningUnchecked.scala
+++ b/frontends/benchmarks/verification/invalid/InliningUnchecked.scala
@@ -1,0 +1,9 @@
+object InliningUnchecked {
+
+  @inline def f: Int = 0
+
+  def g: Int = {
+    f
+  }.ensuring(_ == 10)
+
+}

--- a/frontends/benchmarks/verification/invalid/InliningUnchecked2.scala
+++ b/frontends/benchmarks/verification/invalid/InliningUnchecked2.scala
@@ -1,0 +1,7 @@
+object InliningUnchecked2 {
+  @inline def nonNegative(x: Int): Boolean = x >= 0
+
+  def test: Int = {
+    -10
+  }.ensuring(nonNegative _)
+}


### PR DESCRIPTION
The example `LetTargets` is failing in the current master branch, because the computation of targets in let expressions duplicates the `path` (once for the bound expression `e`, and once for the body `b`). We get targets which are not well-formed.