### PR TITLE
Equivalence checking: add option to specify weights, output resulting weights & ctex in the JSON output, lift batch restriction

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -83,7 +83,8 @@ trait MainHelpers extends inox.MainHelpers { self =>
     equivchk.optNorm -> Description(EquivChk, "Use function f as normalization function for equivalence checking"),
     equivchk.optEquivalenceOutput -> Description(EquivChk, "JSON output file for equivalence checking"),
     equivchk.optN -> Description(EquivChk, "Consider the top N models"),
-    equivchk.optInitScore -> Description(EquivChk, "Initial score for models, must be positive"),
+    equivchk.optInitScore -> Description(EquivChk, "Initial score for models"),
+    equivchk.optInitWeights -> Description(EquivChk, "Initial weights for models, overriding the initial score"),
     equivchk.optMaxPerm -> Description(EquivChk, "Maximum number of permutations to be tested when matching auxiliary functions"),
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)

--- a/core/src/main/scala/stainless/frontend/package.scala
+++ b/core/src/main/scala/stainless/frontend/package.scala
@@ -79,7 +79,7 @@ package object frontend {
 
   private def batchSymbols(activeComponents: Seq[Component])(using ctx: inox.Context): Boolean = {
     ctx.options.findOptionOrDefault(optBatchedProgram) ||
-    activeComponents.exists(Set(genc.GenCComponent, testgen.ScalaTestGenComponent, testgen.GenCTestGenComponent, equivchk.EquivalenceCheckingComponent).contains) ||
+    activeComponents.exists(Set(genc.GenCComponent, testgen.ScalaTestGenComponent, testgen.GenCTestGenComponent).contains) ||
     ctx.options.findOptionOrDefault(optKeep).nonEmpty
   }
 


### PR DESCRIPTION
- Equivalence checking can now be used with `--watch` mode
- Model initial score can be overwritten with `--equivchk-init-weights=f1:w1,f2:w2,...`