### PR TITLE
GenC: annotate unexported function as static

### DIFF
--- a/core/src/main/scala/stainless/genc/package.scala
+++ b/core/src/main/scala/stainless/genc/package.scala
@@ -22,10 +22,10 @@ package object genc {
   // FIXME: see leon definition
   def pathFromRoot(df: Definition)(using Symbols): List[Definition] = List(df)
 
-  // declaration mode for global variables
+  // declaration mode for *global variables*
   sealed abstract class DeclarationMode
   case object Define extends DeclarationMode // #define
-  case object Static extends DeclarationMode // static annotation
+  case object Static extends DeclarationMode // static annotation (only for variables, not functions!)
   case object Volatile extends DeclarationMode // volatile annotation
   case object External extends DeclarationMode // no declaration in the produced code
   case object Export extends DeclarationMode // print in header file


### PR DESCRIPTION
Unexported functions are only visible to the `stainless.c` translation unit. We can annotate them `static`. 
This enables C compilers to perform more optimizations: for instance, we get a ~20% speedup on the QOI encoder benchmark.