### PR TITLE
Support for `new Array(len)` constructor for primitive types

### DIFF
--- a/frontends/benchmarks/extraction/invalid/NewArrayNonPrimitive.check
+++ b/frontends/benchmarks/extraction/invalid/NewArrayNonPrimitive.check
@@ -1,0 +1,4 @@
+[ Error  ] NewArrayNonPrimitive.scala:5:15: Cannot use array constructor for non-primitive type String
+[ Error  ] Hint: you may use `Array.fill` instead
+               val arr = new Array[String](len)
+                         ^^^^^^^^^^^^^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/NewArrayNonPrimitive.scala
+++ b/frontends/benchmarks/extraction/invalid/NewArrayNonPrimitive.scala
@@ -1,0 +1,7 @@
+object NewArrayNonPrimitive {
+  def test(len: Int): Unit = {
+    require(len >= 0)
+    // Cannot use array constructor for non-primitive type String
+    val arr = new Array[String](len)
+  }
+}

--- a/frontends/benchmarks/imperative/invalid/NewArrayNeg.scala
+++ b/frontends/benchmarks/imperative/invalid/NewArrayNeg.scala
@@ -1,0 +1,5 @@
+object NewArrayNeg {
+  def test(len: Int): Unit = {
+    val arr = new Array[Long](len)
+  }
+}

--- a/frontends/benchmarks/imperative/valid/NewArrayPrimitive.scala
+++ b/frontends/benchmarks/imperative/valid/NewArrayPrimitive.scala
@@ -1,0 +1,42 @@
+object NewArrayPrimitive {
+  def test0(len: Int): Unit = {
+    require(len >= 0)
+    val arr = new Array[Long](len)
+    if (len > 0) {
+      assert(arr(len - 1) == (0 : Long))
+    }
+  }
+
+  def test1(len: Int): Unit = {
+    require(len >= 0)
+    val arr = new Array[Int](len)
+    if (len > 0) {
+      assert(arr(len - 1) == 0)
+    }
+  }
+
+  def test2(len: Int): Unit = {
+    require(len >= 0)
+    val arr = new Array[Short](len)
+    if (len > 0) {
+      assert(arr(len - 1) == (0 : Short))
+    }
+  }
+
+  def test3(len: Int): Unit = {
+    require(len >= 0)
+    val arr = new Array[Byte](len)
+    if (len > 0) {
+      assert(arr(len - 1) == (0 : Byte))
+    }
+  }
+
+  def test4(len: Int): Unit = {
+    require(len >= 0)
+    val arr = new Array[Char](len)
+    if (len > 0) {
+      assert(arr(len - 1) == (0 : Char))
+    }
+  }
+
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1580,6 +1580,14 @@ class CodeExtraction(inoxCtx: inox.Context, symbolMapping: SymbolMapping)(using 
       case lct: xt.LocalClassType => xt.LocalClassConstructor(lct, args map extractTree)
       case ct: xt.ClassType => xt.ClassConstructor(ct, args map extractTree)
       case tt: xt.TupleType => xt.Tuple(args map extractTree)
+      case at: xt.ArrayType if args.size == 1 && extractType(args.head.tpe)(using dctx, tr.sourcePos) == xt.Int32Type() =>
+        mkZeroForPrimitive(at.base) match {
+          case Some(zero) =>
+            val recArg = extractTree(args.head)
+            xt.LargeArray(Map.empty, zero, recArg, at.base)
+          case None =>
+            outOfSubsetError(tr, s"Cannot use array constructor for non-primitive type ${at.base}\nHint: you may use `Array.fill` instead")
+        }
       case _ => outOfSubsetError(tr, "Unexpected constructor " + tr.show + "   " + tpe.show)
     }
 
@@ -2425,6 +2433,13 @@ class CodeExtraction(inoxCtx: inox.Context, symbolMapping: SymbolMapping)(using 
         dctx.vars.get(sym).map(e => e())
       case _ => None
     }
+  }
+
+  private def mkZeroForPrimitive(tp: xt.Type): Option[xt.Expr] = tp match {
+    case xt.BooleanType() => Some(xt.BooleanLiteral(false))
+    case xt.BVType(signed, size) => Some(xt.BVLiteral(signed, 0, size))
+    case xt.CharType() => Some(xt.CharLiteral(0.toChar))
+    case _ => None
   }
 
   // @extern function may contain constructs that are not supported by Stainless.

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -1352,6 +1352,14 @@ trait CodeExtraction extends ASTExtractors {
           xt.LocalClassConstructor(lct, args.map(extractTree))
         case ct: xt.ClassType =>
           xt.ClassConstructor(ct, args.map(extractTree))
+        case at: xt.ArrayType if args.size == 1 && extractType(args.head.tpe)(using dctx, tr.pos) == xt.Int32Type() =>
+          mkZeroForPrimitive(at.base) match {
+            case Some(zero) =>
+              val recArg = extractTree(args.head)
+              xt.LargeArray(Map.empty, zero, recArg, at.base)
+            case None =>
+              outOfSubsetError(tr, s"Cannot use array constructor for non-primitive type ${at.base}\nHint: you may use `Array.fill` instead")
+          }
         case _ =>
           outOfSubsetError(tr, "Construction of a non-class type.")
       }
@@ -2071,6 +2079,13 @@ trait CodeExtraction extends ASTExtractors {
         outOfSubsetError(NoPosition, "Tree with null-pointer as type found")
       }
   }).setPos(pos)
+
+  private def mkZeroForPrimitive(tp: xt.Type): Option[xt.Expr] = tp match {
+    case xt.BooleanType() => Some(xt.BooleanLiteral(false))
+    case xt.BVType(signed, size) => Some(xt.BVLiteral(signed, 0, size))
+    case xt.CharType() => Some(xt.CharLiteral(0.toChar))
+    case _ => None
+  }
 
   // @extern function may contain constructs that are not supported by Stainless.
   // However, we must be sure that we have captured all contracts.


### PR DESCRIPTION
This allows for efficient array creation (at runtime) for primitive types that are initialized to their zero value.