### PR TITLE
Add support for smt-cvc5

### DIFF
--- a/.larabot.conf
+++ b/.larabot.conf
@@ -1,6 +1,6 @@
 commands = [
     "sbt -batch -Dtest-parallelism=5 test"
-    "sbt -batch -Dtest-parallelism=5 \"it:testOnly stainless.GhostRewriteSuite stainless.GenCSuite stainless.ScalacExtractionSuite stainless.LibrarySuite stainless.verification.SMTZ3VerificationSuite stainless.verification.SMTZ3UncheckedSuite stainless.verification.TerminationVerificationSuite stainless.verification.ImperativeSuite stainless.verification.FullImperativeSuite stainless.verification.StrictArithmeticSuite stainless.verification.CodeGenVerificationSuite stainless.verification.SMTCVC4VerificationSuite stainless.verification.SMTCVC4UncheckedSuite stainless.verification.PrincessVerificationSuite stainless.termination.TerminationSuite stainless.evaluators.EvaluatorComponentTest\""
+    "sbt -batch -Dtest-parallelism=5 \"it:testOnly stainless.GhostRewriteSuite stainless.GenCSuite stainless.ScalacExtractionSuite stainless.LibrarySuite stainless.verification.VerificationSuite stainless.verification.UncheckedSuite stainless.verification.TerminationVerificationSuite stainless.verification.ImperativeSuite stainless.verification.FullImperativeSuite stainless.verification.StrictArithmeticSuite stainless.termination.TerminationSuite stainless.evaluators.EvaluatorComponentTest\""
 ]
 
 nightly {

--- a/build.sbt
+++ b/build.sbt
@@ -275,7 +275,7 @@ val scriptSettings: Seq[Setting[_]] = Seq(
 def ghProject(repo: String, version: String) = RootProject(uri(s"${repo}#${version}"))
 
 // lazy val inox = RootProject(file("../inox"))
-lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "6bf9302bd9dae1b00ee902654b46b73ac5b01fcd")
+lazy val inox = ghProject("https://github.com/epfl-lara/inox.git", "b265b93559894b722552d2d497f9e7123e423461")
 lazy val cafebabe = ghProject("https://github.com/epfl-lara/cafebabe.git", "616e639b34379e12b8ac202849de3ebbbd0848bc")
 
 // Allow integration test to use facilities from regular tests

--- a/frontends/common/src/it/scala/stainless/ComponentTestSuite.scala
+++ b/frontends/common/src/it/scala/stainless/ComponentTestSuite.scala
@@ -17,7 +17,7 @@ trait ComponentTestSuite extends inox.TestSuite with inox.ResourceUtils with Inp
 
   override def configurations: Seq[Seq[inox.OptionValue[_]]] = Seq(
     Seq(
-      inox.optSelectedSolvers(Set("smt-z3:z3-4.8.12")),
+      inox.optSelectedSolvers(Set("smt-z3")),
       inox.optTimeout(300.seconds),
       verification.optStrictArithmetic(false),
       termination.optInferMeasures(false),

--- a/frontends/common/src/it/scala/stainless/verification/UncheckedSuite.scala
+++ b/frontends/common/src/it/scala/stainless/verification/UncheckedSuite.scala
@@ -5,26 +5,22 @@ package verification
 
 import org.scalatest._
 
-trait UncheckedSuite extends VerificationComponentTestSuite {
+class UncheckedSuite extends VerificationComponentTestSuite {
+  private val solvers = Seq("smt-z3", "smt-cvc4", "smt-cvc5")
 
-  override def configurations = super.configurations.map {
-    seq => Seq(optFailEarly(true), inox.solvers.optCheckModels(false)) ++ seq
+  override def configurations: Seq[Seq[inox.OptionValue[_]]] = {
+    solvers.flatMap { solver =>
+      super.configurations.map {
+        seq => Seq(
+          inox.optSelectedSolvers(Set(solver)),
+          optFailEarly(true),
+          inox.solvers.optCheckModels(false)) ++ seq
+      }
+    }
   }
 
   override val component: VerificationComponent.type = VerificationComponent
 
   testUncheckedAll("verification/unchecked-invalid")
   testUncheckedAll("verification/unchecked-valid")
-}
-
-class SMTZ3UncheckedSuite extends UncheckedSuite {
-  override def configurations = super.configurations.map {
-    seq => inox.optSelectedSolvers(Set("smt-z3:z3-4.8.12")) +: seq
-  }
-}
-
-class SMTCVC4UncheckedSuite extends UncheckedSuite {
-  override def configurations = super.configurations.map {
-    seq => inox.optSelectedSolvers(Set("smt-cvc4")) +: seq
-  }
 }

--- a/frontends/common/src/it/scala/stainless/verification/VerificationSuite.scala
+++ b/frontends/common/src/it/scala/stainless/verification/VerificationSuite.scala
@@ -7,20 +7,228 @@ import scala.concurrent.duration._
 
 import org.scalatest._
 
-trait VerificationSuite extends VerificationComponentTestSuite {
+class VerificationSuite extends VerificationComponentTestSuite {
+  private val solvers = Seq("smt-z3", "smt-cvc4", "smt-cvc5", "princess")
 
-  override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
-    case "verification/invalid/ForallAssoc"           => Ignore  // Hangs
-
+  private val ignoreCommon = Set(
+    // Hangs
+    "verification/invalid/ForallAssoc",
     // unknown/timeout VC but counter-example not found
-    case "verification/invalid/BadConcRope"           => Ignore
-
+    "verification/invalid/BadConcRope",
     // Lemmas used in one equation can leak in other equations due to https://github.com/epfl-lara/inox/issues/139
-    case "verification/invalid/Equations1" => Ignore
-    case "verification/invalid/Equations2" => Ignore
-    case "verification/invalid/Equations3" => Ignore
+    "verification/invalid/Equations1",
+    "verification/invalid/Equations2",
+    "verification/invalid/Equations3",
+  )
 
-    case _ => super.filter(ctx, name)
+  private val ignoreZ3 = ignoreCommon ++
+    Set(
+      // Flaky
+      "verification/valid/PackedFloat8",
+    )
+
+  private val ignoreCVC = ignoreCommon ++
+    Set(
+      // Unknown / cannot encode map with non-default values
+      "verification/valid/ArraySlice",
+      "verification/valid/BigIntMonoidLaws",
+      "verification/valid/BigIntRing",
+      "verification/valid/InnerClasses4",
+      "verification/valid/Iterables",
+      "verification/valid/PartialCompiler",
+      "verification/valid/PartialKVTrace",
+    )
+
+  private val ignorePrincess = ignoreCommon ++
+    Set(
+      // valid/MicroTests
+      "verification/valid/ADTWithArray1",
+      "verification/valid/ADTWithArray2",
+      "verification/valid/ADTWithArray4",
+      "verification/valid/ADTWithArray5",
+      "verification/valid/ADTWithArray6",
+      "verification/valid/Array1",
+      "verification/valid/Array2",
+      "verification/valid/Array3",
+      "verification/valid/Array4",
+      "verification/valid/ArrayUpdated",
+      "verification/valid/BitVectors2",
+      "verification/valid/BitVectors3",
+      "verification/valid/Issue803",
+      "verification/valid/Monads3",
+      "verification/valid/Nested13",
+      "verification/valid/SetIsEmpty",
+      "verification/valid/Sets1",
+      "verification/valid/Sets2",
+      "verification/valid/Subtyping1",
+
+      // valid/
+      "verification/valid/ArraySlice",
+      "verification/valid/AnonymousClasses1",
+      "verification/valid/AssociativeList",
+      "verification/valid/AmortizedQueue",
+      "verification/valid/BalancedParentheses",
+      "verification/valid/BasicReal",
+      "verification/valid/BinarySearch",
+      "verification/valid/BinarySearchTreeQuant",
+      "verification/valid/BinarySearchTreeQuant2",
+      "verification/valid/BitsTricks",
+      "verification/valid/BitsTricksSlow",
+      "verification/valid/BooleanOps",
+      "verification/valid/BVMaxInterpret",
+      "verification/valid/Composition",
+      "verification/valid/ConcRope",
+      "verification/valid/ConcTree",
+      "verification/valid/ContMonad",
+      "verification/valid/Count",
+      "verification/valid/CovCollection",
+      "verification/valid/Filter",
+      "verification/valid/FiniteSort",
+      "verification/valid/FlatMap",
+      "verification/valid/FoolProofAdder",
+      "verification/valid/FunctionMaps",
+      "verification/valid/FunctionMapsObj",
+      "verification/valid/GodelNumbering",
+      "verification/valid/Heaps",
+      "verification/valid/HOInvocations2",
+      "verification/valid/i1379a",
+      "verification/valid/i1379e",
+      "verification/valid/i1379f",
+      "verification/valid/i1379g",
+      "verification/valid/InnerClasses4",
+      "verification/valid/InnerClassesInvariants",
+      "verification/valid/InsertionSort",
+      "verification/valid/IntSetInv",
+      "verification/valid/Iterables",
+      "verification/valid/LawTypeArgsElim",
+      "verification/valid/ListMonad",
+      "verification/valid/ListOperations",
+      "verification/valid/LiteralMaps",
+      "verification/valid/Longs",
+      "verification/valid/MapDiff",
+      "verification/valid/MapGetOrElse2",
+      "verification/valid/MapGetPlus",
+      "verification/valid/MergeSort",
+      "verification/valid/MergeSort2",
+      "verification/valid/Monotonicity",
+      "verification/valid/NNF",
+      "verification/valid/PackedFloat8",
+      "verification/valid/ParBalance",
+      "verification/valid/PartialCompiler",
+      "verification/valid/PartialKVTrace",
+      "verification/valid/PositiveMap",
+      "verification/valid/PropositionalLogic",
+      "verification/valid/QuickSort",
+      "verification/valid/QuickSortFilter",
+      "verification/valid/RedBlackTree",
+      "verification/valid/Reverse",
+      "verification/valid/StableSorter",
+      "verification/valid/TransitiveQuantification",
+      "verification/valid/Trees1",
+      "verification/valid/ValueClasses",
+
+      // invalid/
+      "verification/invalid/AbstractRefinementMap",
+      "verification/invalid/Acc",
+      "verification/invalid/AddNaturals1",
+      "verification/invalid/AddNaturals2",
+      "verification/invalid/ADTWithArray1",
+      "verification/invalid/ADTWithArray2",
+      "verification/invalid/Array1",
+      "verification/invalid/Array2",
+      "verification/invalid/Array3",
+      "verification/invalid/Array4",
+      "verification/invalid/Array5",
+      "verification/invalid/Array6",
+      "verification/invalid/Array7",
+      "verification/invalid/Asserts1",
+      "verification/invalid/AssociativityProperties",
+      "verification/invalid/BadConcRope",
+      "verification/invalid/BigArray",
+      "verification/invalid/BinarySearch1",
+      "verification/invalid/BinarySearch2",
+      "verification/invalid/BinarySearch3",
+      "verification/invalid/BraunTree",
+      "verification/invalid/Choose1",
+      "verification/invalid/Choose2",
+      "verification/invalid/Existentials",
+      "verification/invalid/ExternFallbackMut",
+      "verification/invalid/FiniteSort",
+      "verification/invalid/Float8",
+      "verification/invalid/ForallAssoc",
+      "verification/invalid/HiddenOverride",
+      "verification/invalid/HOInvocations",
+      "verification/invalid/i497",
+      "verification/invalid/i1295",
+      "verification/invalid/InductTacticTest",
+      "verification/invalid/InsertionSort",
+      "verification/invalid/IntSet",
+      "verification/invalid/IntSetUnit",
+      "verification/invalid/InvisibleOpaque",
+      "verification/invalid/Issue1167",
+      "verification/invalid/Issue1167b",
+      "verification/invalid/LawsExampleInvalid",
+      "verification/invalid/ListOperations",
+      "verification/invalid/Lists",
+      "verification/invalid/Nested15",
+      "verification/invalid/PackedFloat8",
+      "verification/invalid/PartialSplit",
+      "verification/invalid/PositiveMap",
+      "verification/invalid/PositiveMap2",
+      "verification/invalid/PropositionalLogic",
+      "verification/invalid/RedBlackTree",
+      "verification/invalid/RedBlackTree2",
+      "verification/invalid/SimpleQuantification2",
+      "verification/invalid/SpecWithExtern",
+
+      // false-valid/ (for greater good...)
+      "verification/false-valid/ForestNothing2",
+    )
+
+  private val ignoreCodegen = Set(
+    // Does not work with --feeling-lucky. See #490
+    "verification/valid/MsgQueue",
+    // assertion failed in `compileLambda`
+    "verification/valid/GodelNumbering"
+  )
+
+  override protected def optionsString(options: inox.Options): String = {
+    "solvr=" + options.findOptionOrDefault(inox.optSelectedSolvers).head + " " +
+    "lucky=" + options.findOptionOrDefault(inox.solvers.unrolling.optFeelingLucky) + " " +
+    "check=" + options.findOptionOrDefault(inox.solvers.optCheckModels) + " " +
+    "codegen=" + options.findOptionOrDefault(evaluators.optCodeGen)
+  }
+
+  override def configurations: Seq[Seq[inox.OptionValue[_]]] = {
+    // All configurations for all possible solvers and codegen / recursive evaluators
+    // Note 1: For codegen, we only use Z3
+    // Note 2: We opt-in for early counter-example discovery for codegen with the "feeling lucky" option
+    for {
+      solver <- solvers
+      codeGen <- Seq(false, true)
+      if !codeGen || solver == "smt-z3"
+      conf <- super.configurations.map {
+        seq =>
+          Seq(
+            inox.optSelectedSolvers(Set(solver)),
+            inox.solvers.optCheckModels(true),
+            evaluators.optCodeGen(codeGen),
+            inox.solvers.unrolling.optFeelingLucky(codeGen)) ++ seq
+      }
+    } yield conf
+  }
+
+  override def filter(ctx: inox.Context, name: String): FilterStatus = {
+    val solvers = ctx.options.findOptionOrDefault(inox.optSelectedSolvers)
+    assert(solvers.size == 1)
+    val ignoredSolver = solvers.head match {
+      case "smt-z3" => ignoreZ3(name)
+      case "smt-cvc4" | "smt-cvc5" => ignoreCVC(name)
+      case "princess" => ignorePrincess(name)
+      case other => fail(s"An unknown solver: $other")
+    }
+    val ignoredCodegen = ctx.options.findOptionOrDefault(evaluators.optCodeGen) && ignoreCodegen(name)
+    if (ignoredSolver || ignoredCodegen) Ignore else super.filter(ctx, name)
   }
 
   // Scala 2 BitVectors tests leverages the fact that `==` can be used to compare two unrelated types.
@@ -42,225 +250,4 @@ trait VerificationSuite extends VerificationComponentTestSuite {
 
   // Tests that should be rejected, but aren't
   testPosAll("verification/false-valid")
-}
-
-class SMTZ3VerificationSuite extends VerificationSuite {
-  override def configurations = super.configurations.map {
-    seq => Seq(
-      inox.optSelectedSolvers(Set("smt-z3:z3-4.8.12")),
-      inox.solvers.optCheckModels(true)
-    ) ++ seq
-  }
-
-  override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
-    // Flaky
-    case "verification/valid/PackedFloat8" => Ignore
-    case _ => super.filter(ctx, name)
-  }
-}
-
-class CodeGenVerificationSuite extends SMTZ3VerificationSuite {
-  override def configurations = super.configurations.map {
-    seq => Seq(
-      inox.solvers.unrolling.optFeelingLucky(true),
-      inox.solvers.optCheckModels(true),
-      evaluators.optCodeGen(true)
-    ) ++ seq
-  }
-
-  override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
-    // Does not work with --feeling-lucky. See #490
-    case "verification/valid/MsgQueue" => Skip
-
-    // assertion failed in `compileLambda`
-    case "verification/valid/GodelNumbering" => Ignore
-
-    case _ => super.filter(ctx, name)
-  }
-}
-
-class SMTCVC4VerificationSuite extends VerificationSuite {
-  override def configurations = super.configurations.map {
-    seq => Seq(
-      inox.optSelectedSolvers(Set("smt-cvc4")),
-      inox.solvers.optCheckModels(true)
-    ) ++ seq
-  }
-
-  override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
-    case "verification/valid/ArraySlice" => Ignore
-    case "verification/valid/BigIntMonoidLaws" => Ignore
-    case "verification/valid/BigIntRing" => Ignore
-    case "verification/valid/ConcRope" => Ignore
-    case "verification/valid/Huffman" => Ignore
-    case "verification/valid/InnerClasses4" => Ignore
-    case "verification/valid/Iterables" => Ignore
-    case "verification/valid/List" => Ignore
-    case "verification/valid/MoreExtendedEuclidGCD" => Ignore
-    case "verification/valid/MoreExtendedEuclidReachability" => Ignore
-    case "verification/valid/Overrides" => Ignore
-    case "verification/valid/PartialCompiler" => Ignore
-    case "verification/valid/PartialKVTrace" => Ignore
-    case "verification/valid/ReachabilityChecker" => Ignore
-    case "verification/valid/TestPartialFunction" => Ignore
-    case "verification/valid/TestPartialFunction3" => Ignore
-
-    case _ => super.filter(ctx, name)
-  }
-}
-
-class PrincessVerificationSuite extends VerificationSuite {
-  override def configurations = super.configurations.map {
-    seq => Seq(
-      inox.optSelectedSolvers(Set("princess")),
-      inox.solvers.optCheckModels(true)
-    ) ++ seq
-  }
-
-  override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
-    // valid/MicroTests
-    case "verification/valid/ADTWithArray1" => Ignore
-    case "verification/valid/ADTWithArray2" => Ignore
-    case "verification/valid/ADTWithArray4" => Ignore
-    case "verification/valid/ADTWithArray5" => Ignore
-    case "verification/valid/ADTWithArray6" => Ignore
-    case "verification/valid/Array1" => Ignore
-    case "verification/valid/Array2" => Ignore
-    case "verification/valid/Array3" => Ignore
-    case "verification/valid/Array4" => Ignore
-    case "verification/valid/ArrayUpdated" => Ignore
-    case "verification/valid/BitVectors2" => Ignore
-    case "verification/valid/BitVectors3" => Ignore
-    case "verification/valid/Issue803" => Ignore
-    case "verification/valid/Monads3" => Ignore
-    case "verification/valid/Nested13" => Ignore
-    case "verification/valid/SetIsEmpty" => Ignore
-    case "verification/valid/Sets1" => Ignore
-    case "verification/valid/Sets2" => Ignore
-    case "verification/valid/Subtyping1" => Ignore
-
-    // valid/
-    case "verification/valid/ArraySlice" => Ignore
-    case "verification/valid/AnonymousClasses1" => Ignore
-    case "verification/valid/AssociativeList" => Ignore
-    case "verification/valid/AmortizedQueue" => Ignore
-    case "verification/valid/BalancedParentheses" => Ignore
-    case "verification/valid/BasicReal" => Ignore
-    case "verification/valid/BinarySearch" => Ignore
-    case "verification/valid/BinarySearchTreeQuant" => Ignore
-    case "verification/valid/BinarySearchTreeQuant2" => Ignore
-    case "verification/valid/BitsTricks" => Ignore
-    case "verification/valid/BitsTricksSlow" => Ignore
-    case "verification/valid/BooleanOps" => Ignore
-    case "verification/valid/BVMaxInterpret" => Ignore
-    case "verification/valid/Composition" => Ignore
-    case "verification/valid/ConcRope" => Ignore
-    case "verification/valid/ConcTree" => Ignore
-    case "verification/valid/ContMonad" => Ignore
-    case "verification/valid/Count" => Ignore
-    case "verification/valid/CovCollection" => Ignore
-    case "verification/valid/Filter" => Ignore
-    case "verification/valid/FiniteSort" => Ignore
-    case "verification/valid/FlatMap" => Ignore
-    case "verification/valid/FoolProofAdder" => Ignore
-    case "verification/valid/FunctionMaps" => Ignore
-    case "verification/valid/FunctionMapsObj" => Ignore
-    case "verification/valid/GodelNumbering" => Ignore
-    case "verification/valid/Heaps" => Ignore
-    case "verification/valid/HOInvocations2" => Ignore
-    case "verification/valid/i1379a" => Ignore
-    case "verification/valid/i1379e" => Ignore
-    case "verification/valid/i1379f" => Ignore
-    case "verification/valid/i1379g" => Ignore
-    case "verification/valid/InnerClasses4" => Ignore
-    case "verification/valid/InnerClassesInvariants" => Ignore
-    case "verification/valid/InsertionSort" => Ignore
-    case "verification/valid/IntSetInv" => Ignore
-    case "verification/valid/Iterables" => Ignore
-    case "verification/valid/LawTypeArgsElim" => Ignore
-    case "verification/valid/ListMonad" => Ignore
-    case "verification/valid/ListOperations" => Ignore
-    case "verification/valid/LiteralMaps" => Ignore
-    case "verification/valid/Longs" => Ignore
-    case "verification/valid/MapDiff" => Ignore
-    case "verification/valid/MapGetOrElse2" => Ignore
-    case "verification/valid/MapGetPlus" => Ignore
-    case "verification/valid/MergeSort" => Ignore
-    case "verification/valid/MergeSort2" => Ignore
-    case "verification/valid/Monotonicity" => Ignore
-    case "verification/valid/NNF" => Ignore
-    case "verification/valid/PackedFloat8" => Ignore
-    case "verification/valid/ParBalance" => Ignore
-    case "verification/valid/PartialCompiler" => Ignore
-    case "verification/valid/PartialKVTrace" => Ignore
-    case "verification/valid/PositiveMap" => Ignore
-    case "verification/valid/PropositionalLogic" => Ignore
-    case "verification/valid/QuickSort" => Ignore
-    case "verification/valid/QuickSortFilter" => Ignore
-    case "verification/valid/RedBlackTree" => Ignore
-    case "verification/valid/Reverse" => Ignore
-    case "verification/valid/StableSorter" => Ignore
-    case "verification/valid/TransitiveQuantification" => Ignore
-    case "verification/valid/Trees1" => Ignore
-    case "verification/valid/ValueClasses" => Ignore
-
-    // invalid/
-    case "verification/invalid/AbstractRefinementMap" => Ignore
-    case "verification/invalid/Acc" => Ignore
-    case "verification/invalid/AddNaturals1" => Ignore
-    case "verification/invalid/AddNaturals2" => Ignore
-    case "verification/invalid/ADTWithArray1" => Ignore
-    case "verification/invalid/ADTWithArray2" => Ignore
-    case "verification/invalid/Array1" => Ignore
-    case "verification/invalid/Array2" => Ignore
-    case "verification/invalid/Array3" => Ignore
-    case "verification/invalid/Array4" => Ignore
-    case "verification/invalid/Array5" => Ignore
-    case "verification/invalid/Array6" => Ignore
-    case "verification/invalid/Array7" => Ignore
-    case "verification/invalid/Asserts1" => Ignore
-    case "verification/invalid/AssociativityProperties" => Ignore
-    case "verification/invalid/BadConcRope" => Ignore
-    case "verification/invalid/BigArray" => Ignore
-    case "verification/invalid/BinarySearch1" => Ignore
-    case "verification/invalid/BinarySearch2" => Ignore
-    case "verification/invalid/BinarySearch3" => Ignore
-    case "verification/invalid/BraunTree" => Ignore
-    case "verification/invalid/Choose1" => Ignore
-    case "verification/invalid/Choose2" => Ignore
-    case "verification/invalid/Existentials" => Ignore
-    case "verification/invalid/ExternFallbackMut" => Ignore
-    case "verification/invalid/FiniteSort" => Ignore
-    case "verification/invalid/Float8" => Ignore
-    case "verification/invalid/ForallAssoc" => Ignore
-    case "verification/invalid/HiddenOverride" => Ignore
-    case "verification/invalid/HOInvocations" => Ignore
-    case "verification/invalid/i497" => Ignore
-    case "verification/invalid/i1295" => Ignore
-    case "verification/invalid/InductTacticTest" => Ignore
-    case "verification/invalid/InsertionSort" => Ignore
-    case "verification/invalid/IntSet" => Ignore
-    case "verification/invalid/IntSetUnit" => Ignore
-    case "verification/invalid/InvisibleOpaque" => Ignore
-    case "verification/invalid/Issue1167" => Ignore
-    case "verification/invalid/Issue1167b" => Ignore
-    case "verification/invalid/LawsExampleInvalid" => Ignore
-    case "verification/invalid/ListOperations" => Ignore
-    case "verification/invalid/Lists" => Ignore
-    case "verification/invalid/Nested15" => Ignore
-    case "verification/invalid/PackedFloat8" => Ignore
-    case "verification/invalid/PartialSplit" => Ignore
-    case "verification/invalid/PositiveMap" => Ignore
-    case "verification/invalid/PositiveMap2" => Ignore
-    case "verification/invalid/PropositionalLogic" => Ignore
-    case "verification/invalid/RedBlackTree" => Ignore
-    case "verification/invalid/RedBlackTree2" => Ignore
-    case "verification/invalid/SimpleQuantification2" => Ignore
-    case "verification/invalid/SpecWithExtern" => Ignore
-
-    // false-valid/ (for greater good...)
-    case "verification/false-valid/ForestNothing2" => Ignore
-
-    case _ => super.filter(ctx, name)
-  }
 }

--- a/frontends/dotty/src/it/scala/stainless/verification/DottyVerificationSuite.scala
+++ b/frontends/dotty/src/it/scala/stainless/verification/DottyVerificationSuite.scala
@@ -37,7 +37,7 @@ trait DottyVerificationSuite extends VerificationComponentTestSuite {
 class SMTZ3DottyVerificationSuite extends DottyVerificationSuite {
   override def configurations = super.configurations.map {
     seq => Seq(
-      inox.optSelectedSolvers(Set("smt-z3:z3-4.8.12")),
+      inox.optSelectedSolvers(Set("smt-z3")),
       inox.solvers.optCheckModels(true)
     ) ++ seq
   }


### PR DESCRIPTION
cvc5 can be selected with `--solvers=smt-cvc5` (as long as its executable can be found in PATH).
The other changes relate to integration test: instead of loading `verification/` per solver, we do it only once.