### PR TITLE
Add assertion for non-negative `Array.fill` size

### DIFF
--- a/core/src/main/scala/stainless/verification/AssertionInjector.scala
+++ b/core/src/main/scala/stainless/verification/AssertionInjector.scala
@@ -72,6 +72,17 @@ class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees, va
         ).copiedFrom(e)
       }}}
 
+    case s.LargeArray(elems, default, size, base) =>
+      val recElems = elems.view.mapValues(transform).toMap
+      val recDefault = transform(default)
+      bindIfCannotDuplicate(size, "sz") { sz =>
+        t.Assert(
+          t.GreaterEquals(sz, t.Int32Literal(0)),
+          Some("Non-negative array size"),
+          t.LargeArray(recElems, recDefault, sz, transform(base)).copiedFrom(e)
+        ).copiedFrom(e)
+      }
+
     case sel @ s.ADTSelector(recv, selector) =>
       if (sel.constructor.sort.constructors.size == 1)
         t.ADTSelector(transform(recv), selector).copiedFrom(e)

--- a/frontends/benchmarks/imperative/invalid/NegativeArrayFill.scala
+++ b/frontends/benchmarks/imperative/invalid/NegativeArrayFill.scala
@@ -1,0 +1,5 @@
+object NegativeArrayFill {
+  def test(len: Int): Unit = {
+    val arr = Array.fill(len)(42)
+  }
+}


### PR DESCRIPTION
`Array.fill` requires a non-negative size