### PR TITLE
Support for enum case objects

### DIFF
--- a/frontends/benchmarks/dotty-specific/valid/CaseObjectEnum1.scala
+++ b/frontends/benchmarks/dotty-specific/valid/CaseObjectEnum1.scala
@@ -1,0 +1,22 @@
+object CaseObjectEnum1 {
+  enum OpKind {
+    case Add
+    case Sub
+    case Mul
+  }
+
+  def eval1(x: BigInt, y: BigInt, kind: OpKind) = kind match {
+    case OpKind.Add => x + y
+    case OpKind.Sub => x - y
+    case OpKind.Mul => x * y
+  }
+
+  def eval2(x: BigInt, y: BigInt, kind: OpKind) = {
+    import OpKind._
+    kind match {
+      case Add => x + y
+      case Sub => x - y
+      case Mul => x * y
+    }
+  }
+}

--- a/frontends/benchmarks/dotty-specific/valid/CaseObjectEnum2.scala
+++ b/frontends/benchmarks/dotty-specific/valid/CaseObjectEnum2.scala
@@ -1,0 +1,33 @@
+object CaseObjectEnum2 {
+  object Nest {
+    enum OpKind {
+      case Add
+      case Sub
+      case Mul
+    }
+  }
+
+  def eval1(x: BigInt, y: BigInt, kind: Nest.OpKind) = kind match {
+    case Nest.OpKind.Add => x + y
+    case Nest.OpKind.Sub => x - y
+    case Nest.OpKind.Mul => x * y
+  }
+
+  def eval2(x: BigInt, y: BigInt, kind: Nest.OpKind) = {
+    import Nest._
+    kind match {
+      case OpKind.Add => x + y
+      case OpKind.Sub => x - y
+      case OpKind.Mul => x * y
+    }
+  }
+
+  def eval3(x: BigInt, y: BigInt, kind: Nest.OpKind) = {
+    import Nest.OpKind._
+    kind match {
+      case Add => x + y
+      case Sub => x - y
+      case Mul => x * y
+    }
+  }
+}

--- a/frontends/benchmarks/extraction/valid/CaseObject3.scala
+++ b/frontends/benchmarks/extraction/valid/CaseObject3.scala
@@ -1,0 +1,12 @@
+object CaseObject3 {
+  sealed trait OpKind
+  case object Add extends OpKind
+  case object Sub extends OpKind
+  case object Mul extends OpKind
+
+  def eval(x: BigInt, y: BigInt, kind: OpKind) = kind match {
+    case Add => x + y
+    case Sub => x - y
+    case Mul => x * y
+  }
+}

--- a/frontends/benchmarks/extraction/valid/CaseObject4.scala
+++ b/frontends/benchmarks/extraction/valid/CaseObject4.scala
@@ -1,0 +1,14 @@
+object CaseObject4 {
+  sealed trait OpKind
+  object OpKind {
+    case object Add extends OpKind
+    case object Sub extends OpKind
+    case object Mul extends OpKind
+  }
+
+  def eval1(x: BigInt, y: BigInt, kind: OpKind) = kind match {
+    case OpKind.Add => x + y
+    case OpKind.Sub => x - y
+    case OpKind.Mul => x * y
+  }
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -919,7 +919,7 @@ class CodeExtraction(inoxCtx: inox.Context, symbolMapping: SymbolMapping)(using 
     case Ident(nme.WILDCARD) =>
       (xt.WildcardPattern(binder).setPos(p.sourcePos), dctx)
 
-    case s @ Select(_, b) if s.tpe.widenDealias.typeSymbol isOneOf (Case | Module) =>
+    case s @ Select(_, b) if (s.tpe.widenDealias.typeSymbol isOneOf (Case | Module)) || (s.tpe.termSymbol is Case) =>
       extractType(s)(using dctx.setResolveTypes(true)) match {
         case ct: xt.ClassType =>
           (xt.ClassPattern(binder, ct, Seq()).setPos(p.sourcePos), dctx)


### PR DESCRIPTION
Add support for enum case objects when pattern matching, which used to trigger an error.