### PR TITLE
Fix unsoundness with HeapGet and reads-frame assumption on heap-modifying functions

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
@@ -640,7 +640,10 @@ trait RefTransform
             }
             val fiProjected = fi.copy(args = heapArg +: fi.args.tail).copiedFrom(fi)
             Assume(
-              unchecked(Equals(res, fiProjected).copiedFrom(fd)),
+              unchecked(
+                if (writes) Equals(res._1, fiProjected._1).copiedFrom(fd)
+                else        Equals(res, fiProjected).copiedFrom(fd)
+              ),
               result
             ).copiedFrom(fd)
           }

--- a/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectElaboration.scala
@@ -367,7 +367,11 @@ trait RefTransform
           ADTSelector(transform(recv, env), fieldId).copiedFrom(e)
 
         case HeapGet() =>
-          env.expectHeapVd(e.getPos, "heap snapshot").toVariable
+          val heap = env.expectHeapVd(e.getPos, "heap snapshot").toVariable
+          val readsDom = env.expectReadsV(e.getPos, "heap snapshot")
+          readsDom
+            .map(readsDom => MapMerge(readsDom, heap, E(dummyHeap.id)()).copiedFrom(e))
+            .getOrElse(heap)
 
         case HeapUnchanged(objs, heap1, heap2) =>
           smartLet("heapBase" :: HeapRefType, transform(heap1, env)) { heapBase =>

--- a/frontends/benchmarks/full-imperative/invalid/HeapGetProjectsReads.scala
+++ b/frontends/benchmarks/full-imperative/invalid/HeapGetProjectsReads.scala
@@ -1,0 +1,28 @@
+import stainless.lang._
+import stainless.annotation._
+
+object HeapGetProjectsReadsExample {
+  case class Cell(var value: BigInt) extends AnyHeapRef
+
+  def onlyOne(c1: Cell, c2: Cell): BigInt = {
+    reads(Set(c1))
+    Heap.get.eval { c2.value }
+  }
+
+  def testOne(c1: Cell, c2: Cell): Unit = {
+    require(c1 != c2)
+    reads(Set(c1, c2))
+    modifies(Set(c2))
+    c2.value = 1
+    val h1 = Heap.get
+    val v1 = onlyOne(c1, c2)
+    assert(v1 == 1)
+    c2.value = 2
+    val h2 = Heap.get
+    assert(Heap.unchanged(Set(c1), h1, h2))
+    val v2 = onlyOne(c1, c2)
+    assert(v2 == 2)
+    assert(v1 == v2)
+    assert(false, "Contradiction")
+  }
+}

--- a/frontends/benchmarks/full-imperative/invalid/UnsoundReadsFrameBug.scala
+++ b/frontends/benchmarks/full-imperative/invalid/UnsoundReadsFrameBug.scala
@@ -1,0 +1,23 @@
+import stainless.lang._
+import stainless.annotation._
+
+object UnsoundReadsFrameBugExample {
+  case class Cell(var value: BigInt) extends AnyHeapRef
+
+  def onlyOne(c1: Cell, c2: Cell): BigInt = {
+    reads(Set(c1))
+    modifies(Set(c1)) // Issue was triggered by adding modifies clause (fun. sig. changed)
+    Heap.get.eval { c2.value }
+  }
+
+  def testOne(c1: Cell, c2: Cell): Unit = {
+    require(c1 != c2)
+    reads(Set(c1, c2))
+    modifies(Set(c1, c2))
+    c2.value = 1
+    // NOTE: This used to erroneously pass, because the reads-frame-condition we
+    //   assumed in the shim of onlyOne was incorrect.
+    val v1 = onlyOne(c1, c2)
+    assert(v1 == 1)
+  }
+}

--- a/frontends/benchmarks/full-imperative/valid/TreeImmutMap.scala
+++ b/frontends/benchmarks/full-imperative/valid/TreeImmutMap.scala
@@ -83,10 +83,11 @@ object TreeImmutMapExample {
           @ghost val (oldList1, oldList2) = (left.toList, right.toList)
           left.map(f)
           right.map(f)
-
           ghost {
+            assert(left.toList == oldList1.map(f))
+            assert(right.toList == oldList2.map(f))
             lemmaMapConcat(oldList1, oldList2, f)
-            check(toList == oldList.map(f))
+            assert(toList == oldList.map(f))
           }
       }
     } ensuring (_ => toList == old(toList.map(f)))

--- a/frontends/benchmarks/full-imperative/valid/TreeImmutMapGeneric.scala
+++ b/frontends/benchmarks/full-imperative/valid/TreeImmutMapGeneric.scala
@@ -57,8 +57,10 @@ object TreeImmutMapGenericExample {
           left.map(f)
           right.map(f)
           ghost {
+            assert(left.toList == oldList1.map(f))
+            assert(right.toList == oldList2.map(f))
             lemmaMapConcat(oldList1, oldList2, f)
-            check(toList == oldList.map(f))
+            assert(toList == oldList.map(f))
           }
       }
     } ensuring (_ => toList == old(toList.map(f)))

--- a/frontends/scalac/src/it/scala/stainless/verification/FullImperativeSuite.scala
+++ b/frontends/scalac/src/it/scala/stainless/verification/FullImperativeSuite.scala
@@ -28,6 +28,9 @@ class FullImperativeSuite extends ComponentTestSuite with inox.MainHelpers {
     // FIXME(gsps): Works locally, but flaky on CI
     case "full-imperative/valid/AllocatorMono" => Skip
 
+    // FIXME(gsps): Works, but slow
+    case "full-imperative/valid/TreeImmutMap" => Skip
+
     case _ => super.filter(ctx, name)
   }
 


### PR DESCRIPTION
Two distinct bugs (see commits and test cases witness issue before the changes).