### PR TITLE
Fix #731

### DIFF
--- a/frontends/benchmarks/termination/valid/i731a.scala
+++ b/frontends/benchmarks/termination/valid/i731a.scala
@@ -1,0 +1,13 @@
+import stainless.collection._
+
+object i731a {
+  def f(l: List[(BigInt, BigInt, BigInt)]): Unit = {
+    require(l.forall { case (_, _, c) => true })
+
+    if (!l.isEmpty)
+      f(l.tail)
+
+  } ensuring { _ =>
+    l.map { case (token, _, identity) => token -> identity }.forall(_ => true)
+  }
+}


### PR DESCRIPTION
In #731, in `forall`, we call the predicate `p` on the head of the list `h`.
In `f`, `p` may either be `{ case (_, _, c) => true }: (BigInt, BigInt, BigInt) => Boolean` (from the `require`) or `_ => true`: `(BigInt, BigInt) => Boolean` (from the ensuring).
As for `h`, it may either be "External" (from coming from `l`) or `(token, identity)` from the `require`.
If I'm not mistaken, it seems we are doing a product of all possible applications. 
However, applying `{ case (_, _, c) => true }` to `(token, identity)` is ill-formed and can never happen.
This PR makes sure we rule out impossible applications by checking the lambda and candidate arguments types.