### PR TITLE
Update `scalac` frontend to 2.13.10

### DIFF
--- a/bin/package-sbt-plugin.sh
+++ b/bin/package-sbt-plugin.sh
@@ -46,7 +46,7 @@ info "$(tput bold)[] Preparing Stainless library jar..."
 OUT_LIB_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-library_2.13/$STAINLESS_VERSION"
 mkdir -p "$OUT_LIB_DIR"
 cp "$PUBLISHED_LIB_DIR/srcs/stainless-library_2.13-sources.jar" "$OUT_LIB_DIR/stainless-library_2.13-$STAINLESS_VERSION-sources.jar"
-cp "$PUBLISHED_LIB_DIR/poms/stainless-library_2.13.pom" "$OUT_LIB_DIR/stainless-library_2.13-$STAINLESS_VERSION-sources.pom"
+cp "$PUBLISHED_LIB_DIR/poms/stainless-library_2.13.pom" "$OUT_LIB_DIR/stainless-library_2.13-$STAINLESS_VERSION.pom"
 
 info "$(tput bold)[] Preparing Dotty plugin jar..."
 OUT_DOTTY_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-dotty-plugin_3.2.0/$STAINLESS_VERSION"

--- a/build.sbt
+++ b/build.sbt
@@ -37,10 +37,10 @@ lazy val nTestParallelism = {
 
 // The Scala version with which Stainless is compiled.
 val stainlessScalaVersion = "3.2.0"
-// Stainless supports Scala 2.13 and Scala 3.0 programs.
-val frontendScalacVersion = "2.13.6"
+// Stainless supports Scala 2.13 and Scala 3.2 programs.
+val frontendScalacVersion = "2.13.10"
 val frontendDottyVersion = stainlessScalaVersion
-// The Stainless libraries use Scala 2.13, but they are compatible with Scala 3.0 as well.
+// The Stainless libraries use Scala 2.13, but they are compatible with Scala 3.2 as well.
 val stainlessLibScalaVersion = frontendScalacVersion
 
 scalaVersion := stainlessScalaVersion


### PR DESCRIPTION
This is necessary to have the `scalac` standalone work. Otherwise, it will not be able to read 3.2 Tasty file stemming from the Stainless library (which must not be removed).