### PR TITLE
Avoid unnecessary capture of PC variables when hoisting functions

### DIFF
--- a/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
+++ b/core/src/main/scala/stainless/extraction/innerfuns/FunctionClosure.scala
@@ -169,7 +169,7 @@ class FunctionClosure(override val s: Trees, override  val t: ast.Trees)
                 // (note that this `vd` is already picked because it appears in `fdsFreeVars`).
                 exprOps.variablesOf(e)
               case Path.CloseBound(vd, e) if exprOps.variablesOf(e).intersect(fdsFreeVars).nonEmpty =>
-                // `vd` may occur in a constrain somewhere, which can also transitively constraint the FVs
+                // `vd` may occur in a constraint somewhere, which can also transitively constrain the FVs
                 Set(vd.toVariable)
               case Path.Condition(cond) =>
                 val varsCond = exprOps.variablesOf(cond)

--- a/frontends/benchmarks/verification/unchecked/NothingTypeEncoding.scala
+++ b/frontends/benchmarks/verification/unchecked/NothingTypeEncoding.scala
@@ -3,6 +3,8 @@ import stainless.lang._
 import stainless.annotation._
 import stainless.io.StdOut
 
+// Should be accepted, but is rejected
+// (see verification/valid/NothingTypeEncoding for a variant that verifies)
 object NothingTypeEncoding {
   sealed abstract class List[T]
   case class Nil[T]() extends List[T]
@@ -25,11 +27,8 @@ object NothingTypeEncoding {
   def foo[T](t: T, arg: Int): T = {
     require(arg > 0)
     if (arg == 0) {
-      def boom: Nothing = {
-        // This will capture `arg` and `boom` will get the PC arg > 0 && arg == 0 (i.e. false)
-        val pullingArgIntoThePit = arg
-        error[Nothing]("boom indeed")
-      }
+      // `boom` does not know that arg == 0 is false because it does not capture it.
+      def boom: Nothing = error[Nothing]("boom indeed")
       boom
     }
     else if (arg < 0) bar

--- a/frontends/benchmarks/verification/valid/InnerFunctions.scala
+++ b/frontends/benchmarks/verification/valid/InnerFunctions.scala
@@ -1,0 +1,65 @@
+// Testing FunctionClosure captures for PC variables
+object InnerFunctions {
+
+  def outer1(x: BigInt): Unit = {
+    require(x >= 0)
+    def inner1(): Unit = ()
+  }
+
+  def outer2(x: BigInt): Unit = {
+    val y = x
+    val z = y
+    def inner2(a: BigInt): Unit = ()
+  }
+
+  def outer3(x: BigInt, a: BigInt): Unit = {
+    require(x >= 0 && a >= x)
+    def inner3(y: BigInt): Unit = {
+      val b = a
+      assert(a >= 0)
+      assert(b >= 0)
+    }
+  }
+
+  def outer4(x: BigInt): Unit = {
+    require(x >= 0)
+    val a = x - 2
+    def inner4(y: BigInt): Unit = {
+      val b = a
+      assert(a >= -2)
+      assert(b >= -2)
+    }
+  }
+
+  def outer5(x: BigInt, y: BigInt, z: BigInt) = {
+    require(0 <= x && x <= y)
+    require(z >= 42)
+    val a = x + 1
+    def inner5A = {
+      val aa = a + 1
+      assert(aa >= 2)
+    }
+    def inner5B = {
+      val yy = y
+      assert(yy >= 0)
+    }
+  }
+
+  def outer6(x: BigInt, y: BigInt, z: BigInt) = {
+    require(0 <= x && x <= y)
+    require(z >= 42)
+    val a = x + 1
+    def inner6A = { val aa = a + 1 }
+    def inner6B = { val yy = y }
+  }
+
+  def outer7(x: BigInt): Unit = {
+    require(0 < x && x < 10)
+    val y = x
+    val z = y + 10
+    def inner7(w: BigInt): Unit = {
+      require(w < z)
+      assert(w < 20)
+    }
+  }
+}

--- a/frontends/common/src/test/scala/stainless/ast/FunctionClosureSuite.scala
+++ b/frontends/common/src/test/scala/stainless/ast/FunctionClosureSuite.scala
@@ -1,0 +1,56 @@
+/* Copyright 2009-2021 EPFL, Lausanne */
+
+package stainless
+package ast
+
+import org.scalatest.funsuite.AnyFunSuite
+
+import scala.util.control.NonFatal
+
+class FunctionClosureSuite extends AnyFunSuite with InputUtils {
+
+  val sources = List(
+    """object InnerFunctions {
+      |  def outer1(x: BigInt): Unit = {
+      |    require(x >= 0) // Introduces a condition on x but should not be captured by inner1
+      |    def inner1(): Unit = ()
+      |  }
+      |  def outer2(x: BigInt): Unit = {
+      |    val y = x // Introduces a binding but neither should be captured by inner1
+      |    val z = y // Ditto
+      |    def inner2(a: BigInt): Unit = ()
+      |  }
+      |  def outer3(x: BigInt, y: BigInt, z: BigInt) = {
+      |    require(0 <= x && x <= y)
+      |    require(z >= 42)
+      |    val a = x + 1
+      |    def inner3A = { val aa = a + 1 }
+      |    def inner3B = { val yy = y }
+      |  }
+      |} """.stripMargin,
+
+  )
+
+  val ctx: inox.Context = stainless.TestContext.empty
+  import ctx.given
+  val (_, xlangProgram) = load(sources)
+  val run = verification.VerificationComponent.run(extraction.pipeline)
+  val program = inox.Program(run.trees)(run extract xlangProgram.symbols)
+
+  import stainless.trees._
+
+  /* Mini DSL for testing purposes */
+
+  def funDef(name: String) = program.lookup[FunDef](name)
+
+  test("FunctionClosure does not close over PC variables not occurring in inner functions") {
+    val inner1 = funDef("InnerFunctions.inner1")
+    val inner2 = funDef("InnerFunctions.inner2")
+    val inner3A = funDef("InnerFunctions.inner3A")
+    val inner3B = funDef("InnerFunctions.inner3B")
+    assert(inner1.params.isEmpty)
+    assert(inner2.params.size == 1)
+    assert(inner3A.params.map(_.id.name) == Seq("x", "y"))
+    assert(inner3B.params.map(_.id.name) == Seq("x", "y"))
+  }
+}


### PR DESCRIPTION
Addresses #1259
Edit: marked as a draft as I've found some bugs (that seem to be related to not taking into account function specifications)
Edit 2: the bug I've encountered has nothing to do with this PR... so I'm going to re-ready it (I'll try to fix the big in a separate PR).