### PR TITLE
Fix #1365

### DIFF
--- a/frontends/benchmarks/extraction/invalid/i1365a.scala
+++ b/frontends/benchmarks/extraction/invalid/i1365a.scala
@@ -1,0 +1,21 @@
+import stainless.annotation._
+object i1365a {
+  def app[@mutable A](mkA: A, ping: A => Unit, get: A => BigInt): BigInt = {
+    val f: A => BigInt = ((a: A) => {ping(a); get(a)+1})
+    f(mkA)
+  } ensuring(res => true)
+
+  case class Cell[T](var content: T)
+
+  def test = {
+    val c = Cell[BigInt](42)
+    val d = Cell[BigInt](7)
+    val myPing = {
+      (c1 : Cell[BigInt]) => c1.content = c1.content + d.content
+    }
+    d.content = 1000
+    val res: BigInt = app[Cell[BigInt]](c, myPing, _.content)
+    assert(c.content == 49)
+    assert(res == 50)
+  }
+}

--- a/frontends/benchmarks/extraction/invalid/i1365b.scala
+++ b/frontends/benchmarks/extraction/invalid/i1365b.scala
@@ -1,0 +1,21 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+// Adapted from InnerfunArgAliasing1
+object i1365b {
+
+  case class Box(var value: Int)
+
+  def outer(x: Box, y: Box, cond: Boolean): Unit = {
+    val z = if (cond) y else x
+
+    // This must be rejected because it captures x.
+    // even if we do not call inner
+    val inner = (innoncentLooking: Box) => {
+      val oldX = x.value
+      innoncentLooking.value = 1234
+      assert(innoncentLooking.value == 1234)
+    }
+  }
+}

--- a/frontends/benchmarks/extraction/invalid/i1365c.scala
+++ b/frontends/benchmarks/extraction/invalid/i1365c.scala
@@ -1,0 +1,22 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+// Adapted from InnerfunArgAliasing3
+object i1365c {
+
+  case class Box(var value: Int)
+
+  def outer(boxes: Array[Box], i: Int, j: Int): Unit = {
+    require(0 <= i && i < boxes.length)
+    require(0 <= j && j < boxes.length)
+
+    // This must be rejected because it captures boxes.
+    // even if we do not call inner
+    val inner = (innoncentLooking: Box) => {
+      val oldI = boxes(i).value
+      innoncentLooking.value = 1234
+      assert(innoncentLooking.value == 1234)
+    }
+  }
+}

--- a/frontends/benchmarks/imperative/invalid/i1365a.scala
+++ b/frontends/benchmarks/imperative/invalid/i1365a.scala
@@ -1,0 +1,21 @@
+import stainless.annotation._
+object i1365a {
+  def app[@mutable A](mkA: A, ping: A => Unit, get: A => BigInt): BigInt = {
+    val f: A => BigInt = ((a: A) => {ping(a); get(a)+1})
+    f(mkA)
+  } ensuring(res => true)
+
+  case class Cell[T](var content: T)
+
+  def test = {
+    val c = Cell[BigInt](42)
+    val d = Cell[BigInt](7)
+    def myPing(c1: Cell[BigInt]): Unit = {
+      c1.content = c1.content + d.content
+    }
+    d.content = 1000
+    val res: BigInt = app[Cell[BigInt]](c, myPing, _.content)
+    assert(c.content == 49) // No, you won't fool me this time
+    assert(res == 50)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/i1365a.scala
+++ b/frontends/benchmarks/imperative/valid/i1365a.scala
@@ -1,0 +1,19 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+object i1365a {
+
+  case class Box(var value: Int)
+
+  def outer(x: Box, y: Box, cond: Boolean): Unit = {
+    val z = if (cond) y else x
+
+    val inner = (box: Box) => {
+      val boxalias = box // Ok, can have alias of params
+      box.value = 1234
+      assert(box.value == 1234)
+      assert(boxalias.value == 1234)
+    }
+  }
+}


### PR DESCRIPTION
Closes #1365
Reject lambdas that capture variables of mutable type.
It would be tempting to relax that condition to allow such capture and proceed to a similar treatment as inner functions in `ImperativeCodeElimination` (where variables of mutable types are explicitly passed for each call), but since lambdas can be returned, aliased and so on, we cannot apply this encoding in general.