### PR TITLE
Address warnings

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -275,7 +275,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 // lazy val inox = RootProject(file("../inox"))
-lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "8b360ea16e7049f5ecfb140f001971745cf9f9ad")
+lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "1c8c0bac611ad4edc2c5b209deea9c75359d51b1")
 lazy val cafebabe = ghProject("https://github.com/epfl-lara/cafebabe.git", "616e639b34379e12b8ac202849de3ebbbd0848bc")
 
 // Allow integration test to use facilities from regular tests

--- a/core/src/main/scala/stainless/extraction/imperative/ReturnElimination.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/ReturnElimination.scala
@@ -270,11 +270,14 @@ class ReturnElimination(override val s: Trees, override val t: Trees)
                 // postcondition of the top-level function hold
                 v => t.SplitAnd.many(
                   optInvChecked.getOrElse(t.BooleanLiteral(true).copiedFrom(wh)),
-                  topLevelPost.map { case s.exprOps.Postcondition(s.Lambda(Seq(postVd), postBody)) =>
-                    t.exprOps.replaceFromSymbols(
-                      Map(simpleWhileTransformer.transform(postVd) -> v),
-                      simpleWhileTransformer.transform(postBody)
-                    )(using t.convertToVal)
+                  topLevelPost.map {
+                    case s.exprOps.Postcondition(s.Lambda(Seq(postVd), postBody)) =>
+                      t.exprOps.replaceFromSymbols(
+                        Map(simpleWhileTransformer.transform(postVd) -> v),
+                        simpleWhileTransformer.transform(postBody)
+                      )(using t.convertToVal)
+                    case s.exprOps.Postcondition(l @ s.Lambda(_, _)) =>
+                      sys.error(s"Unexpected number of params for postcondition lambda: $l")
                   }.getOrElse(t.BooleanLiteral(true)),
                 ),
                 // when the while loop terminates without returning, we check the loop condition

--- a/core/src/main/scala/stainless/extraction/inlining/ChooseInjector.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/ChooseInjector.scala
@@ -69,8 +69,11 @@ class ChooseInjector(override val s: inlining.Trees,
 
     if (context.toReplace.contains(fd.id)) {
       val choose = post
-        .map { case Postcondition(Lambda(Seq(vd), post)) =>
-          Choose(vd, freshenLocals(specced.wrapLets(post)))
+        .map {
+          case Postcondition(Lambda(Seq(vd), post)) =>
+            Choose(vd, freshenLocals(specced.wrapLets(post)))
+          case Postcondition(l @ Lambda(_, _)) =>
+            sys.error(s"Unexpected number of params for postcondition lambda: $l")
         }
         .getOrElse {
           Choose(ValDef(FreshIdentifier("res", true), fd.returnType), BooleanLiteral(true))

--- a/core/src/main/scala/stainless/extraction/inlining/FunctionSpecialization.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/FunctionSpecialization.scala
@@ -225,6 +225,8 @@ class FunctionSpecialization(override val s: Trees)(override val t: s.type)
             val cond = and(cond1, exprOps.replaceFromSymbols(Map(res2 -> res1.toVariable), cond2))
             Postcondition(Lambda(Seq(res1), cond.copiedFrom(cond2)).copiedFrom(lam2))
               .setPos(pc2.getPos)
+          case (Postcondition(l1 @ Lambda(_, _)), Postcondition(l2 @ Lambda(_, _))) =>
+            sys.error(s"Unexpected number of params for postcondition lambdas: $l1 and $l2")
         },
         mergeOptions(specced1.getSpec(PreconditionKind), speccedOuter.getSpec(PreconditionKind)) {
           case (Precondition(cond1), pc2 @ Precondition(cond2)) =>

--- a/core/src/main/scala/stainless/extraction/innerclasses/InnerClasses.scala
+++ b/core/src/main/scala/stainless/extraction/innerclasses/InnerClasses.scala
@@ -121,7 +121,6 @@ class InnerClasses(override val s: Trees, override val t: methods.Trees)
         outerRefs map {
           case ValDef(_, ct: ClassType, _) if currentClass.id == ct.id => thiss
           case ValDef(id, _, _) => ClassSelector(thiss, id)
-          case _ => sys.error("Unreachable") // To silence false positive warning
         }
       }
     }

--- a/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
+++ b/core/src/main/scala/stainless/extraction/oo/RefinementLifting.scala
@@ -218,6 +218,8 @@ class RefinementLifting(override val s: Trees, override val t: Trees)
           Some(s.Lambda(Seq(res), s.and(
               exprOps.replaceFromSymbols(Map(vd2 -> res.toVariable), pred),
               body).copiedFrom(body)).copiedFrom(post))
+        case Some(post @ s.Lambda(_, _)) =>
+          sys.error(s"Unexpected number of params for postcondition lambda: $post")
         case None =>
           Some(s.Lambda(Seq(vd2), pred).copiedFrom(fd))
       }

--- a/core/src/main/scala/stainless/termination/ChainProcessor.scala
+++ b/core/src/main/scala/stainless/termination/ChainProcessor.scala
@@ -72,8 +72,7 @@ class ChainProcessor(override val checker: ProcessingPipeline)
                 s"No measure annotated in function `${fd.id}` which was cleared in chain processor.")
           }
         })
