### PR TITLE
GenC improvements

### DIFF
--- a/core/src/main/scala/stainless/genc/CAST.scala
+++ b/core/src/main/scala/stainless/genc/CAST.scala
@@ -43,8 +43,7 @@ object CAST { // C Abstract Syntax Tree
 
   case class Prog(
     includes: Set[Include],
-    // boolean is set to true when for global declarations that are declared outside of the Stainless program
-    decls: Seq[(Decl, DeclarationMode)],
+    decls: Seq[(Decl, Seq[DeclarationMode])],
     typeDefs: Set[TypeDef],
     enums: Set[Enum],
     types: Seq[DataType], // Both structs and unions, order IS important! See NOTE above.

--- a/core/src/main/scala/stainless/genc/ir/IR.scala
+++ b/core/src/main/scala/stainless/genc/ir/IR.scala
@@ -40,7 +40,7 @@ private[genc] sealed trait IR { ir =>
   sealed abstract class Def extends Tree
 
   case class Prog(
-    decls: Seq[(Decl, DeclarationMode)],
+    decls: Seq[(Decl, Seq[DeclarationMode])],
     functions: Seq[FunDef],
     classes: Seq[ClassDef]
   ) {

--- a/core/src/main/scala/stainless/genc/ir/Transformer.scala
+++ b/core/src/main/scala/stainless/genc/ir/Transformer.scala
@@ -51,10 +51,10 @@ abstract class Transformer[From <: IR, To <: IR](final val from: From, final val
 
   protected def rec(prog: Prog)(implicit env: Env): to.Prog = {
     if (prog.decls.nonEmpty) {
-      val externality = prog.decls.map(_._2)
+      val modes = prog.decls.map(_._2)
       val (to.Block(newDecls), newEnv) = recImpl(Block(prog.decls.map(_._1)))
       to.Prog(
-        newDecls.map(_.asInstanceOf[to.Decl]).zip(externality),
+        newDecls.map(_.asInstanceOf[to.Decl]).zip(modes),
         prog.functions.map(rec(_)(newEnv)),
         prog.classes.map(rec(_)(newEnv)),
       )

--- a/core/src/main/scala/stainless/genc/package.scala
+++ b/core/src/main/scala/stainless/genc/package.scala
@@ -24,7 +24,7 @@ package object genc {
 
   // declaration mode for global variables
   sealed abstract class DeclarationMode
-  case object Normal extends DeclarationMode
   case object Static extends DeclarationMode // static annotation
+  case object Volatile extends DeclarationMode // static annotation
   case object External extends DeclarationMode // no declaration in the produced code
 }

--- a/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
@@ -59,8 +59,8 @@ private class IR2CImpl(val ctx: inox.Context) {
 
   private def rec(prog: Prog): C.Prog = {
 
-    val decls = prog.decls.map { case (decl, external) => rec(decl, allowFixedArray = true) match {
-      case res: C.Decl => (res, external)
+    val decls = prog.decls.map { case (decl, modes) => rec(decl, allowFixedArray = true) match {
+      case res: C.Decl => (res, modes)
       case res =>
         ctx.reporter.fatalError(
           "Only simple values are supported as default values for global variables.\n" +

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -123,7 +123,7 @@ private class S2IRImpl(val context: inox.Context, val ctxDB: FunCtxDB, val deps:
    *                                                       Caches                                     *
    ****************************************************************************************************/
 
-  var declResults = new scala.collection.mutable.ListBuffer[(CIR.Decl, DeclarationMode)]()
+  var declResults = new scala.collection.mutable.ListBuffer[(CIR.Decl, Seq[DeclarationMode])]()
 
   // For functions, we associate each TypedFunDef to a CIR.FunDef for each "type context" (TypeMapping).
   // This is very important for (non-generic) functions nested in a generic function because for N
@@ -584,6 +584,12 @@ private class S2IRImpl(val context: inox.Context, val ctxDB: FunCtxDB, val deps:
 
     type Translation = Map[ClassType, CIR.ClassDef]
 
+    def flagsToModes(flags: Seq[Flag]): Seq[DeclarationMode] = flags.flatMap {
+      case flag if flag.name == "cCode.static" => Some(Static)
+      case flag if flag.name == "cCode.volatile" => Some(Volatile)
+      case _ => None
+    }
+
     def recTopDown(ct: ClassType, parent: Option[CIR.ClassDef], acc: Translation): Translation = {
       val tcd = ct.tcd
       val cd = tcd.cd
@@ -643,20 +649,20 @@ private class S2IRImpl(val context: inox.Context, val ctxDB: FunCtxDB, val deps:
               s"We found ${paramInits.length} initializations instead of ${fields.length}."
             )
           }
-          for (((field, paramInit), static) <- fields.zip(paramInits).zip(nonGhostFields.map(vd => vd.flags.exists(_.name == "cCode.static")))) {
+          for (((field, paramInit), vd) <- fields.zip(paramInits).zip(nonGhostFields)) {
             implicit val emptyEnv = Env(Map(), Map(), false)
-            val decl = (CIR.Decl(field, Some(rec(paramInit.fullBody))), if (static) Static else Normal)
+            val decl = (CIR.Decl(field, Some(rec(paramInit.fullBody))), flagsToModes(vd.flags))
             if (declResults.map(_._1.vd).contains(field)) {
               reporter.fatalError(cd.getPos, s"Global variable ${field.id} is defined twice")
             }
             declResults.append(decl)
           }
         } else if (cd.isGlobalUninitialized) {
-          for ((field, static) <- fields.zip(nonGhostFields.map(vd => vd.flags.exists(_.name == "cCode.static")))) {
-            declResults.append((CIR.Decl(field, None), if (static) Static else Normal))
+          for ((field, vd) <- fields.zip(nonGhostFields)) {
+            declResults.append((CIR.Decl(field, None), flagsToModes(vd.flags)))
           }
         } else if (cd.isGlobalExternal) {
-          for (field <- fields) declResults.append((CIR.Decl(field, None), External))
+          for (field <- fields) declResults.append((CIR.Decl(field, None), Seq(External)))
         }
         newAcc
       } else {

--- a/frontends/library/stainless/annotation/cCode.scala
+++ b/frontends/library/stainless/annotation/cCode.scala
@@ -102,4 +102,8 @@ object cCode {
   /* The `static` annotation can be used to mark variables that appear in `@global` annotated classes */
   @ignore @field @getter @setter @param
   class static() extends StaticAnnotation
+
+  /* The `volatile` annotation can be used to mark variables that appear in `@global` annotated classes */
+  @ignore @field @getter @setter @param
+  class volatile() extends StaticAnnotation
 }


### PR DESCRIPTION
* Add `@cCode.volatile` annotation for global variables
* Avoid pointers in global variables in GenC