### PR TITLE
Fix #1379

### DIFF
--- a/core/src/main/scala/stainless/ast/TypeOps.scala
+++ b/core/src/main/scala/stainless/ast/TypeOps.scala
@@ -61,11 +61,10 @@ trait TypeOps extends inox.ast.TypeOps {
               unapplyAccessorResultType(get, unapp.returnType).exists {
                 case TupleType(tps) =>
                   tps.size == subs.size &&
-                  ((tps zip subs) forall (patternIsTyped(_, _)).tupled)
+                  ((tps zip subs) forall patternIsTyped.tupled)
                 case tpe if subs.size == 1 =>
                   patternIsTyped(tpe, subs.head)
-                case UnitType() if subs.isEmpty => true
-                case _ => false
+                case _ => subs.isEmpty
               }
             }
         }

--- a/frontends/benchmarks/verification/invalid/i1379a.scala
+++ b/frontends/benchmarks/verification/invalid/i1379a.scala
@@ -1,0 +1,19 @@
+object i1379a {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  case object MyNone extends MyOption[Nothing]
+
+  trait Animal
+  case class Cow(id: BigInt) extends Animal
+
+  def smth(an: MyOption[Animal]): BigInt = an match {
+    case MyNone => 0
+    case MySome(c: Cow) => 41
+    case MySome(animal) => 42
+    case _ => 1
+  }
+
+  def test(animal: Animal): Unit = {
+    assert(smth(MyNone) != 0)
+  }
+}

--- a/frontends/benchmarks/verification/invalid/i1379b.scala
+++ b/frontends/benchmarks/verification/invalid/i1379b.scala
@@ -1,0 +1,17 @@
+object i1379b {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  case class MyDefault(x: BigInt) extends MyOption[Nothing]
+
+  trait Animal
+  case class Cow(id: BigInt) extends Animal
+
+  def smth(an: MyOption[Animal]): BigInt = an match {
+    case MyDefault(xyz) => xyz
+    case MySome(_) => 42
+  }
+
+  def test(a: Animal): Unit = {
+    assert(smth(MyDefault(43)) != 43)
+  }
+}

