### PR TITLE
Some clean-up and update Inox

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -86,10 +86,8 @@ lazy val commonSettings: Seq[Setting[_]] = artifactSettings ++ Seq(
     "-feature"
   ),
 
-  resolvers ++= Seq(
-    Resolver.sonatypeRepo("releases").withAllowInsecureProtocol(true),
-    ("uuverifiers" at "http://logicrunch.research.it.uu.se/maven").withAllowInsecureProtocol(true),
-  ),
+  resolvers ++= Resolver.sonatypeOssRepos("releases"),
+  resolvers += ("uuverifiers" at "http://logicrunch.research.it.uu.se/maven").withAllowInsecureProtocol(true),
 
   libraryDependencies ++= Seq(
     // "ch.epfl.lara"    %% "inox"          % inoxVersion,
@@ -275,7 +273,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 // lazy val inox = RootProject(file("../inox"))
-lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "3964bcb6be5581d95ad88521e53141b1bef7564b")
+lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "66a2241a95fa3cb7b4d01bbdcd63faf062a61403")
 lazy val cafebabe = ghProject("https://github.com/epfl-lara/cafebabe.git", "616e639b34379e12b8ac202849de3ebbbd0848bc")
 
 // Allow integration test to use facilities from regular tests

--- a/core/src/main/scala/stainless/Report.scala
+++ b/core/src/main/scala/stainless/Report.scala
@@ -9,12 +9,13 @@ import io.circe.syntax.*
 import stainless.extraction._
 import stainless.utils.JsonConvertions.given
 
