### PR TITLE
Updating Inox and removing Solver reference from VCResult objects

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -275,7 +275,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 // lazy val inox = RootProject(file("../inox"))
-lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "8c70620a11d07ddd6a1a077bc692fd4625210e52")
+lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "4f7a8ef0c810d299e9b7fe134f2fa720456c3187")
 lazy val cafebabe = ghProject("https://github.com/epfl-lara/cafebabe.git", "616e639b34379e12b8ac202849de3ebbbd0848bc")
 
 // Allow integration test to use facilities from regular tests

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -29,8 +29,11 @@ trait MainHelpers extends inox.MainHelpers { self =>
     optModels -> Description(General, "Consider functions f1, f2, ... as model functions for equivalence checking"),
     extraction.utils.optDebugObjects -> Description(General, "Only print debug output for functions/adts named o1,o2,..."),
     extraction.utils.optDebugPhases -> Description(General, {
+      // f interpolator does not process escape sequence, we workaround that with the following trick.
+      // See https://github.com/lampepfl/dotty/issues/11750
+      val nl = '\n'
       "Only print debug output for phases p1,p2,...\nAvailable: " +
-      extraction.phases.map { case (name, desc) => f"\n  $name%-26s : $desc" }.mkString("")
+      extraction.phases.map { case (name, desc) => f"$nl  $name%-26s : $desc" }.mkString("")
     }),
     extraction.imperative.optFullImperative -> Description(Verification, "Use the full imperative phase. That might be unstable because it is still under development."),
     extraction.imperative.optCheckHeapContracts -> Description(Verification, "Check that heap reads and modifies clauses are valid"),

--- a/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
+++ b/core/src/main/scala/stainless/verification/VerificationAnalysis.scala
@@ -18,9 +18,8 @@ trait VerificationAnalysis extends AbstractAnalysis {
   private lazy val records = vrs map { case (vc, vr) =>
     val time = vr.time.getOrElse(0L) // TODO make time mandatory (?)
     val status = VerificationReport.Status(program)(vr.status)
-    val solverName = vr.solver map { _.name }
     val source = symbols.getFunction(vc.fid).source
-    VerificationReport.Record(vc.fid, vc.getPos, time, status, solverName, vc.kind.name, derivedFrom = source)
+    VerificationReport.Record(vc.fid, vc.getPos, time, status, vr.solverName, vc.kind.name, derivedFrom = source)
   }
 
   override val name = VerificationComponent.name

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -32,7 +32,7 @@ trait VerificationChecker { self =>
   private lazy val checkModels = options.findOptionOrDefault(optCheckModels)
 
   given givenDebugSection: DebugSectionVerification.type = DebugSectionVerification
-  
+
   type VC = verification.VC[program.trees.type]
   val VC = verification.VC
 
@@ -245,7 +245,7 @@ trait VerificationChecker { self =>
 
       val vcres = tryRes match {
         case _ if interruptManager.isInterrupted =>
-          VCResult(VCStatus.Cancelled, Some(s), Some(time))
+          VCResult(VCStatus.Cancelled, Some(s.name), Some(time))
 
         case Success(res) => res match {
           case Unknown =>
@@ -255,33 +255,33 @@ trait VerificationChecker { self =>
                 case _ => VCStatus.Unknown
               }
               case _ => VCStatus.Unknown
-            }, Some(s), Some(time))
+            }, Some(s.name), Some(time))
 
           case Unsat if !vc.satisfiability =>
-            VCResult(VCStatus.Valid, s.getResultSolver, Some(time))
+            VCResult(VCStatus.Valid, s.getResultSolver.map(_.name), Some(time))
 
           case SatWithModel(model) if checkModels && vc.kind.isInstanceOf[VCKind.AdtInvariant] =>
             val VCKind.AdtInvariant(invId) = vc.kind
             val status = checkAdtInvariantModel(vc, invId, model)
-            VCResult(status, s.getResultSolver, Some(time))
+            VCResult(status, s.getResultSolver.map(_.name), Some(time))
 
           case SatWithModel(model) if !vc.satisfiability =>
-            VCResult(VCStatus.Invalid(VCStatus.CounterExample(model)), s.getResultSolver, Some(time))
+            VCResult(VCStatus.Invalid(VCStatus.CounterExample(model)), s.getResultSolver.map(_.name), Some(time))
 
           case Sat if vc.satisfiability =>
-            VCResult(VCStatus.Valid, s.getResultSolver, Some(time))
+            VCResult(VCStatus.Valid, s.getResultSolver.map(_.name), Some(time))
 
           case Unsat if vc.satisfiability =>
-            VCResult(VCStatus.Invalid(VCStatus.Unsatisfiable), s.getResultSolver, Some(time))
+            VCResult(VCStatus.Invalid(VCStatus.Unsatisfiable), s.getResultSolver.map(_.name), Some(time))
         }
 
         case Failure(u: inox.Unsupported) =>
           reporter.warning(u.getMessage)
-          VCResult(VCStatus.Unsupported, Some(s), Some(time))
+          VCResult(VCStatus.Unsupported, Some(s.name), Some(time))
 
         case Failure(e @ NotWellFormedException(d, info)) =>
           reporter.error(d.getPos, e.getMessage)
-          VCResult(VCStatus.Crashed, Some(s), Some(time))
+          VCResult(VCStatus.Crashed, Some(s.name), Some(time))
 
         case Failure(e) => reporter.internalError(e)
       }

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -105,7 +105,7 @@ object VCStatus {
 
 case class VCResult[+Model](
   status: VCStatus[Model],
-  solver: Option[Solver],
+  solverName: Option[String],
   time: Option[Long]
 ) {
   def isValid           = status == VCStatus.Valid || isValidFromCache


### PR DESCRIPTION
The second change allows the `Solver` object to be garbage-collected while `checkVCs` is running.