### PR TITLE
Fix verification deactivation through SBT plugin

### DIFF
--- a/bin/package-sbt-plugin.sh
+++ b/bin/package-sbt-plugin.sh
@@ -6,10 +6,12 @@ if [[ $(git diff --stat) != '' ]]; then
   STAINLESS_VERSION="$STAINLESS_VERSION-SNAPSHOT"
 fi
 
+SCALA_VERSION="3.3.0"
+SCALA_LIB_VERSION="2.13"
 PUBLISHED_SBT_PLUGIN_DIR="$HOME/.ivy2/local/ch.epfl.lara/sbt-stainless/scala_2.12/sbt_1.0/$STAINLESS_VERSION"
-PUBLISHED_LIB_DIR="$HOME/.ivy2/local/ch.epfl.lara/stainless-library_2.13/$STAINLESS_VERSION"
-PUBLISHED_DOTTY_DIR="$HOME/.ivy2/local/ch.epfl.lara/stainless-dotty-plugin_3.2.0/$STAINLESS_VERSION"
-PUBLISHED_SCALAC_DIR="$HOME/.ivy2/local/ch.epfl.lara/stainless-scalac-plugin_3.2.0/$STAINLESS_VERSION"
+PUBLISHED_LIB_DIR="$HOME/.ivy2/local/ch.epfl.lara/stainless-library_$SCALA_LIB_VERSION/$STAINLESS_VERSION"
+PUBLISHED_DOTTY_DIR="$HOME/.ivy2/local/ch.epfl.lara/stainless-dotty-plugin_$SCALA_VERSION/$STAINLESS_VERSION"
+PUBLISHED_SCALAC_DIR="$HOME/.ivy2/local/ch.epfl.lara/stainless-scalac-plugin_$SCALA_VERSION/$STAINLESS_VERSION"
 
 OUTPUT="./.stainless-package-sbt-plugin"
 rm -rf "$OUTPUT" || true
@@ -43,22 +45,22 @@ mkdir -p "$OUT_SBT_JAR_DIR"
 cp "$PUBLISHED_SBT_PLUGIN_DIR/jars/sbt-stainless.jar" "$OUT_SBT_JAR_DIR/sbt-stainless.jar"
 
 info "$(tput bold)[] Preparing Stainless library jar..."
-OUT_LIB_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-library_2.13/$STAINLESS_VERSION"
+OUT_LIB_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-library_$SCALA_LIB_VERSION/$STAINLESS_VERSION"
 mkdir -p "$OUT_LIB_DIR"
-cp "$PUBLISHED_LIB_DIR/srcs/stainless-library_2.13-sources.jar" "$OUT_LIB_DIR/stainless-library_2.13-$STAINLESS_VERSION-sources.jar"
-cp "$PUBLISHED_LIB_DIR/poms/stainless-library_2.13.pom" "$OUT_LIB_DIR/stainless-library_2.13-$STAINLESS_VERSION.pom"
+cp "$PUBLISHED_LIB_DIR/srcs/stainless-library_$SCALA_LIB_VERSION-sources.jar" "$OUT_LIB_DIR/stainless-library_$SCALA_LIB_VERSION-$STAINLESS_VERSION-sources.jar"
+cp "$PUBLISHED_LIB_DIR/poms/stainless-library_$SCALA_LIB_VERSION.pom" "$OUT_LIB_DIR/stainless-library_$SCALA_LIB_VERSION-$STAINLESS_VERSION.pom"
 
 info "$(tput bold)[] Preparing Dotty plugin jar..."
-OUT_DOTTY_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-dotty-plugin_3.2.0/$STAINLESS_VERSION"
+OUT_DOTTY_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-dotty-plugin_$SCALA_VERSION/$STAINLESS_VERSION"
 mkdir -p "$OUT_DOTTY_DIR"
-cp "$PUBLISHED_DOTTY_DIR/jars/stainless-dotty-plugin_3.2.0.jar" "$OUT_DOTTY_DIR/stainless-dotty-plugin_3.2.0-$STAINLESS_VERSION.jar"
-cp "$PUBLISHED_DOTTY_DIR/poms/stainless-dotty-plugin_3.2.0.pom" "$OUT_DOTTY_DIR/stainless-dotty-plugin_3.2.0-$STAINLESS_VERSION.pom"
+cp "$PUBLISHED_DOTTY_DIR/jars/stainless-dotty-plugin_$SCALA_VERSION.jar" "$OUT_DOTTY_DIR/stainless-dotty-plugin_$SCALA_VERSION-$STAINLESS_VERSION.jar"
+cp "$PUBLISHED_DOTTY_DIR/poms/stainless-dotty-plugin_$SCALA_VERSION.pom" "$OUT_DOTTY_DIR/stainless-dotty-plugin_$SCALA_VERSION-$STAINLESS_VERSION.pom"
 
 info "$(tput bold)[] Preparing Scalac plugin jar..."
-OUT_SCALAC_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-scalac-plugin_3.2.0/$STAINLESS_VERSION"
+OUT_SCALAC_DIR="$OUTPUT/stainless/ch/epfl/lara/stainless-scalac-plugin_$SCALA_VERSION/$STAINLESS_VERSION"
 mkdir -p "$OUT_SCALAC_DIR"
-cp "$PUBLISHED_SCALAC_DIR/jars/stainless-scalac-plugin_3.2.0.jar" "$OUT_SCALAC_DIR/stainless-scalac-plugin_3.2.0-$STAINLESS_VERSION.jar"
-cp "$PUBLISHED_SCALAC_DIR/poms/stainless-scalac-plugin_3.2.0.pom" "$OUT_SCALAC_DIR/stainless-scalac-plugin_3.2.0-$STAINLESS_VERSION.pom"
+cp "$PUBLISHED_SCALAC_DIR/jars/stainless-scalac-plugin_$SCALA_VERSION.jar" "$OUT_SCALAC_DIR/stainless-scalac-plugin_$SCALA_VERSION-$STAINLESS_VERSION.jar"
+cp "$PUBLISHED_SCALAC_DIR/poms/stainless-scalac-plugin_$SCALA_VERSION.pom" "$OUT_SCALAC_DIR/stainless-scalac-plugin_$SCALA_VERSION-$STAINLESS_VERSION.pom"
 
 info "$(tput bold)[] Creating archive..."
 ARCHIVE="sbt-stainless"

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/GhostAccessRewriter.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/GhostAccessRewriter.scala
@@ -13,9 +13,9 @@ import Contexts.{Context => DottyContext}
 import plugins._
 import transform._
 
-class GhostAccessRewriter extends PluginPhase { self =>
+class GhostAccessRewriter(afterPhase: String) extends PluginPhase { self =>
   override val phaseName = "ghost-removal"
-  override val runsAfter = Set("stainless")
+  override val runsAfter = Set(afterPhase)
   override val runsBefore = Set(FirstTransform.name)
 
   override def run(using dottyCtx: DottyContext): Unit = (new GhostAccessMacroTransform).run

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/StainlessPlugin.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/StainlessPlugin.scala
@@ -37,7 +37,7 @@ class StainlessPlugin extends StandardPlugin {
         Some(new ExtractionAndVerification)
       else None,
       if (pluginOpts.enableGhostElimination)
-        Some(new GhostAccessRewriter)
+        Some(new GhostAccessRewriter(if (pluginOpts.enableVerification) "stainless" else Pickler.name))
       else None
     ).flatten
   }


### PR DESCRIPTION
Disabling Stainless verification would cause a crash due to `ghost-elim` depending on being run after `stainless`.