### PR TITLE
Add first class heap representation

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/HeapASTExtractors.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/HeapASTExtractors.scala
@@ -79,4 +79,19 @@ trait HeapASTExtractors {
       case _ => None
     }
   }
+
+  /** An extractor for the eval method on stainless.lang.Heap */
+  object HeapEval {
+    object Id {
+      def unapply(id: Identifier): Boolean = id match {
+        case ast.SymbolIdentifier("stainless.lang.Heap.eval") => true
+        case _ => false
+      }
+    }
+
+    def unapply(e: Expr): Option[(Expr, Expr)] = e match {
+      case FunctionInvocation(Id(), Seq(_), Seq(heap, value)) => Some((heap, value))
+      case _ => None
+    }
+  }
 }

--- a/core/src/main/scala/stainless/extraction/imperative/HeapASTExtractors.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/HeapASTExtractors.scala
@@ -1,0 +1,82 @@
+/* Copyright 2009-2020 EPFL, Lausanne */
+
+package stainless
+package extraction
+package imperative
+
+trait HeapASTExtractors {
+  val s: Trees
+  import s._
+
+  /** An extractor for the Heap type in the stainless.lang package */
+  object HeapType {
+    // TODO(gsps): Cache this ClassDef
+    def classDefOpt(implicit s: Symbols): Option[ClassDef] =
+      s.lookup.get[ClassDef]("stainless.lang.Heap")
+
+    def unapply(tpe: Type)(implicit s: Symbols): Boolean = tpe match {
+      case ct: ClassType => classDefOpt.map(_.id == ct.id).getOrElse(false)
+      case _ => false
+    }
+  }
+
+  /** An extractor for the refEq method on AnyHeapRef */
+  object RefEq {
+    object Id {
+      def unapply(id: Identifier): Boolean = id match {
+        case ast.SymbolIdentifier("stainless.lang.AnyHeapRef.refEq") => true
+        case _ => false
+      }
+    }
+
+    def unapply(expr: Expr)(implicit s: Symbols): Option[(Expr, Expr)] = expr match {
+      case FunctionInvocation(Id(), _, Seq(e1, e2)) => Some((e1, e2))
+      case _ => None
+    }
+  }
+
+  /** An extractor for the refEq function in stainless.lang */
+  object ObjectIdentity {
+    object Id {
+      def unapply(id: Identifier): Boolean = id match {
+        case ast.SymbolIdentifier("stainless.lang.objectId") => true
+        case _ => false
+      }
+    }
+
+    def unapply(e: Expr): Option[Expr] = e match {
+      case FunctionInvocation(Id(), Seq(_), Seq(obj)) => Some(obj)
+      case _ => None
+    }
+  }
+
+  /** An extractor for the get function in stainless.lang.Heap */
+  object HeapGet {
+    object Id {
+      def unapply(id: Identifier): Boolean = id match {
+        case ast.SymbolIdentifier("stainless.lang.Heap.get") => true
+        case _ => false
+      }
+    }
+
+    def unapply(e: Expr): Boolean = e match {
+      case FunctionInvocation(Id(), Seq(), Seq()) => true
+      case _ => false
+    }
+  }
+
+  /** An extractor for the unchanged function in stainless.lang.Heap */
+  object HeapUnchanged {
+    object Id {
+      def unapply(id: Identifier): Boolean = id match {
+        case ast.SymbolIdentifier("stainless.lang.Heap.unchanged") => true
+        case _ => false
+      }
+    }
+
+    def unapply(e: Expr): Option[(Expr, Expr, Expr)] = e match {
+      case FunctionInvocation(Id(), Seq(), Seq(objs, heap1, heap2)) => Some((objs, heap1, heap2))
+      case _ => None
+    }
+  }
+}

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -262,12 +262,12 @@ trait Trees extends oo.Trees with Definitions { self =>
 
   private[this] lazy val dummyHeapId: Identifier = ast.SymbolIdentifier("stainless.lang.dummyHeap")
   lazy val dummyHeap: FunDef = dsl.mkFunDef(dummyHeapId, Synthetic, Extern)() { _ =>
-    (Seq(), HeapType, { _ => NoTree(HeapType) })
+    (Seq(), HeapMapType, { _ => NoTree(HeapMapType) })
   }
 
   lazy val HeapRefType: Type = ADTType(heapRefId, Seq.empty)
   lazy val HeapRefSetType: Type = SetType(HeapRefType)
-  lazy val HeapType: MapType = MapType(HeapRefType, AnyType())
+  lazy val HeapMapType: MapType = MapType(HeapRefType, AnyType())
 
   object ObjectIdentity {
     def unapply(e: Expr): Option[Expr] = e match {

--- a/frontends/benchmarks/full-imperative/invalid/HeapEvalIsHypothetical.scala
+++ b/frontends/benchmarks/full-imperative/invalid/HeapEvalIsHypothetical.scala
@@ -1,0 +1,18 @@
+import stainless.lang._
+import stainless.annotation._
+
+object HeapEvalIsHypotheticalExample {
+  case class Cell(var value: BigInt) extends AnyHeapRef
+
+  def getHypotheticalIsHypothetical(c: Cell): Unit = {
+    reads(Set(c))
+    modifies(Set(c))
+    val heapA = Heap.get
+    val heapB = heapA.eval {
+      c.value += 1
+      Heap.get
+    }
+    // Our implicit heap was unaffected, so this does not hold:
+    assert(heapB.eval { c.value } == c.value)
+  }
+}

--- a/frontends/benchmarks/full-imperative/invalid/HeapUnchangedInvalid.scala
+++ b/frontends/benchmarks/full-imperative/invalid/HeapUnchangedInvalid.scala
@@ -1,0 +1,15 @@
+import stainless.lang._
+import stainless.annotation._
+
+object HeapUnchangedInvalidExample {
+  case class Cell(var value: BigInt) extends AnyHeapRef
+
+  def f(c: Cell): Unit = {
+    reads(Set(c))
+    modifies(Set(c))
+    val heapA = Heap.get
+    c.value += 2
+    val heapB = Heap.get
+    assert(Heap.unchanged(Set(c), heapA, heapB))
+  }
+}

--- a/frontends/benchmarks/full-imperative/valid/FirstClassHeap.scala
+++ b/frontends/benchmarks/full-imperative/valid/FirstClassHeap.scala
@@ -4,7 +4,7 @@ import stainless.annotation._
 object FirstClassHeapExample {
   case class Cell(var value: BigInt) extends AnyHeapRef
 
-  def f(c1: Cell, c2: Cell): Unit = {
+  def getAndCompareHeapRegions(c1: Cell, c2: Cell): Unit = {
     reads(Set(c1, c2))
     modifies(Set(c1, c2))
     require(c1 != c2)
@@ -17,11 +17,45 @@ object FirstClassHeapExample {
     assert(Heap.unchanged(Set(c1), heapB, heapC))
   }
 
-  def g(c: Cell): BigInt = {
+  def rewindAndEvaluate(c: Cell): BigInt = {
     reads(Set(c))
     modifies(Set(c))
     val heapA = Heap.get
     c.value += 1
     heapA.eval { c.value }
   } ensuring (_ == old(c.value))
+
+  def getHypothetical(c: Cell): Unit = {
+    reads(Set(c))
+    modifies(Set(c))
+    val heapA = Heap.get
+    val heapB = heapA.eval {
+      c.value += 1
+      Heap.get
+    }
+    assert(heapA == Heap.get)
+    assert(heapB.eval { c.value } == c.value + 1)
+  }
+
+  def compareHypotheticalHeaps(c1: Cell, c2: Cell): Unit = {
+    reads(Set(c1, c2))
+    modifies(Set(c1, c2))
+    require(c1 != c2)
+    val heapA = Heap.get
+    val heapB1 = heapA.eval {
+      c1.value += 1
+      c2.value += 2
+      Heap.get
+    }
+    val heapB2 = heapA.eval {
+      c2.value += 2
+      c1.value += 3
+      Heap.get
+    }
+    // Even though
+    // - c1 and c2 are modified in different orders, and
+    // - c1 is incremented by a different value
+    // we can nonetheless show that the two resulting heaps agree on c2:
+    assert(Heap.unchanged(Set(c2), heapB1, heapB2))
+  }
 }

--- a/frontends/benchmarks/full-imperative/valid/FirstClassHeap.scala
+++ b/frontends/benchmarks/full-imperative/valid/FirstClassHeap.scala
@@ -1,0 +1,19 @@
+import stainless.lang._
+import stainless.annotation._
+
+object FirstClassHeapExample {
+  case class Cell(var value: BigInt) extends AnyHeapRef
+
+  def f(c1: Cell, c2: Cell): Unit = {
+    reads(Set(c1, c2))
+    modifies(Set(c1, c2))
+    require(c1 != c2)
+    val heapA = Heap.get
+    c1.value += 2
+    val heapB = Heap.get
+    c2.value += 3
+    val heapC = Heap.get
+    assert(Heap.unchanged(Set(c2), heapA, heapB))
+    assert(Heap.unchanged(Set(c1), heapB, heapC))
+  }
+}

--- a/frontends/benchmarks/full-imperative/valid/FirstClassHeap.scala
+++ b/frontends/benchmarks/full-imperative/valid/FirstClassHeap.scala
@@ -16,4 +16,12 @@ object FirstClassHeapExample {
     assert(Heap.unchanged(Set(c2), heapA, heapB))
     assert(Heap.unchanged(Set(c1), heapB, heapC))
   }
+
+  def g(c: Cell): BigInt = {
+    reads(Set(c))
+    modifies(Set(c))
+    val heapA = Heap.get
+    c.value += 1
+    heapA.eval { c.value }
+  } ensuring (_ == old(c.value))
 }

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -194,7 +194,12 @@ package object lang {
   def objectId[T <: AnyHeapRef](x: T): BigInt = ???
 
   @extern @library
-  case class Heap(/*opaque*/)
+  case class Heap(/*opaque*/) {
+    // Evaluates a value expression in the given heap.
+    // Caveat: Reads and modifies clauses are currently unchecked in the value expression.
+    @extern @library
+    def eval[T](value: T): T = ???
+  }
 
   object Heap {
     // Returns a snapshot of the current heap.

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -193,7 +193,7 @@ package object lang {
   @extern @library
   def objectId[T <: AnyHeapRef](x: T): BigInt = ???
 
-  @extern @library
+  @library
   case class Heap(/*opaque*/) {
     // Evaluates a value expression in the given heap.
     // Caveat: Reads and modifies clauses are currently unchecked in the value expression.

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -192,4 +192,18 @@ package object lang {
 
   @extern @library
   def objectId[T <: AnyHeapRef](x: T): BigInt = ???
+
+  @extern @library
+  case class Heap(/*opaque*/)
+
+  object Heap {
+    // Returns a snapshot of the current heap.
+    @extern @library
+    def get: Heap = ???
+
+    // Returns whether two heaps are equal on all the given objects.
+    @extern @library
+    def unchanged(objs: Set[AnyHeapRef], h0: Heap, h1: Heap): Boolean =
+      /* objs.mapMerge(h1, h0) == h0 */ ???
+  }
 }


### PR DESCRIPTION
Exposes `Heap` in the standard library which allows explicit manipulation of different heap states. In particular `Heap.get` returns the current state, `Heap.unchanged(objs, heap1, heap2)` returns true whenever `heap1` and `heap2` are equal on all objects in `objs`, and `Heap#eval(e)` evaluates expression `e` in the context of the given heap.