### PR TITLE
Fix ghost rewriting phase

### DIFF
--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/GhostAccessRewriter.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/GhostAccessRewriter.scala
@@ -32,7 +32,9 @@ class GhostAccessRewriter extends PluginPhase { self =>
     override protected def newTransformer(using DottyContext): Transformer = new GhostRewriteTransformer
 
     private class GhostRewriteTransformer(using DottyContext) extends Transformer {
-      val ghostAnnotation = Symbols.requiredClass("stainless.annotation.ghost")
+      private val StainlessLangPackage = Symbols.requiredPackage("stainless.lang")
+      private val ghostAnnotation = Symbols.requiredClass("stainless.annotation.ghost")
+      private val ghostFun = StainlessLangPackage.info.decl(Names.termName("ghost")).alternatives.toSet
 
       /**
         * Is this symbol @ghost, or enclosed inside a ghost definition?
@@ -78,7 +80,7 @@ class GhostAccessRewriter extends PluginPhase { self =>
         case vd@ValDef(name, tpt, _) if effectivelyGhost(tree.symbol) =>
           cpy.ValDef(tree)(name, tpt, mkZero(vd.rhs.tpe))
 
-        case Apply(fun, args) if effectivelyGhost(fun.symbol) =>
+        case Apply(fun, args) if effectivelyGhost(fun.symbol) || ghostFun(fun.symbol) =>
           mkZero(tree.tpe)
 
         case f@Apply(fun, args) =>

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/GhostAccessRewriter.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/GhostAccessRewriter.scala
@@ -31,6 +31,8 @@ trait GhostAccessRewriter extends Transform {
   }
 
   private class GhostRewriteTransformer extends Transformer {
+    private val StainlessLangPackage = rootMirror.getPackageIfDefined("stainless.lang")
+    private val ghostFun = StainlessLangPackage.info.decl(newTermName("ghost")).alternatives.toSet
 
     /**
      * Is this symbol @ghost, or enclosed inside a ghost definition?
@@ -71,7 +73,7 @@ trait GhostAccessRewriter extends Transform {
       case Apply(tt@TypeTree(), args) =>
         treeCopy.Apply(tree, tt, transformTrees(args))
 
-      case f @ Apply(fun, args) if effectivelyGhost(fun.symbol) =>
+      case f @ Apply(fun, args) if effectivelyGhost(fun.symbol) || ghostFun(fun.symbol) =>
         gen.mkZero(tree.tpe)
 
       case f @ Apply(fun, args) =>

--- a/sbt-plugin/src/sbt-test/sbt-plugin/ghost/test
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/ghost/test
@@ -1,5 +1,5 @@
 > + basic/run
 $ exists basic/target/scala-2.13/classes/test/Main.class
-$ exists basic/target/scala-3.2.0/classes/test/Main.class
+$ exists basic/target/scala-3.3.0/classes/test/Main.class
 $ absent basic/target/sneakyGhostCalled basic/target/insideGhostCalled
 > + actor-tests/compile

--- a/sbt-plugin/src/sbt-test/sbt-plugin/simple/test
+++ b/sbt-plugin/src/sbt-test/sbt-plugin/simple/test
@@ -2,5 +2,5 @@
 > + success/compile
 # check that a module on which stainless verification passes compiles fine (i.e., binaries are produced)
 $ exists success/target/scala-2.13/classes/Extern1.class
-$ exists success/target/scala-3.2.0/classes/Extern1.class
+$ exists success/target/scala-3.3.0/classes/Extern1.class
 # > failure/checkScalaFailures


### PR DESCRIPTION
For the Scala 2 fronted, the `ghost` function used to generate invalid bytecode, so calls to this function are now explicitly removed. This problem does not apply to the Scala 3 frontend, but calls to `ghost` are also removed for symmetry. 