### PR TITLE
Fix #1321

### DIFF
--- a/core/src/main/scala/stainless/verification/TypeCheckerUtils.scala
+++ b/core/src/main/scala/stainless/verification/TypeCheckerUtils.scala
@@ -152,6 +152,15 @@ object TypeCheckerUtils {
     case _ => t
   }
 
+  def retypeVariables(vars: Map[Variable, Type], expr: Expr): Expr = {
+    if (vars.isEmpty) return expr
+
+    new ConcreteStainlessSelfTreeTransformer {
+      override def transform(vd: ValDef): ValDef =
+        vars.get(vd.toVariable).map(tp => vd.copy(tpe = tp)).getOrElse(vd)
+    }.transform(expr)
+  }
+
   def pp(v: Variable)(using PrinterOptions): String = v.tpe match {
     case Truth(e) => e.asString
     case _ => v.asString + ": " + v.tpe.asString

--- a/frontends/benchmarks/verification/valid/i1321a.scala
+++ b/frontends/benchmarks/verification/valid/i1321a.scala
@@ -1,0 +1,36 @@
+object i1321a {
+  sealed abstract class List[+A] {
+    def map[B](f: A => B): List[B] = this match {
+      case Nil => Nil
+      case Cons(a, as) => Cons(f(a), as.map(f))
+    }
+  }
+  case object Nil extends List[Nothing]
+  case class Cons[+A](head: A, tail: List[A]) extends List[A]
+
+  trait MyInt {
+    def x: BigInt
+  }
+
+  final case class PosInt(v: BigInt) extends MyInt {
+    require(0 <= v)
+    def x = v
+  }
+
+  def applyTwice[A](xs: List[A], f: A => A): List[A] =
+    xs.map(f).map(f)
+
+  def getPos(n: BigInt): List[PosInt] = {
+    require(0 <= n)
+    if (n <= 0) Nil
+    else Cons(PosInt(n), getPos(n-1))
+  }
+
+  def onlyPos(x: PosInt): PosInt =
+    PosInt(x.v + 1)
+
+  def work(n: BigInt) = {
+    require(0 <= n)
+    applyTwice[PosInt](getPos(n), xyz => onlyPos(xyz))
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1321b.scala
+++ b/frontends/benchmarks/verification/valid/i1321b.scala
@@ -1,0 +1,15 @@
+object i1321b {
+  trait MyInt {
+    def x: BigInt
+  }
+  final case class PosInt(v: BigInt) extends MyInt {
+    def x = v
+  }
+
+  def onlyPos(x: PosInt): PosInt =
+    PosInt(x.v + 1)
+
+  def forget[A](f: A => A): Unit = ()
+
+  def work() = forget[PosInt](xyz => onlyPos(xyz))
+}


### PR DESCRIPTION
#1321 root cause is due to having the lambda parameter `x` be typed differently.
In the body of the lambda, `x` has a plain type (non-refined). The lambda function type, however, has parameter type refined. The fix is to replace all occurrences of `x: MySimpleType` with `x: MyRefinedType`.