-      case (Seq(), _, _) =>
-        None
+      case _ => None
     }
   }
 

--- a/core/src/main/scala/stainless/termination/MeasureInference.scala
+++ b/core/src/main/scala/stainless/termination/MeasureInference.scala
@@ -214,6 +214,8 @@ class MeasureInference(override val s: Trees, override val t: Trees)(using overr
           val newNBody: t.Expr = t.exprOps.replaceFromSymbols(newMap, nbody)(using t.convertToVal)
           val refinement = t.RefinementType(newVd, newNBody)
           original.copy(returnType = refinement).copiedFrom(original)
+        case Some(post@t.Lambda(_, _)) =>
+          sys.error(s"Unexpected number of params for postcondition lambda: $post")
         case None       => original
       }
     }

--- a/core/src/main/scala/stainless/transformers/PartialEvaluator.scala
+++ b/core/src/main/scala/stainless/transformers/PartialEvaluator.scala
@@ -62,6 +62,8 @@ trait PartialEvaluator extends SimplifierWithPC { self =>
               Let(res, body, Assert(post,
                 Some("Inlined postcondition of " + tfd.id.name), res.toVariable).copiedFrom(lambda)
               ).copiedFrom(body)
+            case Postcondition(lambda @ Lambda(_, _)) =>
+              sys.error(s"Unexpected number of params for postcondition lambda: $lambda")
           } .getOrElse(body)
 
           val bodyPrePost = exprOps.preconditionOf(tfd.fullBody).map { case pre =>

--- a/core/src/main/scala/stainless/verification/ChooseInjector.scala
+++ b/core/src/main/scala/stainless/verification/ChooseInjector.scala
@@ -47,8 +47,11 @@ class ChooseInjector private(val trees: ast.Trees)
 
         val newSpecced = if ((fd.flags contains Extern) || (fd.flags contains Opaque)) {
           val choose = post
-            .map { case Postcondition(Lambda(Seq(vd), post)) =>
-              Choose(vd, freshenLocals(specced.wrapLets(post)))
+            .map {
+              case Postcondition(Lambda(Seq(vd), post)) =>
+                Choose(vd, freshenLocals(specced.wrapLets(post)))
+              case Postcondition(l @ Lambda(_, _)) =>
+                sys.error(s"Unexpected number of params for postcondition lambda: $l")
             }
             .getOrElse {
               Choose(ValDef(FreshIdentifier("res", true), fd.returnType), BooleanLiteral(true))

--- a/core/src/main/scala/stainless/verification/CoqEncoder.scala
+++ b/core/src/main/scala/stainless/verification/CoqEncoder.scala
@@ -454,6 +454,8 @@ trait CoqEncoder {
         case None => transformType(fd.returnType)
         case Some(Lambda(Seq(vd), post)) =>
           Refinement(makeFresh(vd.id), transformType(vd.tpe), transformTree(post) === trueBoolean)
+        case Some(l @ Lambda(_, _)) =>
+          sys.error(s"Unexpected number of params for postcondition lambda: $l")
       }
       val allParams = tparams ++ params ++ preconditionParam
       val tmp = if (fd.isRecursive) {

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -281,6 +281,8 @@ trait VerificationChecker { self =>
 
           case Unsat if vc.satisfiability =>
             VCResult(VCStatus.Invalid(VCStatus.Unsatisfiable), s.getResultSolver.map(_.name), Some(time))
+
+          case _ => sys.error(s"Unreachable: $res")
         }
 
         case Failure(u: inox.Unsupported) =>

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ScalaCompiler.scala
@@ -98,8 +98,8 @@ class ScalaCompiler(settings: NSCSettings, val ctx: inox.Context, val callback: 
      with Positions { self =>
 
   // Normally, we would initialize the fields with early-initializer. Since this feature has been dropped in Scala 3,
-  // we work-around that by definining a dummy class overriding all members.
-  // This ensure that these fields are correctly initialized
+  // we work-around that by defining a dummy class overriding all members.
+  // This ensure that these fields are correctly initialized.
   class StainlessExtractionImpl(override val global: self.type,
                                 override val phaseName: String,
                                 override val runsAfter: List[String],


### PR DESCRIPTION
The only remaining warnings are those stemming from the `scalac` frontend, which uses general type projection due to the Scala 2 compiler relying on them.