### PR TITLE
Fix #1332

### DIFF
--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -32,6 +32,11 @@ case class VC[T <: ast.Trees](val trees: T)(val condition: trees.Expr, val fid: 
 sealed abstract class VCKind(val name: String, val abbrv: String) {
   override def toString = name
   def underlying = this
+
+  def isMeasureRelated: Boolean = this match {
+    case VCKind.MeasureDecreases | VCKind.MeasurePositive | VCKind.MeasureMissing => true
+    case _ => false
+  }
 }
 
 object VCKind {

--- a/frontends/benchmarks/termination/looping/i1332a.scala
+++ b/frontends/benchmarks/termination/looping/i1332a.scala
@@ -1,0 +1,13 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+object i1332a {
+  @inlineOnce
+  def looping_f(i: BigInt): BigInt = {
+    require(i >= 0)
+    decreases(i)
+    val x = looping_f(looping_f(i) - i - 1)
+    x + 1
+  }.ensuring(_ == i + 1)
+}

--- a/frontends/benchmarks/termination/looping/i1332b.scala
+++ b/frontends/benchmarks/termination/looping/i1332b.scala
@@ -1,0 +1,14 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+object i1332b {
+  @opaque
+  @inlineOnce
+  def looping_f(i: BigInt): BigInt = {
+    require(i >= 0)
+    decreases(i)
+    val x = looping_f(looping_f(i) - i - 1)
+    x + 1
+  }.ensuring(_ == i + 1)
+}

--- a/frontends/benchmarks/termination/looping/i1332c.scala
+++ b/frontends/benchmarks/termination/looping/i1332c.scala
@@ -1,0 +1,12 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+object i1332c {
+  @inlineOnce
+  def looping_g(i: BigInt): BigInt = {
+    require(i >= 0)
+    decreases(i)
+    looping_g(i)
+  }
+}

--- a/frontends/benchmarks/termination/looping/i1332d.scala
+++ b/frontends/benchmarks/termination/looping/i1332d.scala
@@ -1,0 +1,13 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+object i1332d {
+  @opaque
+  @inlineOnce
+  def looping_g(i: BigInt): BigInt = {
+    require(i >= 0)
+    decreases(i)
+    looping_g(i)
+  }
+}

--- a/frontends/benchmarks/termination/looping/i1332e.scala
+++ b/frontends/benchmarks/termination/looping/i1332e.scala
@@ -1,0 +1,29 @@
+import stainless._
+import stainless.collection._
+import stainless.proof._
+import stainless.lang._
+import stainless.annotation._
+
+object i1332e {
+
+  @pure
+  def upd(arr: Array[BigInt], i: Int): (Array[BigInt], Int) = {
+    require(0 <= i && i < arr.length - 10)
+    (freshCopy(arr).updated(i, 1234), 1234)
+  }
+
+  @inlineOnce
+  def looping_app(arr: Array[BigInt], i: Int): Unit = {
+    decreases(i)
+    require(0 <= i && i < arr.length - 10)
+    val (arr2, x) = upd(arr, i)
+
+    {
+      if (i == 0) ()
+      else {
+        val (arr3, xyz) = upd(arr2, i)
+        looping_app(arr3, 1 + i - 1)
+      }
+    }.ensuring { _ => i < arr.length }
+  }
+}

--- a/frontends/common/src/it/scala/stainless/termination/TerminationSuite.scala
+++ b/frontends/common/src/it/scala/stainless/termination/TerminationSuite.scala
@@ -26,6 +26,11 @@ class TerminationSuite extends VerificationComponentTestSuite {
     "solver=" + options.findOptionOrDefault(inox.optSelectedSolvers).head
   }
 
+  override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
+    case "verification/valid/BitsTricksSlow" => Skip
+    case _ => super.filter(ctx, name)
+  }
+
   def getResults(analysis: VerificationAnalysis) = {
     import analysis.program.symbols
     import analysis.program.trees._


### PR DESCRIPTION
Closes #1332
This PR addresses the issue by not ignoring measure VCs even inside `DropVCs` expressions, as discussed with @vkuncak 