### PR TITLE
Some improvements to OL and OCBSL based simplifiers

### DIFF
--- a/core/src/main/scala/stainless/transformers/lattices/Definitions.scala
+++ b/core/src/main/scala/stainless/transformers/lattices/Definitions.scala
@@ -170,6 +170,11 @@ trait Definitions {
       case _ => false
     }
 
+    def isIfExpr: Boolean = this match {
+      case IfExpr => true
+      case _ => false
+    }
+
     lazy val hc: Int = java.util.Objects.hash(this.ordinal)
     override def hashCode(): Int = hc
   }
@@ -177,6 +182,8 @@ trait Definitions {
     type AssumeLike = Label.Assume.type | Label.Assert.type | Label.Require.type | Label.Decreases.type
 
     type LambdaLike = Label.Lambda | Label.Choose | Label.Forall
+
+    type Rel = Label.Equals.type | Label.GreaterEquals.type | Label.GreaterThan.type | Label.LessEquals.type | Label.LessThan.type
 
     object LambdaLike {
       def unapply(l: LambdaLike): Seq[VarId] = l match {


### PR DESCRIPTION
- Add further simplification rules, such as `(if(b) T else E) == A` ~> `if(b) T == A else E == A` also for `<` `<=` etc (without duplicating `A` of course)
- Try to keep the memory consumption in-check