### PR TITLE
Less casts in imperative phase, more freshening of local variables, and add SplitAnd tree

### DIFF
--- a/core/src/main/scala/stainless/ast/Deconstructors.scala
+++ b/core/src/main/scala/stainless/ast/Deconstructors.scala
@@ -216,6 +216,7 @@ trait TreeDeconstructor extends inox.ast.TreeDeconstructor {
     case s.Final => (Seq(), Seq(), Seq(), (_, _, _) => t.Final)
     case s.DropVCs => (Seq(), Seq(), Seq(), (_, _, _) => t.DropVCs)
     case s.DropConjunct => (Seq(), Seq(), Seq(), (_, _, _) => t.DropConjunct)
+    case s.SplitVC => (Seq(), Seq(), Seq(), (_, _, _) => t.SplitVC)
     case s.Library => (Seq(), Seq(), Seq(), (_, _, _) => t.Library)
     case s.Synthetic => (Seq(), Seq(), Seq(), (_, _, _) => t.Synthetic)
     case s.Derived(None) => (Seq(), Seq(), Seq(), (_, _, _) => t.Derived(None))

--- a/core/src/main/scala/stainless/ast/Definitions.scala
+++ b/core/src/main/scala/stainless/ast/Definitions.scala
@@ -24,6 +24,7 @@ trait Definitions extends inox.ast.Definitions { self: Trees =>
   case object Final extends Flag("final", Seq.empty)
   case object DropVCs extends Flag("DropVCs", Seq.empty)
   case object DropConjunct extends Flag("dropConjunct", Seq.empty)
+  case object SplitVC extends Flag("splitVC", Seq.empty)
   case object Library extends Flag("library", Seq.empty)
   case object Synthetic extends Flag("synthetic", Seq())
   case object PartialEval extends Flag("partialEval", Seq())

--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -293,7 +293,10 @@ trait EffectsAnalyzer extends oo.CachingPhase {
         for {
           ct  <- asClassType(expr.getType)
           tcd <- symbols.classForField(ct, id)
-          res <- wrap(ClassSelector(AsInstanceOf(expr, tcd.toType), id), xs)
+          res <- if (tcd.cd.parents.isEmpty && tcd.cd.children.isEmpty)
+            wrap(ClassSelector(expr, id), xs)
+          else
+            wrap(ClassSelector(AsInstanceOf(expr, tcd.toType), id), xs)
         } yield res
 
       case ArrayAccessor(idx) +: xs =>

--- a/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
@@ -294,11 +294,6 @@ private class IR2CImpl(val ctx: inox.Context) {
      *      See comment in CmpFactory.
      */
     case BinOp(op @ (Equals | NotEquals), lhs, rhs) if !(lhs.getType.isLogical || lhs.getType.isIntegral) =>
-      // if (lhs.getType != rhs.getType)
-        // ctx.reporter.warning("Comparing ${lhs} (type ${lhs.getType}) and ${rhs} (type ${rhs.getType}) which have different types")
-      assert(lhs.getType == rhs.getType,
-        s"Operands $lhs and $rhs of equality operator must have the same type (here, ${lhs.getType} and ${rhs.getType})"
-      )
       val cmp = CmpFactory(lhs.getType)
       val equals = App(cmp, Seq(), Seq(lhs, rhs))
       val test = if (op == Equals) equals else UnOp(Not, equals)

--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -18,7 +18,7 @@ trait InoxEncoder extends ProgramEncoder {
   import context._
 
   private[this] def keepFlag(flag: Flag): Boolean = flag match {
-    case DropVCs | DropConjunct | Library | Synthetic | PartialEval | Extern => false
+    case DropVCs | DropConjunct | SplitVC | Library | Synthetic | PartialEval | Extern => false
     case Opaque | Private | Final | Law | Ghost | Erasable | Wrapping | Lazy => false
     case Derived(_) | IsField(_) | IsUnapply(_, _) | IndexedAt(_) | ClassParamInit(_) => false
     case TerminationStatus(_) => false

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -19,9 +19,9 @@ class StainlessSerializer(override val trees: ast.Trees, serializeProducts: Bool
   /** An extension to the set of registered classes in the `InoxSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 120 to 171.
+    * The new identifiers in the mapping range from 120 to 172.
     *
-    * NEXT ID: 172
+    * NEXT ID: 173
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -65,6 +65,7 @@ class StainlessSerializer(override val trees: ast.Trees, serializeProducts: Bool
       classSerializer[IsUnapply]       (144),
       classSerializer[ClassParamInit](170),
       classSerializer[DropConjunct.type](171),
+      classSerializer[SplitVC.type]     (172),
 
       classSerializer[TerminationStatus]      (161),
       classSerializer[TR.Unknown.type]        (162),

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -30,6 +30,11 @@ package object lang {
     def ==>(that: => Boolean): Boolean = {
       if (underlying) that else true
     }
+
+    // Use this "and" operator instead of `&&` when you want verification conditions to be split
+    def &&&(that: => Boolean): Boolean = {
+      if (underlying) that else false
+    }
   }
 
   @library

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -353,6 +353,24 @@ trait ASTExtractors {
       }
     }
 
+    /** Matches `lhs &&& rhs` and returns (lhs, rhs)*/
+    object ExSplitAnd {
+      def unapply(tree: Apply) : Option[(Tree, Tree)] = tree match {
+        case
+          Apply(
+            Select(
+              Apply(
+                ExSymbol("stainless", "lang", "BooleanDecorations"),
+                lhs :: Nil
+              ),
+              ExNamed("$amp$amp$amp")
+            ),
+            rhs :: Nil
+          ) => Some((lhs, rhs))
+        case _ => None
+      }
+    }
+
     /** Extracts the 'require' contract from an expression (only if it's the
      * first call in the block). */
     object ExRequiredExpression {

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -1451,6 +1451,9 @@ trait CodeExtraction extends ASTExtractors {
     case ExImplies(lhs, rhs) =>
       xt.Implies(extractTree(lhs), extractTree(rhs))
 
+    case ExSplitAnd(lhs, rhs) =>
+      xt.Annotated(xt.And(extractTree(lhs), extractTree(rhs)), Seq(xt.SplitVC))
+
     case c @ ExCall(rec, sym, tps, args) => rec match {
       case None if sym.owner.isModuleClass && sym.owner.isCase =>
         val ct = extractType(sym.owner.tpe)(dctx, c.pos).asInstanceOf[xt.ClassType]


### PR DESCRIPTION
* Less casts and more freshening in imperative phase
* Add SplitAnd tree (&&&) to split verification conditions