--- a/frontends/benchmarks/verification/invalid/i1379c.scala
+++ b/frontends/benchmarks/verification/invalid/i1379c.scala
@@ -1,0 +1,25 @@
+object i1379c {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  sealed abstract class MyDefault[+T] extends MyOption[T] {
+    def a: T
+    def b: T
+  }
+  case class MyBiggerDefault[+T](a: T, b: T, c: T) extends MyDefault[T]
+  case class MySimpleDefault[+T](a: T, b: T) extends MyDefault[T]
+
+  trait Animal {
+    def id: BigInt
+  }
+  case class Cow(id: BigInt) extends Animal
+
+  def smth(an: MyOption[Animal]): BigInt = an match {
+    case MyBiggerDefault(a, b, c) => a.id + b.id + c.id
+    case MySimpleDefault(a, b) => a.id + b.id
+    case MySome(_) => 42
+  }
+
+  def test(a: Animal): Unit = {
+    assert(smth(MyBiggerDefault(Cow(42), a, Cow(44))) != 86 + a.id)
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1379a.scala
+++ b/frontends/benchmarks/verification/valid/i1379a.scala
@@ -1,0 +1,24 @@
+object i1379a {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  case object MyNone extends MyOption[Nothing]
+
+  trait Animal
+  case class Cow(id: BigInt) extends Animal
+
+  def smth(an: MyOption[Animal]): BigInt = an match {
+    case MyNone => 0
+    case MySome(c: Cow) => 41
+    case MySome(animal) => 42
+    case _ => 0
+  }
+
+  def test(animal: Animal): Unit = {
+    assert(smth(MyNone) == 0)
+    assert(smth(MySome(Cow(1))) == 41)
+    assert(animal match {
+      case c: Cow => smth(MySome(animal)) == 41
+      case _ => smth(MySome(animal)) == 42
+    })
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1379b.scala
+++ b/frontends/benchmarks/verification/valid/i1379b.scala
@@ -1,0 +1,18 @@
+object i1379b {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  case class MyDefault(x: BigInt) extends MyOption[Nothing]
+
+  trait Animal
+  case class Cow(id: BigInt) extends Animal
+
+  def smth(an: MyOption[Animal]): BigInt = an match {
+    case MyDefault(xyz) => xyz
+    case MySome(_) => 42
+  }
+
+  def test(a: Animal): Unit = {
+    assert(smth(MyDefault(43)) == 43)
+    assert(smth(MySome(a)) == 42)
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1379c.scala
+++ b/frontends/benchmarks/verification/valid/i1379c.scala
@@ -1,0 +1,18 @@
+object i1379c {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  case class MyDefault(a: BigInt, b: BigInt) extends MyOption[Nothing]
+
+  trait Animal
+  case class Cow(id: BigInt) extends Animal
+
+  def smth(an: MyOption[Animal]): BigInt = an match {
+    case MyDefault(a, b) => a + b
+    case MySome(_) => 42
+  }
+
+  def test(a: Animal): Unit = {
+    assert(smth(MyDefault(42, 43)) == 85)
+    assert(smth(MySome(a)) == 42)
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1379d.scala
+++ b/frontends/benchmarks/verification/valid/i1379d.scala
@@ -1,0 +1,55 @@
+object i1379d {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  case class MyDefault[+T](a: T, b: T) extends MyOption[T]
+
+  trait Animal {
+    def id: BigInt
+  }
+  case class Cow(id: BigInt) extends Animal
+
+  def smth1(an: MyOption[Animal]): BigInt = an match {
+    case MyDefault(a, b) => a.id + b.id
+    case MySome(_) => 42
+    case _ => 123
+  }
+
+  def test1(a: Animal): Unit = {
+    assert(smth1(MyDefault(Cow(42), Cow(43))) == 85)
+    assert(smth1(MySome(a)) == 42)
+  }
+
+  def smth2(an: MyOption[Animal]): BigInt = an match {
+    case MyDefault(Cow(id), b) => id + b.id
+    case MyDefault(a, b) => a.id + b.id - 1
+    case MySome(_) => 42
+    case _ => 123
+  }
+
+  def test2(a: Animal): Unit = {
+    require(a match {
+      case Cow(_) => false
+      case _ => true
+    })
+    assert(smth2(MyDefault(Cow(42), Cow(43))) == 85)
+    assert(smth2(MyDefault(a, Cow(43))) == a.id + 43 - 1)
+    assert(smth2(MySome(a)) == 42)
+  }
+
+  def smth3(an: MyOption[Animal]): BigInt = an match {
+    case MyDefault(Cow(id1), Cow(id2)) => id1 + id2
+    case MyDefault(a, b) => a.id + b.id - 1
+    case MySome(_) => 42
+    case _ => 123
+  }
+
+  def test3(a: Animal, b: Animal): Unit = {
+    require((a, b) match {
+      case (Cow(_), Cow(_)) => false
+      case _ => true
+    })
+    assert(smth3(MyDefault(Cow(42), Cow(43))) == 85)
+    assert(smth3(MyDefault(a, b)) == a.id + b.id - 1)
+    assert(smth3(MySome(a)) == 42)
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1379e.scala
+++ b/frontends/benchmarks/verification/valid/i1379e.scala
@@ -1,0 +1,35 @@
+object i1379e {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  sealed abstract class MyDefault extends MyOption[Nothing] {
+    def a: BigInt
+    def b: BigInt
+  }
+  case class MyBiggerDefault(a: BigInt, b: BigInt, c: BigInt) extends MyDefault
+  case class MySimpleDefault(a: BigInt, b: BigInt) extends MyDefault
+
+  trait Animal
+  case class Cow(id: BigInt) extends Animal
+
+  def smth1(an: MyOption[Animal]): BigInt = an match {
+    case md: MyDefault => md.a + md.b
+    case MySome(_) => 42
+  }
+
+  def test1(a: Animal): Unit = {
+    assert(smth1(MyBiggerDefault(42, 43, 44)) == 85)
+    assert(smth1(MySome(a)) == 42)
+  }
+
+  def smth2(an: MyOption[Animal]): BigInt = an match {
+    case MyBiggerDefault(a, b, c) => a + b + c
+    case md: MyDefault => md.a + md.b
+    case MySome(_) => 42
+  }
+
+  def test2(a: Animal, md: MyDefault): Unit = {
+    assert(smth2(MyBiggerDefault(42, 43, 44)) == 129)
+    assert(smth2(MySimpleDefault(42, 43)) == 85)
+    assert(smth2(MySome(a)) == 42)
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1379f.scala
+++ b/frontends/benchmarks/verification/valid/i1379f.scala
@@ -1,0 +1,29 @@
+object i1379f {
+  sealed abstract class MyOption[+T]
+  case class MySome[+T](value: T) extends MyOption[T]
+  sealed abstract class MyDefault[+T] extends MyOption[T] {
+    def a: T
+    def b: T
+  }
+  case class MyBiggerDefault[+T](a: T, b: T, c: T) extends MyDefault[T]
+  case class MySimpleDefault[+T](a: T, b: T) extends MyDefault[T]
+
+  trait Animal {
+    def id: BigInt
+  }
+  case class Cow(id: BigInt) extends Animal
+
+  def smth1(an: MyOption[Animal]): BigInt = an match {
+    case MyBiggerDefault(a, b, c) => a.id + b.id + c.id
+    case MySimpleDefault(a, b) => a.id + b.id
+    case MySome(_) => 42
+  }
+
+  def test1(a: Animal): Unit = {
+    assert(smth1(MyBiggerDefault(Cow(42), Cow(43), Cow(44))) == 129)
+    assert(smth1(MyBiggerDefault(Cow(42), a, Cow(44))) == 86 + a.id)
+    assert(smth1(MySimpleDefault(Cow(42), Cow(43))) == 85)
+    assert(smth1(MySimpleDefault(Cow(42), a)) == 42 +  a.id)
+    assert(smth1(MySome(a)) == 42)
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1379g.scala
+++ b/frontends/benchmarks/verification/valid/i1379g.scala
@@ -1,0 +1,68 @@
+import stainless.lang._
+import stainless.annotation._
+
+object i1379g {
+
+  trait Animal
+  case class Cow(id: BigInt) extends Animal
+
+  sealed abstract class List[+A] {
+    def :: [B >: A](elem: B): List[B] = new ::(elem, this)
+  }
+  final case class ::[+A](first: A, next: List[A]) extends List[A]
+  case object Nil extends List[Nothing]
+
+  // It would be quite ironic for Seal to be non-sealed...
+  sealed trait Seal
+  case class EmpressSeal(name: String) extends Seal
+  case class EmperorSeal(name: String) extends Seal
+
+  def groupedConcreteUnsealed(xs: List[Animal]): List[List[Animal]] = {
+    decreases(xs)
+    xs match {
+      case Nil => Nil
+      case a1 :: a2 :: rest => (a1 :: a2 :: Nil) :: groupedConcreteUnsealed(rest)
+      case a1 :: Nil => (a1 :: Nil) :: Nil
+    }
+  }
+
+  def groupedConcreteSealed(xs: List[Seal]): List[List[Seal]] = {
+    decreases(xs)
+    xs match {
+      case Nil => Nil
+      case a1 :: a2 :: rest => (a1 :: a2 :: Nil) :: groupedConcreteSealed(rest)
+      case a1 :: Nil => (a1 :: Nil) :: Nil
+    }
+  }
+
+  def groupedAbstract[A](xs: List[A]): List[List[A]] = {
+    decreases(xs)
+    xs match {
+      case Nil => Nil
+      case a1 :: a2 :: rest => (a1 :: a2 :: Nil) :: groupedAbstract(rest)
+      case a1 :: Nil => (a1 :: Nil) :: Nil
+    }
+  }
+
+  @ghost
+  def testConcreteUnsealed(a1: Animal, a2: Animal, a3: Animal, a4: Animal): Unit = {
+    assert(groupedConcreteUnsealed(a1 :: a2 :: a3 :: a4 :: Nil) == (a1 :: a2 :: Nil) :: (a3 :: a4 :: Nil) :: Nil)
+    assert(groupedConcreteUnsealed(a1 :: a2 :: a3 :: Nil) == (a1 :: a2 :: Nil) :: (a3 :: Nil) :: Nil)
+    assert(groupedConcreteUnsealed(a1 :: Nil) == (a1 :: Nil) :: Nil)
+    assert(groupedConcreteUnsealed(Nil) == Nil)
+  }
+
+  def testConcreteSealed(a1: Seal, a2: Seal, a3: Seal, a4: Seal): Unit = {
+    assert(groupedConcreteSealed(a1 :: a2 :: a3 :: a4 :: Nil) == (a1 :: a2 :: Nil) :: (a3 :: a4 :: Nil) :: Nil)
+    assert(groupedConcreteSealed(a1 :: a2 :: a3 :: Nil) == (a1 :: a2 :: Nil) :: (a3 :: Nil) :: Nil)
+    assert(groupedConcreteSealed(a1 :: Nil) == (a1 :: Nil) :: Nil)
+    assert(groupedConcreteSealed(Nil) == Nil)
+  }
+
+  def testAbstract[A](a1: A, a2: A, a3: A, a4: A): Unit = {
+    assert(groupedAbstract(a1 :: a2 :: a3 :: a4 :: Nil) == (a1 :: a2 :: Nil) :: (a3 :: a4 :: Nil) :: Nil)
+    assert(groupedAbstract(a1 :: a2 :: a3 :: Nil) == (a1 :: a2 :: Nil) :: (a3 :: Nil) :: Nil)
+    assert(groupedAbstract(a1 :: Nil) == (a1 :: Nil) :: Nil)
+    assert(groupedAbstract(Nil) == Nil)
+  }
+}


### PR DESCRIPTION
Closes #1379
- Relax a condition for a pattern to be well-typed
- Adapt the "class unapply" function to return the fields of the class (if any) or unit (if none)