### PR TITLE
Temporarily remove failing tests

### DIFF
--- a/.larabot.conf
+++ b/.larabot.conf
@@ -12,8 +12,6 @@ nightly {
     "bash bin/external-tests.sh --only-dotty"
     "sbt -batch scripted"
     "bash bin/build-slc-lib.sh"
-    "bash -c \"frontends/scalac/target/universal/stage/bin/stainless-scalac --coq frontends/benchmarks/coq/*.scala\""
-    "bash -c \"frontends/dotty/target/universal/stage/bin/stainless-dotty --coq frontends/benchmarks/coq/*.scala\""
   ]
 }
 


### PR DESCRIPTION
The larabot is apparently running these two removed tests under JDK8 while Stainless and its dependencies are compiled against JDK17