### PR TITLE
Fix #1349

### DIFF
--- a/frontends/benchmarks/verification/valid/i1349a.scala
+++ b/frontends/benchmarks/verification/valid/i1349a.scala
@@ -1,0 +1,27 @@
+import stainless.lang._
+import stainless.collection._
+
+object i1349a {
+  type Index = BigInt
+
+  type LIndex = List[Index]
+
+  case class IndexedKey(index: BigInt, key: LIndex) {
+    require(0 <= index && index < key.length)
+  }
+
+  def mkIndexedKey1(index: BigInt, key: LIndex): IndexedKey = {
+    require(0 <= index && index < key.length)
+    IndexedKey(index, key)
+  }
+
+  def mkIndexedKey2(index: BigInt, key: List[Index]): IndexedKey = {
+    require(0 <= index && index < key.length)
+    IndexedKey(index, key)
+  }
+
+  def mkIndexedKey3(index: Index, key: LIndex): IndexedKey = {
+    require(0 <= index && index < key.length)
+    IndexedKey(index, key)
+  }
+}

--- a/frontends/benchmarks/verification/valid/i1349b.scala
+++ b/frontends/benchmarks/verification/valid/i1349b.scala
@@ -1,0 +1,21 @@
+object i1349b {
+  final case class Wrap[A](a: A) {
+    def get: A = a
+  }
+
+  type WInt = Wrap[Int]
+
+  case class IndexedKey(key: WInt) {
+    require(key.get < 100)
+  }
+
+  def mkIndexedKey1(key: WInt): IndexedKey = {
+    require(key.get < 100)
+    IndexedKey(key)
+  }
+
+  def mkIndexedKey2(key: Wrap[Int]): IndexedKey = {
+    require(key.get < 100)
+    IndexedKey(key)
+  }
+}


### PR DESCRIPTION
Close #1349
A type alias is represented as `TypeApply`, which needs to be explicitly handled in the `MethodLifting` phase.