### PR TITLE
Equivalence checking: split 'erroneous' into 'unequivalent' and 'unsafe'

### DIFF
--- a/core/src/main/scala/stainless/equivchk/EquivalenceCheckingReport.scala
+++ b/core/src/main/scala/stainless/equivchk/EquivalenceCheckingReport.scala
@@ -38,7 +38,7 @@ object EquivalenceCheckingReport {
 
     def isInvalid: Boolean = this match {
       case Verification(status) => status.isInvalid
-      case Equivalence(EquivalenceStatus.Erroneous | EquivalenceStatus.Wrong) => true
+      case Equivalence(EquivalenceStatus.Unequivalent | EquivalenceStatus.Unsafe | EquivalenceStatus.Wrong) => true
       case _ => false
     }
 
@@ -51,7 +51,8 @@ object EquivalenceCheckingReport {
 
   enum EquivalenceStatus {
     case Valid(model: Identifier, fromCache: Boolean, trivial: Boolean)
-    case Erroneous
+    case Unequivalent
+    case Unsafe
     case Wrong
     case Unknown
   }
@@ -87,7 +88,8 @@ class EquivalenceCheckingReport(override val results: Seq[EquivalenceCheckingRep
         case Status.Verification(stat) => stat.name
         case Status.Equivalence(EquivalenceStatus.Valid(model, _, _)) => CheckFilter.fixedFullName(model)
         case Status.Equivalence(EquivalenceStatus.Wrong) => "signature mismatch"
-        case Status.Equivalence(EquivalenceStatus.Erroneous) => "erroneous"
+        case Status.Equivalence(EquivalenceStatus.Unequivalent) => "not equivalent"
+        case Status.Equivalence(EquivalenceStatus.Unsafe) => "unsafe"
         case Status.Equivalence(EquivalenceStatus.Unknown) => "unknown"
       }
       val level = levelOf(status)

--- a/frontends/benchmarks/equivalence/addHorn/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/addHorn/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/boardgame/expected_outcome_1.json
+++ b/frontends/benchmarks/equivalence/boardgame/expected_outcome_1.json
@@ -7,11 +7,12 @@
       ]
     }
   ],
-  "erroneous": [
+  "unequivalent": [
     "Candidate2.validCitySettlement",
     "Candidate3.validCitySettlement",
     "Candidate4.validCitySettlement"
   ],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/boardgame/expected_outcome_2.json
+++ b/frontends/benchmarks/equivalence/boardgame/expected_outcome_2.json
@@ -13,9 +13,11 @@
       ]
     }
   ],
-  "erroneous": [
-    "Candidate3.adjacencyBonus",
+  "unequivalent": [
     "Candidate4.adjacencyBonus"
+  ],
+  "unsafe": [
+    "Candidate3.adjacencyBonus"
   ],
   "timeout": [],
   "wrong": []

--- a/frontends/benchmarks/equivalence/cloudSculpting/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/cloudSculpting/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/dup/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/dup/expected_outcome.json
@@ -8,10 +8,11 @@
       ]
     }
   ],
-  "erroneous": [
+  "unequivalent": [
     "Candidate2.dup",
     "Candidate4.dup"
   ],
+  "unsafe": [],
   "timeout": [],
   "wrong": [
     "Candidate3.dup"

--- a/frontends/benchmarks/equivalence/factorial/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/factorial/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/fibonacci/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/fibonacci/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/foolproof/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/foolproof/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/foolproof/test_conf.json
+++ b/frontends/benchmarks/equivalence/foolproof/test_conf.json
@@ -5,5 +5,7 @@
   "comparefuns": [
     "Candidate.funnyZip"
   ],
+  "unequivalent": [],
+  "unsafe": [],
   "tests": []
 }

--- a/frontends/benchmarks/equivalence/fullAlternation/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/fullAlternation/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/funnyarith1/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/funnyarith1/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/funnyarith2/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/funnyarith2/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/funnyarith3/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/funnyarith3/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/halfAlternation/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/halfAlternation/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/i1264/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/i1264/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/inlining/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/inlining/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/isSorted/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/isSorted/expected_outcome.json
@@ -13,9 +13,10 @@
       ]
     }
   ],
-  "erroneous": [
+  "unequivalent": [
     "IsSorted.isSortedA"
   ],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/iseven1/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/iseven1/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/iseven2/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/iseven2/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/limit1/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/limit1/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/limit2/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/limit2/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/limit3/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/limit3/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/max1/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/max1/expected_outcome.json
@@ -13,7 +13,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/max2/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/max2/expected_outcome.json
@@ -9,10 +9,11 @@
       ]
     }
   ],
-  "erroneous": [
+  "unequivalent": [
     "Candidate4.max",
     "Candidate5.max"
   ],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/max3/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/max3/expected_outcome.json
@@ -1,6 +1,7 @@
 {
   "equivalent": [],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": ["Candidate.max"],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/pascal/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/pascal/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/sigma/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/sigma/expected_outcome.json
@@ -1,6 +1,7 @@
 {
   "equivalent": [],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": ["Candidate.sigma"],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/sum/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/sum/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/unfoldingSorted/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/unfoldingSorted/expected_outcome.json
@@ -8,10 +8,11 @@
       ]
     }
   ],
-  "erroneous": [
+  "unequivalent": [
     "Candidate3.unfoldingSorted",
     "Candidate4.unfoldingSorted"
   ],
+  "unsafe": [],
   "timeout": [],
   "wrong": [
     "Candidate2.unfoldingSorted"

--- a/frontends/benchmarks/equivalence/uniq1/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/uniq1/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/uniq2/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/uniq2/expected_outcome.json
@@ -13,7 +13,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/unrolling/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/unrolling/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/unused/expected_outcome.json
+++ b/frontends/benchmarks/equivalence/unused/expected_outcome.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_1.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_1.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_2.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_2.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_3.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_3.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_4.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_4.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_5.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_5.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_6.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/expected_outcome_6.json
@@ -7,7 +7,8 @@
       ]
     }
   ],
-  "erroneous": [],
+  "unequivalent": [],
+  "unsafe": [],
   "timeout": [],
   "wrong": []
 }


### PR DESCRIPTION
We now distinguish between a candidate function being incorrect due to unsafety (e.g. division by zero) or due to not being equivalent. Previously, these two kinds of incorrectness were merged into one category.