-case class ReportStats(total: Int, time: Long, valid: Int, validFromCache: Int, invalid: Int, unknown: Int) {
+case class ReportStats(total: Int, time: Long, valid: Int, validFromCache: Int, trivial: Int, invalid: Int, unknown: Int) {
   def +(more: ReportStats) = ReportStats(
     total + more.total,
     time + more.time,
     valid + more.valid,
     validFromCache + more.validFromCache,
+    trivial + more.trivial,
     invalid + more.invalid,
     unknown + more.unknown
   )
@@ -121,7 +122,7 @@ trait AbstractReport[SelfType <: AbstractReport[SelfType]] { self: SelfType =>
 
     val footer =
       f"total: ${stats.total}%-4d " +
-      f"valid: ${stats.valid}%-4d (${stats.validFromCache} from cache) " +
+      f"valid: ${stats.valid}%-4d (${stats.validFromCache} from cache, ${stats.trivial} trivial) " +
       f"invalid: ${stats.invalid}%-4d " +
       f"unknown: ${stats.unknown}%-4d " +
       f"time: ${stats.time/1000d}%7.2f"
@@ -337,7 +338,7 @@ class NoReport extends AbstractReport[NoReport] { // can't do this CRTP with obj
   override val emitJson = Json.arr()
   override val annotatedRows = Seq.empty
   override val extractionSummary = ExtractionSummary.NoSummary
-  override val stats = ReportStats(0, 0, 0, 0, 0, 0)
+  override val stats = ReportStats(0, 0, 0, 0, 0, 0, 0)
   override def filter(ids: Set[Identifier]) = this
   override def ~(other: NoReport) = this
 }

--- a/core/src/main/scala/stainless/evaluators/EvaluatorReport.scala
+++ b/core/src/main/scala/stainless/evaluators/EvaluatorReport.scala
@@ -65,7 +65,7 @@ class EvaluatorReport(val results: Seq[EvaluatorReport.Record], val sources: Set
   private lazy val totalInvalid = results.size - totalValid
 
   override lazy val stats =
-    ReportStats(results.size, totalTime, totalValid, validFromCache = 0, totalInvalid, unknown = 0)
+    ReportStats(results.size, totalTime, totalValid, validFromCache = 0, trivial = 0, totalInvalid, unknown = 0)
 
   private def levelOf(status: Status) = status match {
     case PostHeld(_) | NoPost(_) => Level.Normal

--- a/core/src/main/scala/stainless/frontend/StainlessReports.scala
+++ b/core/src/main/scala/stainless/frontend/StainlessReports.scala
@@ -39,6 +39,7 @@ trait StainlessReports {
         reportStats.map(_.time          ).sum,
         reportStats.map(_.valid         ).sum,
         reportStats.map(_.validFromCache).sum,
+        reportStats.map(_.trivial       ).sum,
         reportStats.map(_.invalid       ).sum,
         reportStats.map(_.unknown       ).sum)
     }

--- a/core/src/main/scala/stainless/genc/GenCComponent.scala
+++ b/core/src/main/scala/stainless/genc/GenCComponent.scala
@@ -144,5 +144,5 @@ case class GenCReport(results: Seq[Record], sources: Set[Identifier], override v
   private lazy val totalInvalid = results.size - totalValid
 
   override lazy val stats =
-    ReportStats(results.size, totalTime, totalValid, validFromCache = 0, totalInvalid, unknown = 0)
+    ReportStats(results.size, totalTime, totalValid, validFromCache = 0, trivial = 0, totalInvalid, unknown = 0)
 }

--- a/core/src/main/scala/stainless/termination/MeasureInference.scala
+++ b/core/src/main/scala/stainless/termination/MeasureInference.scala
@@ -234,7 +234,6 @@ class MeasureInference(override val s: Trees, override val t: Trees)(using overr
       sortCache.cached(sort, context)(extractSort(context, sort))
     }.toSeq.unzip
 
-    // fnsSummaries and sortSummaries are
     (t.NoSymbols.withSorts(sorts).withFunctions(functions ++ sizeFunctions), AllSummaries(fnsSummaries, sortSummaries))
   }
 }

--- a/core/src/main/scala/stainless/termination/TerminationReport.scala
+++ b/core/src/main/scala/stainless/termination/TerminationReport.scala
@@ -78,6 +78,6 @@ class TerminationReport(val results: Seq[TerminationReport.Record], val sources:
   }
 
   override lazy val stats =
-    ReportStats(results.size, 0L, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
+    ReportStats(results.size, 0L, totalValid, totalValidFromCache, trivial = 0, totalInvalid, totalUnknown)
 
 }

--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -276,19 +276,18 @@ trait VerificationChecker { self =>
 
   protected def checkVC(vc: VC, origVC: VC, sf: SolverFactory { val program: self.program.type }): VCResult = {
     import SolverResponses._
+
+    val cond = vc.condition
+    if (cond == BooleanLiteral(true)) {
+      return VCResult(VCStatus.Trivial, None, None)
+    }
+
     val s = sf.getNewSolver()
-
     try {
-      val cond = vc.condition
-
       reporter.synchronized {
         reporter.debug(s" - Now solving '${vc.kind}' VC for ${vc.fid.asString} @${vc.getPos}...")
         debugVC(vc, origVC)
         reporter.debug("Solving with: " + s.name)
-      }
-
-      if (cond == BooleanLiteral(true)) {
-        return VCResult(VCStatus.Valid, Some("(trivial)"), Some(0)) // TODO: No, (trivial) is bad, replace it None and have VCStatus.Trival
       }
 
       val (time, tryRes) = timers.verification.runAndGetTime {

--- a/core/src/main/scala/stainless/verification/VerificationComponent.scala
+++ b/core/src/main/scala/stainless/verification/VerificationComponent.scala
@@ -118,7 +118,6 @@ class VerificationRun private(override val component: VerificationComponent.type
       if (!functions.isEmpty) {
         reporter.debug(s"Finished generating VCs")
       }
-      // TODO: Faire comme extraction pipeline pour que l'on puisse obtenir les @extern
       val opaqueEncoder = inox.transformers.ProgramEncoder(vcGenEncoder.targetProgram)(OpaqueChooseInjector(vcGenEncoder.targetProgram))
       val res: Future[Map[VC[p.trees.type], VCResult[p.Model]]] =
         if (context.options.findOptionOrDefault(optAdmitVCs)) {

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -100,6 +100,7 @@ object VCStatus {
   case object Valid extends VCStatus[Nothing]("valid")
   case object Admitted extends VCStatus[Nothing]("admitted")
   case object ValidFromCache extends VCStatus[Nothing]("valid from cache")
+  case object Trivial extends VCStatus[Nothing]("trivial")
   case object Unknown extends VCStatus[Nothing]("unknown")
   case object Timeout extends VCStatus[Nothing]("timeout")
   case object Cancelled extends VCStatus[Nothing]("cancelled")
@@ -113,8 +114,9 @@ case class VCResult[+Model](
   solverName: Option[String],
   time: Option[Long]
 ) {
-  def isValid           = status == VCStatus.Valid || isValidFromCache
+  def isValid           = status == VCStatus.Valid || isValidFromCache || isTrivial
   def isValidFromCache  = status == VCStatus.ValidFromCache
+  def isTrivial         = status == VCStatus.Trivial
   def isAdmitted        = status == VCStatus.Admitted
   def isInvalid         = status.isInstanceOf[VCStatus.Invalid[_]]
   def isInconclusive    = !isValid && !isInvalid

--- a/core/src/main/scala/stainless/verification/VerificationReport.scala
+++ b/core/src/main/scala/stainless/verification/VerificationReport.scala
@@ -19,8 +19,9 @@ object VerificationReport {
    * inconclusive status mapped to [[Inconclusive]].
    */
   sealed abstract class Status(val name: String) {
-    def isValid = this == Status.Valid || isValidFromCache
+    def isValid = this == Status.Valid || isValidFromCache || isTrivial
     def isValidFromCache = this == Status.ValidFromCache
+    def isTrivial = this == Status.Trivial
     def isInvalid = this.isInstanceOf[Status.Invalid]
     def isInconclusive = this.isInstanceOf[Status.Inconclusive]
   }
@@ -28,6 +29,7 @@ object VerificationReport {
   object Status {
     case object Valid extends Status("valid")
     case object ValidFromCache extends Status("valid from cache")
+    case object Trivial extends Status("trivial")
     case class Inconclusive(reason: String) extends Status(reason)
     case class Invalid(reason: String) extends Status("invalid")
 
@@ -38,6 +40,7 @@ object VerificationReport {
       case VCStatus.Invalid(VCStatus.Unsatisfiable) => Invalid("unsatisfiable")
       case VCStatus.Valid => Valid
       case VCStatus.ValidFromCache => ValidFromCache
+      case VCStatus.Trivial => Trivial
       case inconclusive => Inconclusive(inconclusive.name)
     }
   }
@@ -74,6 +77,7 @@ class VerificationReport(val results: Seq[VerificationReport.Record], val source
   lazy val totalTime = results.map(_.time).sum
   lazy val totalValid = results.count(_.status.isValid)
   lazy val totalValidFromCache = results.count(_.status.isValidFromCache)
+  lazy val totalTrivial = results.count(_.status.isTrivial)
   lazy val totalInvalid = results.count(_.status.isInvalid)
   lazy val totalUnknown = results.count(_.status.isInconclusive)
 
@@ -96,7 +100,7 @@ class VerificationReport(val results: Seq[VerificationReport.Record], val source
   }
 
   override lazy val stats =
-    ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalInvalid, totalUnknown)
+    ReportStats(totalConditions, totalTime, totalValid, totalValidFromCache, totalTrivial, totalInvalid, totalUnknown)
 
 }
 


### PR DESCRIPTION
* ~~Change measure inference timeout from n / 100 to n / 2 where n is the global verification timeout~~ 
Reverted, because it is not always appropriate (e.g. breaks `TerminationSuite`) 
* Some clean-up