### PR TITLE
Experimental test cases generation

### DIFF
--- a/core/src/main/scala/stainless/Component.scala
+++ b/core/src/main/scala/stainless/Component.scala
@@ -73,7 +73,7 @@ trait ComponentRun { self =>
 
   /* Override point for pipeline extensions in certain components.
    * For example, the partial evaluator and measure inference pipeline in the verification component. */
-  protected def createPipeline: extraction.StainlessPipeline = pipeline andThen lowering
+  def createPipeline: extraction.StainlessPipeline = pipeline andThen lowering
 
   private[this] final val extractionPipeline = createPipeline andThen extraction.completer(trees)
 

--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -20,6 +20,9 @@ trait MainHelpers extends inox.MainHelpers { self =>
   case object Pipelines extends Category
   case object Verification extends Category
   case object Termination extends Category
+  case object TestsGeneration extends Category {
+    override def toString: String = "Tests Generation"
+  }
 
   override protected def getOptions: Map[inox.OptionDef[_], Description] = super.getOptions - inox.solvers.optAssumeChecked ++ Map(
     optVersion -> Description(General, "Display the version number"),
@@ -63,7 +66,9 @@ trait MainHelpers extends inox.MainHelpers { self =>
     frontend.optKeep -> Description(General, "Keep library objects marked by @keepFor(g) for some g in g1,g2,... (implies --batched)"),
     frontend.optExtraDeps -> Description(General, "Fetch the specified extra source dependencies and add their source files to the session"),
     frontend.optExtraResolvers -> Description(General, "Extra resolvers to use to fetch extra source dependencies"),
-    utils.Caches.optCacheDir -> Description(General, "Specify the directory in which cache files should be stored")
+    utils.Caches.optCacheDir -> Description(General, "Specify the directory in which cache files should be stored"),
+    testgen.optOutputFile -> Description(TestsGeneration, "Specify the output file"),
+    testgen.optGenCIncludes -> Description(TestsGeneration, "(GenC variant only) Specify header includes"),
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)
     option -> Description(Pipelines, component.description)

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -40,7 +40,9 @@ package object frontend {
   val allComponents: Seq[Component] = Seq(
     verification.VerificationComponent,
     evaluators.EvaluatorComponent,
-    genc.GenCComponent
+    genc.GenCComponent,
+    testgen.ScalaTestGenComponent,
+    testgen.GenCTestGenComponent,
   )
 
   /**
@@ -76,8 +78,8 @@ package object frontend {
 
   private def batchSymbols(activeComponents: Seq[Component])(using ctx: inox.Context): Boolean = {
     ctx.options.findOptionOrDefault(optBatchedProgram) ||
-    activeComponents.contains(genc.GenCComponent) ||
-    !ctx.options.findOptionOrDefault(optKeep).isEmpty
+    activeComponents.exists(Set(genc.GenCComponent, testgen.ScalaTestGenComponent, testgen.GenCTestGenComponent).contains) ||
+    ctx.options.findOptionOrDefault(optKeep).nonEmpty
   }
 
 

--- a/core/src/main/scala/stainless/genc/GenerateC.scala
+++ b/core/src/main/scala/stainless/genc/GenerateC.scala
@@ -9,7 +9,10 @@ import phases._
 
 object GenerateC {
 
-  def pipeline(arrayLengthsMap: Map[Identifier, Int])(using inox.Context) =
+  def pipeline(symbols: Symbols)(using inox.Context): LeonPipeline[Symbols, CAST.Prog] = {
+    // extract lengths before `GhostElimination` erases them
+    val arrayLengthsMap = ArraysLengthsExtraction.get(symbols)
+
     NamedLeonPhase("GhostElimination", new GhostEliminationPhase) andThen
     NamedLeonPhase("TrimSymbols", new TrimSymbols) andThen
     NamedLeonPhase("ComputeFunCtx", LeonPipeline.both(NoopPhase[Symbols], new ComputeFunCtxPhase)) andThen
@@ -18,13 +21,11 @@ object GenerateC {
     NamedLeonPhase("Lifting", new LiftingPhase) andThen
     NamedLeonPhase("Referencing", new ReferencingPhase) andThen
     NamedLeonPhase("StructInlining", new StructInliningPhase) andThen
-    NamedLeonPhase("IR2C", new IR2CPhase) andThen
-    new CFileOutputPhase
+    NamedLeonPhase("IR2C", new IR2CPhase)
+  }
 
-  def run(symbols: Symbols)(using ctx: inox.Context) = {
-    // extract lengths before `GhostElimination` erases them
-    val arrayLengthsMap = ArraysLengthsExtraction.get(symbols)
-    pipeline(arrayLengthsMap).run(symbols)
+  def emit(symbols: Symbols)(using ctx: inox.Context): Unit = {
+    (pipeline(symbols) andThen new CFileOutputPhase).run(symbols)
   }
 
 }

--- a/core/src/main/scala/stainless/testgen/GenCTestGen.scala
+++ b/core/src/main/scala/stainless/testgen/GenCTestGen.scala
@@ -1,0 +1,147 @@
+package stainless
+package testgen
+
+import stainless.extraction.throwing.{trees => tt}
+import stainless.extraction.xlang.{trees => xt}
+import stainless.genc._
+import stainless.genc.phases._
+import stainless.verification._
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.{Files, OpenOption, StandardOpenOption}
+
+object GenCTestGen {
+  import stainless.trees._
+
+  def generateTestCases(origSyms: xt.Symbols)
+                       (p: inox.Program {val trees: stainless.trees.type})
+                       (res: Map[VC[p.trees.type], VCResult[p.Model]])
+                       (using ctx: inox.Context): Unit = {
+    val counterExs = res.toSeq.collect {
+      case (vc, VCResult(VCStatus.Invalid(VCStatus.CounterExample(model)), _, _)) => (vc, model)
+    }
+    if (counterExs.isEmpty) {
+      return
+    }
+
+    given XLangTestGen.TyParamSubst = XLangTestGen.TyParamSubst(
+      BVType(true, 64),
+      x =>
+        if (Long.MinValue <= x && x <= Long.MaxValue) Some(BVLiteral(true, x, 64))
+        else None)
+
+    val output = {
+      val pathStr = ctx.options.findOptionOrDefault(testgen.optOutputFile).getAbsolutePath
+      new File(pathStr.replace(".scala", ".c"))
+    }
+    val existingContent = readExistingTestBodies(output)
+
+    val testCaseNbrOffset = existingContent.map(_._1).getOrElse(0) + 1
+    val xtTestCases = counterExs.zipWithIndex.flatMap {
+      case ((vc, model), i) =>
+        given XLangTestGen.TestCaseCtx = XLangTestGen.TestCaseCtx(origSyms, p, vc)(model)
+
+        XLangTestGen.generateTestCase(i + testCaseNbrOffset).map {
+          case (faultyFd0, testCase0) =>
+            val faultyFd = faultyFd0.copy(flags = faultyFd0.flags :+ xt.Annotation("cCode.drop", Seq.empty))
+            val testCase = testCase0.copy(flags = testCase0.flags :+ xt.Annotation("cCode.export", Seq.empty))
+            (faultyFd, testCase)
+        }
+    }
+
+    val testNames: Set[String] = xtTestCases.map(_._2.id.name).toSet
+    val testCaseSyms = xt.NoSymbols
+      .withFunctions(xtTestCases.map(_._1) ++ xtTestCases.map(_._2))
+      .withClasses(origSyms.classes.values.toSeq)
+
+    val symbolsAfterPipeline: tt.Symbols = GenCRun.pipelineBegin.extract(testCaseSyms)
+    val cprog = GenerateC.pipeline(symbolsAfterPipeline).run(symbolsAfterPipeline)
+    val fnTestCases = cprog.functions.filter(f => testNames.contains(f.id.name))
+      .toSeq.sortBy(_.id.name.drop("testCase".length).toInt)
+
+    existingContent match {
+      case Some((_, existingBodies)) =>
+        val fnBodyStrMap = fnTestCases.map { fn =>
+          val str = fn.toString
+          // Only take what's inside the function:
+          //   void testCaseX(void) {  // drop
+          //      ...                  // trimmed
+          //   }                       // drop
+          val bodyStr = str.split("\n").init.tail.map(_.trim)
+          StrTestBody(bodyStr.toSeq) -> str
+        }
+        val toBeAppended = fnBodyStrMap.filter((strTestBody, _) => !existingBodies.contains(strTestBody)).map(_._2)
+        if (toBeAppended.nonEmpty) {
+          Files.write(output.toPath, ("\n\n" ++ toBeAppended.mkString("\n\n")).getBytes(StandardCharsets.UTF_8), StandardOpenOption.APPEND)
+        }
+
+      case None =>
+        val includes = ctx.options.findOptionOrDefault(testgen.optGenCIncludes)
+          .map(hd => s"""#include "$hd"""")
+          .mkString("\n")
+        val content =
+          s"""$includes
+              |
+              |${fnTestCases.mkString("\n\n")}""".stripMargin
+        Files.createDirectories(output.toPath.getParent)
+        Files.write(output.toPath, content.getBytes(StandardCharsets.UTF_8))
+    }
+  }
+
+  ////////////////////////////////////////////////
+
+  private case class StrTestBody(trimmedLines: Seq[String])
+
+  private val testCaseFnRegex = """\s*(?>STAINLESS_FUNC_PURE )?void testCase(\d+)\(void\) \{""".r
+
+  private def readExistingTestBodies(file: File): Option[(Int, Set[StrTestBody])] = {
+    def fnBodyContent(lines: IndexedSeq[String], fnStartIx: Int): Option[StrTestBody] = {
+      def go(bracesCnt: Int, lineIx: Int): Option[StrTestBody] = {
+        if (lineIx >= lines.length) {
+          // Either we do not know how to count, or the C function is ill-formed
+          None
+        } else {
+          val currLine = lines(lineIx)
+          val newCnt = currLine.foldLeft(bracesCnt) {
+            case (acc, '{') => acc + 1
+            case (acc, '}') => acc - 1
+            case (acc, _) => acc
+          }
+          if (newCnt == 0) {
+            // Note: we assume that the last '}' is on a line of its own so that we do not have to include the last line of the last '}'
+            // We also do not include the "void testCaseX(void) {" (hence the start at fnStartIx + 1)
+            Some(StrTestBody(lines.slice(fnStartIx + 1, lineIx).map(_.trim)))
+          } else {
+            go(newCnt, lineIx + 1)
+          }
+        }
+      }
+
+      go(1, fnStartIx + 1)
+    }
+
+    if (!file.exists()) {
+      None
+    } else {
+      val existingContentSrc = scala.io.Source.fromFile(file)
+      try {
+        val lines = existingContentSrc.getLines().toIndexedSeq
+        val fnLineIndices = lines.zipWithIndex.flatMap {
+          case (testCaseFnRegex(testNbr), lineIx) => Some((testNbr.toInt, lineIx))
+          case _ => None
+        }
+
+        if (fnLineIndices.isEmpty) {
+          None
+        } else {
+          val lastTestNbr = fnLineIndices.maxBy(_._1)._1
+          val existingBodies = fnLineIndices.flatMap((_, fnStartIx) => fnBodyContent(lines, fnStartIx)).toSet
+          Some((lastTestNbr, existingBodies))
+        }
+      } finally {
+        existingContentSrc.close()
+      }
+    }
+  }
+}

--- a/core/src/main/scala/stainless/testgen/GenCTestGenComponent.scala
+++ b/core/src/main/scala/stainless/testgen/GenCTestGenComponent.scala
@@ -1,0 +1,50 @@
+package stainless
+package testgen
+
+import io.circe.Json
+import stainless.extraction._
+import stainless.extraction.xlang.{trees => xt}
+import stainless.verification._
+import stainless.verification.VerificationComponent.{Analysis, Report}
+
+import scala.concurrent.Future
+
+object GenCTestGenComponent extends Component {
+  override val name = "genc-testgen"
+  override val description = "(Experimental) Attempt to create C test cases from reported counter-examples (implies --batched)"
+
+  override type Report = VerificationComponent.Report
+  override type Analysis = VerificationComponent.Analysis
+
+  override val lowering = VerificationComponent.lowering
+
+  override def run(pipeline: StainlessPipeline)(using inox.Context): GenCTestGenRun = {
+    new GenCTestGenRun(pipeline)
+  }
+}
+
+class GenCTestGenRun private(override val component: GenCTestGenComponent.type,
+                             override val trees: stainless.trees.type,
+                             override val pipeline: StainlessPipeline,
+                             val underlyingRun: VerificationRun)
+                            (using override val context: inox.Context) extends ComponentRun {
+
+  import component.{Analysis, Report}
+
+  def this(pipeline: StainlessPipeline)(using inox.Context) =
+    this(GenCTestGenComponent, stainless.trees, pipeline, new VerificationRun(pipeline))
+
+  override def createPipeline = underlyingRun.createPipeline
+
+  override def parse(json: Json): VerificationReport = underlyingRun.parse(json)
+
+  override def apply(ids: Seq[Identifier], symbols: xt.Symbols): Future[Analysis] = {
+    underlyingRun(ids, symbols).map { res =>
+      GenCTestGen.generateTestCases(symbols)(res.program)(res.results)
+      res
+    }
+  }
+
+  override private[stainless] def execute(functions: Seq[Identifier], symbols: trees.Symbols): Future[Analysis] =
+    sys.error("Unreachable because def apply was overridden")
+}

--- a/core/src/main/scala/stainless/testgen/ScalaTestGen.scala
+++ b/core/src/main/scala/stainless/testgen/ScalaTestGen.scala
@@ -1,0 +1,223 @@
+/* Copyright 2009-2022 EPFL, Lausanne */
+
+package stainless
+package testgen
+
+import stainless.extraction.xlang
+import xlang.{trees => xt}
+import stainless.verification._
+
+import java.io.File
+import java.nio.charset.StandardCharsets
+import java.nio.file.Files
+import scala.concurrent.Future
+import scala.util.matching.Regex
+
+object ScalaTestGen {
+
+  import stainless.trees._
+
+  private val testCaseFnRegex: Regex = """\s*def testCase(\d+): Unit = (.+)""".r
+  private val importsRegex: Regex = """import ((?:\w+\.)*)(?:(\w+)|\{((?:\w+\s*,\s*)*\w+)\})""".r("path", "iden", "idens")
+
+  def generateTestCases(origSyms: xt.Symbols)
+                       (p: inox.Program {val trees: stainless.trees.type})
+                       (res: Map[VC[p.trees.type], VCResult[p.Model]])
+                       (using ctx: inox.Context): Unit = {
+    val counterExs = res.toSeq.collect {
+      case (vc, VCResult(VCStatus.Invalid(VCStatus.CounterExample(model)), _, _)) => (vc, model)
+    }
+    if (counterExs.isEmpty) {
+      return
+    }
+
+    given XLangTestGen.TyParamSubst = XLangTestGen.TyParamSubst(IntegerType(), x => Some(IntegerLiteral(x)))
+
+    val output = ctx.options.findOptionOrDefault(testgen.optOutputFile)
+    val existingContent = readExistingContent(output)
+
+    val testCaseNbrOffset = existingContent.map(_.lastTextNbr).getOrElse(0) + 1
+    val xtTestCases = counterExs.zipWithIndex.flatMap {
+      case ((vc, model), i) =>
+        given XLangTestGen.TestCaseCtx = XLangTestGen.TestCaseCtx(origSyms, p, vc)(model)
+        XLangTestGen.generateTestCase(i + testCaseNbrOffset).map((_, fd) => (fd.id.name, fd.body.get))
+    }
+
+    val existingTests = existingContent.toSet.flatMap(_.testBodies)
+
+    val printer = new CustomPrinter
+    val testCases = xtTestCases.flatMap { case (name, funBody) =>
+      val pctx = xt.PrinterContext(funBody, Nil, xt.PrinterOptions().baseIndent, xt.PrinterOptions())
+      printer.pp(funBody)(using pctx)
+      val bodyStr = pctx.sb.toString
+      if (existingTests.contains(bodyStr)) None
+      else Some(s"def $name: Unit = $bodyStr")
+    }
+
+    if (testCases.isEmpty) {
+      return
+    }
+
+    val importsCollector = new ImportsCollector
+    xtTestCases.foreach((_, funBody) => importsCollector.traverse(funBody))
+    val currTestsImports = importsCollector.imports
+
+    val fileContent = existingContent match {
+      case Some(existingContent) =>
+        val allImports = existingContent.imports ++ currTestsImports
+        val lastBraceIx = existingContent.linesNoImports.zipWithIndex.reverse.find((l, _) => l.trim == "}").map(_._2)
+        lastBraceIx.map { ix =>
+          val (linesBefore, linesAfter) = existingContent.linesNoImports.splitAt(ix)
+          s"""${allImports.pretty}
+             |${linesBefore.mkString("\n")}
+             |
+             |${testCases.mkString("  ", "\n\n  ", "")}
+             |${linesAfter.mkString("\n")}""".stripMargin
+        }.getOrElse {
+          // This should not happen. If it does, to not overwrite existing content,
+          // we just append the test cases (wrapped in an object TestCases)
+          s"""${existingContent.linesNoImports.mkString("\n")}
+             |${withWrapper(allImports, testCases)}""".stripMargin
+        }
+      case None =>
+        withWrapper(baseImports ++ currTestsImports, testCases)
+    }
+
+    val outputPath = output.getAbsoluteFile.toPath
+    Files.createDirectories(outputPath.getParent)
+    Files.write(outputPath, fileContent.getBytes(StandardCharsets.UTF_8))
+  }
+
+  private case class ExistingContent(lastTextNbr: Int,
+                                     // The test case bodies, which are all on a single line
+                                     testBodies: Set[String],
+                                     imports: Imports,
+                                     // The file content, except that we have filtered out the imports
+                                     // (because we may need to add new imports)
+                                     linesNoImports: IndexedSeq[String])
+
+  private def readExistingContent(file: File): Option[ExistingContent] = {
+    if (!file.exists()) {
+      None
+    } else {
+      val existingContentSrc = scala.io.Source.fromFile(file)
+      try {
+        val lines = existingContentSrc.getLines().toIndexedSeq
+        val (testNbrs, existingTestBodies) = lines.collect {
+          case testCaseFnRegex(ix, body) => (ix.toInt, body)
+        }.unzip
+        val (existingImports, importsIxs) = parseExistingImports(lines)
+        val linesNoImports = lines.zipWithIndex.filterNot((_, ix) => importsIxs(ix)).map(_._1)
+        Some(ExistingContent(testNbrs.maxOption.getOrElse(0), existingTestBodies.toSet, existingImports, linesNoImports))
+      } finally {
+        existingContentSrc.close()
+      }
+    }
+  }
+
+  private def withWrapper(imports: Imports, tests: Seq[String]): String = {
+    s"""${imports.pretty}
+       |
+       |object TestCases {
+       |${tests.mkString("  ", "\n\n  ", "")}
+       |}""".stripMargin
+  }
+
+  private def parseExistingImports(lines: Seq[String]): (Imports, Set[Int]) = {
+    val (importss, ixs) = lines.zipWithIndex
+      .flatMap { case (line, ix) =>
+        importsRegex.findFirstMatchIn(line).flatMap { mtch =>
+          val prefixPath = Option(mtch.group("path")).toSeq
+            .flatMap(p => p.dropRight(1).split("\\."))
+          val iden = Option(mtch.group("iden"))
+          val idens = Option(mtch.group("idens"))
+          (iden, idens) match {
+            case (Some(iden), None) =>
+              // Single identifier import (possibly with a prefix path) such as `import Foo` or `import aa.bb.Foo`
+              Some(Imports(Map(Path(prefixPath) -> Set(iden))) -> ix)
+            case (None, Some(idensStr)) if prefixPath.nonEmpty =>
+              // Multiple identifier imports with a prefix path such as `import aa.bb.{Foo, Qux, cc}`
+              val idens = idensStr.split(",").map(_.trim).toSet
+              Some(Imports(Map(Path(prefixPath) -> idens)) -> ix)
+            case _ => None // Should not happen, if it does, silently ignore
+          }
+        }
+      }.unzip
+    val imports = importss.foldLeft(Imports(Map.empty))(_ ++ _)
+    (imports, ixs.toSet)
+  }
+
+  private val baseImports = Imports(Map(
+    Path(Seq("stainless")) -> Set("_"),
+    Path(Seq("stainless", "lang")) -> Set("_"),
+    Path(Seq("stainless", "collection")) -> Set("_"),
+    Path(Seq("stainless", "math")) -> Set("_"),
+    Path(Seq("stainless", "math", "BitVectors")) -> Set("_"),
+  ))
+
+  private case class Path(parts: Seq[String])
+
+  private case class Imports(imports: Map[Path, Set[String]]) {
+    def ++(other: Imports): Imports = {
+      Imports((imports.keySet ++ other.imports.keySet).foldLeft(Map.empty) {
+        case (acc, path) =>
+          val idens0 = imports.getOrElse(path, Set.empty) ++ other.imports.getOrElse(path, Set.empty)
+          val idens = if (idens0.contains("_")) Set("_") else idens0
+          acc + (path -> idens)
+      })
+    }
+
+    def pretty: String = {
+      val (withoutPrefix, withPrefix) = imports.toSeq.partition(_._1.parts.isEmpty)
+      val withoutPrefixPretty = withoutPrefix.flatMap(_._2).sorted
+      val withPrefixPretty = withPrefix
+        .sortBy { case (path, _) => (if (path.parts.head.contains("stainless")) 0 else 1, path.parts.size, path.parts.mkString(".")) }
+        .map {
+          case (path, idens) =>
+            val pathsStr = path.parts.mkString(".")
+            idens.toSeq match {
+              case Seq() => pathsStr
+              case Seq(iden) => s"${pathsStr}.$iden"
+              case idens => s"${pathsStr}.{${idens.mkString(", ")}}"
+            }
+        }
+
+      (withPrefixPretty ++ withoutPrefixPretty).mkString("import ", "\nimport ", "")
+    }
+  }
+
+  private class ImportsCollector extends xt.ConcreteOOSelfTreeTraverser {
+    var imports: Imports = Imports(Map.empty)
+
+    override def traverse(id: Identifier): Unit = id match {
+      case sid: SymbolIdentifier =>
+        assert(sid.symbol.path.nonEmpty)
+        imports ++= Imports(Map(Path(sid.symbol.path.init) -> Set(sid.symbol.path.last)))
+      case _ => ()
+    }
+  }
+
+  private class CustomPrinter(override val trees: xt.type) extends xlang.Printer {
+    def this() = this(xt)
+
+    override def ppBody(tree: xt.Tree)(using xt.PrinterContext): Unit = tree match {
+      case bv: xt.BVLiteral =>
+        val bigInt = bv.toBigInt
+        val bigIntStr = bigInt.toString
+        val litStr =
+          if (Int.MinValue <= bigInt && bigInt <= Int.MaxValue) bigIntStr
+          else if (Long.MinValue <= bigInt && bigInt <= Long.MaxValue) s"${bigIntStr}L"
+          else s"""BigInt("$bigIntStr")"""
+
+        if (bv.signed && bv.size == 8) p"$litStr.toByte"
+        else if (bv.signed && bv.size == 16) p"$litStr.toShort"
+        else if (bv.signed && bv.size == 32) p"$litStr"
+        else if (bv.signed && bv.size == 64) p"${litStr}L"
+        else {
+          val bvTypeStr = s"""${if (bv.signed) "I" else "U"}Int${bv.size}"""
+          p"$litStr: $bvTypeStr"
+        }
+      case _ => super.ppBody(tree)
+    }
+  }
+}

--- a/core/src/main/scala/stainless/testgen/ScalaTestGenComponent.scala
+++ b/core/src/main/scala/stainless/testgen/ScalaTestGenComponent.scala
@@ -1,0 +1,50 @@
+package stainless
+package testgen
+
+import io.circe.Json
+import stainless.extraction._
+import stainless.extraction.xlang.{trees => xt}
+import stainless.verification._
+import stainless.verification.VerificationComponent.{Analysis, Report}
+
+import scala.concurrent.Future
+
+object ScalaTestGenComponent extends Component {
+  override val name = "testgen"
+  override val description = "(Experimental) Attempt to create Scala test cases from reported counter-examples (implies --batched)"
+
+  override type Report = VerificationComponent.Report
+  override type Analysis = VerificationComponent.Analysis
+
+  override val lowering = VerificationComponent.lowering
+
+  override def run(pipeline: StainlessPipeline)(using inox.Context): ScalaTestGenRun = {
+    new ScalaTestGenRun(pipeline)
+  }
+}
+
+class ScalaTestGenRun private(override val component: ScalaTestGenComponent.type,
+                              override val trees: stainless.trees.type,
+                              override val pipeline: StainlessPipeline,
+                              val underlyingRun: VerificationRun)
+                             (using override val context: inox.Context) extends ComponentRun {
+
+  import component.{Analysis, Report}
+
+  def this(pipeline: StainlessPipeline)(using inox.Context) =
+    this(ScalaTestGenComponent, stainless.trees, pipeline, new VerificationRun(pipeline))
+
+  override def createPipeline = underlyingRun.createPipeline
+
+  override def parse(json: Json): VerificationReport = underlyingRun.parse(json)
+
+  override def apply(ids: Seq[Identifier], symbols: xt.Symbols): Future[Analysis] = {
+    underlyingRun(ids, symbols).map { res =>
+      ScalaTestGen.generateTestCases(symbols)(res.program)(res.results)
+      res
+    }
+  }
+
+  override private[stainless] def execute(functions: Seq[Identifier], symbols: trees.Symbols): Future[Analysis] =
+    sys.error("Unreachable because def apply was overridden")
+}

--- a/core/src/main/scala/stainless/testgen/XLangTestGen.scala
+++ b/core/src/main/scala/stainless/testgen/XLangTestGen.scala
@@ -1,0 +1,219 @@
+package stainless
+package testgen
+
+import stainless.ast.SymbolIdentifier
+import stainless.extraction.xlang.trees as xt
+import stainless.verification.*
+
+object XLangTestGen {
+  import stainless.trees._
+
+  case class TyParamSubst(numericTpe: Type, numericExprCtor: BigInt => Option[Expr])
+
+  case class TestCaseCtx(origSyms: xt.Symbols,
+                         p: inox.Program {val trees: stainless.trees.type},
+                         vc: VC[stainless.trees.type])
+                        // For some reasons, this needs to be put as val, otherwise it is inaccessible...
+                        (val cex: p.Model) {
+    // We override hashCode and equals because, for some reasons, the synthesized methods do not use `cex`
+
+    override def canEqual(that: Any): Boolean = that.isInstanceOf[TestCaseCtx]
+
+    override def equals(other: Any): Boolean = other match {
+      case that: TestCaseCtx => p == that.p && vc == that.vc && cex == that.cex
+      case _ => false
+    }
+
+    override def hashCode(): Int = java.util.Objects.hash(p, vc, cex)
+  }
+
+  case class FaultyFd(fd: FunDef)
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  // TODO: If a falsified VC is reported for the following
+  //  -local fns
+  //  -local classes
+  //  -loops
+  //  then the translation is a bit too naive (we need to call the "enclosing" function of the faulty fn,
+  //  not the faulty fn as it is inaccessible from outside)
+
+  def generateTestCase(testCaseNbr: Int)(using tyParamSubst: TyParamSubst, tcCtx: TestCaseCtx, ctx: inox.Context): Option[(xt.FunDef, xt.FunDef)] = {
+    import tcCtx._
+
+    if (cex.chooses.nonEmpty) {
+      recognizeFailure("due to the presence of 'chooses' in the model")
+      return None
+    }
+
+    val faultyFd: FunDef = {
+      try p.symbols.getFunction(vc.fid)
+      catch {
+        case _: FunctionLookupException =>
+          recognizeFailure(s"due to the inability of recovering the function definition of ${vc.fid}")
+          return None
+      }
+    }
+    given FaultyFd = FaultyFd(faultyFd)
+
+    if ((cex.vars.keys ++ faultyFd.params).exists(vd => vd.tpe match {
+      case PiType(_, _) => true
+      case _ => false
+    })) {
+      recognizeFailure("due to the presence of dependant-types")
+      return None
+    }
+
+    val vdMapping: Map[ValDef, (ValDef, Int)] = cex.vars.keySet.flatMap(cexVd =>
+      faultyFd.params.zipWithIndex.find(_._1.id.name == cexVd.id.name).map(fnVd => cexVd -> fnVd)).toMap
+    if (vdMapping.size != cex.vars.size) {
+      recognizeFailure(s"due to the inability of reconciling the variables of the model and the parameters of ${vc.fid}")
+      return None
+    }
+    if (vdMapping.keys.size != cex.vars.size) {
+      recognizeFailure(s"due to name collision with the parameters of ${vc.fid}")
+      return None
+    }
+
+    val missingMapping: Set[(ValDef, Int)] = faultyFd.params.zipWithIndex.toSet -- vdMapping.values.toSet
+    val (defaultArgsErrs, defaultArgs) = missingMapping.toSeq.partitionMap {
+      case (fnVd, pos) =>
+        val expr = tryFindDefaultValue(substTypeParams(fnVd.tpe))
+        expr.map(e => pos -> e)
+    }
+    if (defaultArgsErrs.nonEmpty) {
+      recognizeFailure(
+        s"""due to:
+           |${defaultArgsErrs.flatten.mkString("  - ", "\n", "")}""".stripMargin)
+      return None
+    }
+
+    val (cexArgsErr, cexArgs) = cex.vars.toSeq.partitionMap {
+      case (cexVd, expr) =>
+        val pos = vdMapping(cexVd)._2
+        val rewrittenExpr = tryRewriteExpr(expr)
+        rewrittenExpr.map(e => pos -> e)
+    }
+    if (cexArgsErr.nonEmpty) {
+      recognizeFailure(
+        s"""due to:
+           |${cexArgsErr.flatten.mkString("  - ", "\n", "")}""".stripMargin)
+      return None
+    }
+    val args = (defaultArgs ++ cexArgs).sortBy(_._1).map(_._2)
+
+    val testCaseBody = FunctionInvocation(vc.fid, faultyFd.tparams.map(_ => IntegerType()), args)
+    val testCaseId = SymbolIdentifier(s"testCase$testCaseNbr")
+    val testCaseFd = FunDef(testCaseId, Seq.empty, Seq.empty, UnitType(), testCaseBody, Seq.empty)
+
+    val adtToClass = new AdtToClass(origSyms)
+    val xtFaultyFdNoBody = adtToClass.transform(unlowering.transform(faultyFd.copy(fullBody = NoTree(faultyFd.returnType))))
+    val xtTestCaseFd = adtToClass.transform(unlowering.transform(testCaseFd))
+    if (adtToClass.failures.nonEmpty) {
+      val msgs = adtToClass.failures.map(adtTpe => s"  - the inability of rewriting $adtTpe into a class").mkString("\n")
+      recognizeFailure(
+        s"""due to:
+           |$msgs""".stripMargin)
+      return None
+    }
+    Some((xtFaultyFdNoBody, xtTestCaseFd))
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  def recognizeFailure(msg: String)(using tcCtx: TestCaseCtx, ctx: inox.Context): Unit = {
+    ctx.reporter.warning(tcCtx.vc.getPos,
+      s"""Could not generate a test case from the following counter-example:
+         |  ${tcCtx.cex.asString(using PrinterOptions()).replaceAll("\n", "\n  ")}
+         |$msg""".stripMargin)
+  }
+
+  def tryFindDefaultValue(tpe: Type)(using faultyFd: FaultyFd, tcCtx: TestCaseCtx, tps: TyParamSubst, ctx: inox.Context): Either[List[String], Expr] = {
+    try {
+      tryRewriteExpr(tcCtx.p.symbols.simplestValue(tpe, allowSolver = false)(using tcCtx.p.getSemantics))
+    } catch {
+      case _: tcCtx.p.symbols.NoSimpleValue => Left(s"the inability of finding a default value for $tpe" :: Nil)
+    }
+  }
+
+  def substTypeParams(tpe: Type)(using faultyFd: FaultyFd, tps: TyParamSubst): Type = {
+    val subst = new SubstTypeParamsAndGenericValues(faultyFd.fd.tparams)
+    val newTpe = subst.transform(tpe)
+    assert(subst.failures.isEmpty, "failures are impossible when substituting for types (only for Expr)")
+    newTpe
+  }
+
+  def tryRewriteExpr(expr: Expr)(using faultyFd: FaultyFd, tps: TyParamSubst): Either[List[String], Expr] = {
+    val subst = new SubstTypeParamsAndGenericValues(faultyFd.fd.tparams)
+    val newExpr = subst.transform(expr)
+    if (subst.failures.isEmpty) Right(newExpr)
+    else Left(subst.failures.map(e => s"the inability of rewriting $e"))
+  }
+
+  /////////////////////////////////////////////////////////////////////////////////////////////////
+
+  private val unlowering = new UnloweringImpl(trees, xt)
+
+  private class UnloweringImpl(override val s: trees.type, override val t: xt.type)
+    extends transformers.ConcreteTreeTransformer(s, t)
+
+
+  private class AdtToClass(val origSyms: xt.Symbols) extends xt.ConcreteOOSelfTreeTransformer {
+    var failures: List[xt.ADTType] = Nil
+
+    override def transform(tpe: xt.Type): xt.Type = tpe match {
+      case adtTpe: xt.ADTType =>
+        adtTypeToClassType(adtTpe) match {
+          case Some(ct) => ct
+          case None =>
+            failures = adtTpe :: failures
+            adtTpe
+        }
+      case _ => super.transform(tpe)
+    }
+
+    override def transform(e: xt.Expr): xt.Expr = e match {
+      case adt@xt.ADT(id, tps, args) =>
+        val adtTpe = xt.ADTType(id, tps)
+        adtTypeToClassType(adtTpe) match {
+          case Some(ct) => xt.ClassConstructor(ct, args.map(transform))
+          case None =>
+            failures = adtTpe :: failures
+            adt
+        }
+      case _ => super.transform(e)
+    }
+
+    def adtTypeToClassType(adtType: xt.ADTType): Option[xt.ClassType] = {
+      origSyms.classes.find(_._1.name == adtType.id.name)
+        .map((clsId, _) => xt.ClassType(clsId, adtType.tps.map(transform)))
+    }
+  }
+
+  private class SubstTypeParamsAndGenericValues(tparams: Seq[TypeParameterDef])
+                                               (using tyParamSubst: TyParamSubst) extends ConcreteSelfTreeTransformer {
+    var failures: List[Expr] = Nil
+
+    override def transform(tpe: Type): Type = tpe match {
+      case tp: TypeParameter if tparams.exists(_.tp.id.name == tp.id.name) => tyParamSubst.numericTpe
+      case _ => super.transform(tpe)
+    }
+
+    override def transform(expr: Expr): Expr = expr match {
+      case GenericValue(tp, id) =>
+        val newExpr = tparams.zipWithIndex
+          .find((tpDef, _) => tpDef.tp.id.name == tp.id.name)
+          .flatMap { (_, tpIx) =>
+            tyParamSubst.numericExprCtor(BigInt(id) * BigInt(tparams.size) + BigInt(tpIx))
+          }
+        newExpr match {
+          case Some(e) => e
+          case None =>
+            failures = expr :: failures
+            expr
+        }
+      case _ => super.transform(expr)
+    }
+  }
+
+}

--- a/core/src/main/scala/stainless/testgen/package.scala
+++ b/core/src/main/scala/stainless/testgen/package.scala
@@ -1,0 +1,24 @@
+package stainless
+
+import inox.OptionParsers.{OptionParser, stringParser}
+
+import java.io.File
+
+package object testgen {
+
+  object optOutputFile extends FileOptionDef {
+    val name = "testgen-file"
+    val default = new File("TestCases.scala")
+  }
+
+  object optGenCIncludes extends inox.SeqOptionDef[String] {
+    override val elementParser: OptionParser[String] = stringParser
+
+    override val name: String = "genc-testgen-includes"
+
+    override def default: Seq[String] = Seq("stainless.h")
+
+    override def usageRhs: String = "header1.h,header2.h,..."
+  }
+
+}

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -62,7 +62,7 @@ class VerificationRun private(override val component: VerificationComponent.type
 
   override def parse(json: Json): Report = VerificationReport.parse(json)
 
-  override protected def createPipeline = {
+  override def createPipeline = {
     pipeline andThen
     extraction.utils.DebugPipeline("MeasureInference", MeasureInference(extraction.trees)) andThen
     extraction.utils.DebugPipeline("PartialEvaluation", PartialEvaluation(extraction.trees))


### PR DESCRIPTION
Add two new phases that attempts in creating test cases from reported counter-examples, namely `--testgen` (outputs Scala code) and `--genc-testgen` (outputs C code)