### PR TITLE
VC checking in parallel

### DIFF
--- a/core/src/main/scala/stainless/package.scala
+++ b/core/src/main/scala/stainless/package.scala
@@ -152,9 +152,7 @@ package object stainless {
     Option(System.getProperty("parallel"))
       .flatMap(p => scala.util.Try(p.toInt).toOption)
 
-  lazy val useParallelism: Boolean =
-    (nParallel.isEmpty || nParallel.exists(_ > 1)) &&
-    !System.getProperty("os.name").toLowerCase().contains("mac")
+  lazy val useParallelism: Boolean = nParallel.isEmpty || nParallel.exists(_ > 1)
 
   private lazy val currentThreadExecutionContext: ExecutionContext =
     ExecutionContext.fromExecutor(new java.util.concurrent.Executor {


### PR DESCRIPTION
The VCs were actually not checked in parallel due to the use of `Future.successful` (eager) instead of `Future.apply` (maybe on purpose?).
It also enables parallelism back for macOS (as it seems the problem was caused by https://github.com/Z3Prover/z3/issues/1080, which is now addressed)