### PR TITLE
Do not use description to name error variables

### DIFF
--- a/core/src/main/scala/stainless/solvers/InoxEncoder.scala
+++ b/core/src/main/scala/stainless/solvers/InoxEncoder.scala
@@ -102,9 +102,9 @@ private class TreeEncoder[Prog <: Program](val sourceProgram: Prog)
           t.BooleanLiteral(true).copiedFrom(e)
         ).copiedFrom(e)
 
-      case s.Error(tpe, desc) =>
+      case s.Error(tpe, _) =>
         t.Choose(
-          t.ValDef(FreshIdentifier("error: " + desc, true), transform(tpe)).copiedFrom(e),
+          t.ValDef(FreshIdentifier("err", true), transform(tpe)).copiedFrom(e),
           t.BooleanLiteral(true).copiedFrom(e)
         ).copiedFrom(e)
 


### PR DESCRIPTION
In some circumstances (which I could not minimize sadly), this could lead to ill-formed SMT queries which for some reasons Z3 can handle but not CVC4.