### PR TITLE
Improve heap ref set handling

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
@@ -55,6 +55,8 @@ trait EffectElaboration
   override protected def extractSymbols(tctx: TransformerContext, symbols: s.Symbols): t.Symbols = {
     def shouldDropFun(fd: FunDef)(implicit symbols: s.Symbols): Boolean =
       fd.id match {
+        case AsHeapRefSet.WrapperId() => true
+        case AsHeapRefSet.Id() => true
         case RefEq.Id() => true
         case ObjectIdentity.Id() => true
         case HeapGet.Id() => true
@@ -401,6 +403,9 @@ trait RefTransform
           // Will be translated separately in postconditions
           // TODO(gsps): Add ability to refer back to old state snapshots for any ghost code
           e
+
+        case AsHeapRefSet(objs) =>
+          transform(objs, env)
 
         case RefEq(e1, e2) =>
           // Reference equality is transformed into value equality on references

--- a/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
@@ -103,48 +103,6 @@ object EffectElaboration {
 
 /** The actual Ref transformation **/
 
-/*
-trait SyntheticHeapFunctions { self =>
-  val s: Trees
-  val t: s.trees
-
-  import t._
-  import dsl._
-
-  protected lazy val heapReadId: Identifier = ast.SymbolIdentifier("stainless.lang.HeapRef.read")
-  protected lazy val heapModifyId: Identifier = ast.SymbolIdentifier("stainless.lang.HeapRef.modify")
-
-  protected def heapFunctions: Seq[FunDef] = {
-    val readFd = mkFunDef(heapReadId, Unchecked, Synthetic, Inline)() { _ =>
-      (Seq("heap" :: HeapMapType, "x" :: HeapRefType), AnyType(), {
-        case Seq(heap, x) =>
-          Require(
-            heap.select(heapReadableId).contains(x),
-            MapApply(heap.select(heapMapId), x)
-          )
-      })
-    }
-    val modifyFd = mkFunDef(heapModifyId, Unchecked, Synthetic, Inline)() { _ =>
-      (Seq("heap" :: HeapMapType, "x" :: HeapRefType, "v" :: AnyType()), UnitType(), {
-        case Seq(heap, x) =>
-          Require(
-            heap.select(heapModifiableId).contains(x),
-            heapWithMap(heap, MapUpdated(heap.select(heapMapId), x, v))
-          )
-      })
-    }
-    Seq(readFd, modifyFd)
-  }
-
-  protected def heapWithMap(oldHeap: Expr, newMap: Expr): Expr =
-    C(heapCons)(
-      newMap,
-      oldHeap.select(heapReadableId),
-      oldHeap.select(heapModifiableId)
-    )
-}
-*/
-
 trait RefTransform
   extends oo.CachingPhase
      with utils.SyntheticSorts

--- a/core/src/main/scala/stainless/extraction/imperative/HeapASTExtractors.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/HeapASTExtractors.scala
@@ -8,6 +8,30 @@ trait HeapASTExtractors {
   val s: Trees
   import s._
 
+  /** An extractor for the asRefs conversion of heap ref sets */
+  object AsHeapRefSet {
+    object WrapperId {
+      def unapply(id: Identifier): Boolean = id match {
+        case ast.SymbolIdentifier("stainless.lang.HeapRefSetDecorations") => true
+        case _ => false
+      }
+    }
+
+    object Id {
+      def unapply(id: Identifier): Boolean = id match {
+        case ast.SymbolIdentifier("stainless.lang.HeapRefSetDecorations.asRefs") => true
+        case _ => false
+      }
+    }
+
+    def unapply(expr: Expr)(implicit s: Symbols): Option[Expr] = expr match {
+      case FunctionInvocation(Id(), _, Seq(
+          FunctionInvocation(WrapperId(), Seq(_), Seq(objs)))) =>
+        Some(objs)
+      case _ => None
+    }
+  }
+
   /** An extractor for the Heap type in the stainless.lang package */
   object HeapType {
     // TODO(gsps): Cache this ClassDef

--- a/core/src/main/scala/stainless/extraction/imperative/package.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/package.scala
@@ -28,6 +28,7 @@ package object imperative {
   }
 
   def oldImperative(implicit ctx: inox.Context) = {
+    utils.DebugPipeline("EffectElaboration", EffectElaboration(trees)) andThen  // only drops definitions
     utils.DebugPipeline("AntiAliasing", AntiAliasing(trees)) andThen
     utils.DebugPipeline("ReturnElimination", ReturnElimination(trees)) andThen
     utils.DebugPipeline("ImperativeCodeElimination", ImperativeCodeElimination(trees)) andThen

--- a/frontends/benchmarks/full-imperative/valid/AsHeapRefSet.scala
+++ b/frontends/benchmarks/full-imperative/valid/AsHeapRefSet.scala
@@ -1,0 +1,26 @@
+import stainless.lang._
+import stainless.annotation._
+import stainless.collection._
+
+// Set[T <: AnyHeapRef]#asRefs is convenient for specifying reads and modifies clauses
+object AsHeapRefSetExample {
+  case class Cell(var value: BigInt) extends AnyHeapRef
+
+  def increasing(cells: List[Cell], bound: BigInt = 0): Boolean = {
+    reads(cells.content.asRefs)
+    cells match {
+      case Nil() => true
+      case Cons(cell, cells0) => cell.value >= bound && increasing(cells0, cell.value)
+    }
+  }
+
+  def combine(cells1: List[Cell], cells2: List[Cell]): Unit = {
+    reads(cells1.content.asRefs ++ cells2.content.asRefs)
+    require(
+      cells1.nonEmpty && cells2.nonEmpty &&
+      cells1.last.value <= cells2.head.value &&
+      increasing(cells1) && increasing(cells2)
+    )
+    ()
+  }
+}

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -184,6 +184,12 @@ package object lang {
     def refEq(that: AnyHeapRef): Boolean = true
   }
 
+  @extern @library
+  implicit class HeapRefSetDecorations[T <: AnyHeapRef](val objs: Set[T]) {
+    @extern @library
+    def asRefs: Set[AnyHeapRef] = ???
+  }
+
   @ignore
   def reads(@ghost objs: Set[AnyHeapRef]): Unit = ()
 


### PR DESCRIPTION
Adds the `asRefs` extension method that allows us to convert `Set[T <: AnyHeapRef]` to `Set[AnyHeapRef]`, working around the invariance of `Set[T]`. This is useful to deal with reads and modifies clauses. During lowering in the full-imperative phase the new method is erased, simplifying proofs. This is sound, because all types inheriting from `AnyHeapRef` are erased to `HeapRef` anyways (as is `AnyHeapRef` itself, of course).