### PR TITLE
Cell swap (#2)

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala
@@ -494,6 +494,32 @@ class AntiAliasing(override val s: Trees)(override val t: s.type)(using override
                 Block(updates.init, updates.last).setPos(swap)
               ).setPos(swap)
 
+          case cellSwap @ CellSwap(cell1, cell2) =>
+            // Though `cell1`, `cell2` are all normalized, we still need to recursively transform
+            // them, as they can refer to constructs that needs transformation, such as lambdas that mutate their params
+            val recCell1 = transform(cell1, env)
+            val recCell2 = transform(cell2, env)
+
+            val base = recCell1.getType.asInstanceOf[ClassType].tps.head
+
+            val cellClassDef = symbols.lookup.get[ClassDef]("stainless.lang.Cell").get
+            val vFieldId = cellClassDef.fields.head.id
+
+            val temp = ValDef.fresh("temp", base).setPos(cellSwap)
+            val targets1 = getDirectTargetsDealiased(cell1, ClassFieldAccessor(vFieldId), env)
+              .getOrElse(throw MalformedStainlessCode(cellSwap, "Unsupported cellSwap (first cell)"))
+            val targets2 = getDirectTargetsDealiased(cell2, ClassFieldAccessor(vFieldId), env)
+              .getOrElse(throw MalformedStainlessCode(cellSwap, "Unsupported cellSwap (second cell)"))
+
+            val updates1 = updatedTargetsAndAliases(targets2, ClassSelector(cell1, vFieldId).setPos(cellSwap), env, cellSwap.getPos)
+            val updates2 = updatedTargetsAndAliases(targets1, temp.toVariable, env, cellSwap.getPos)
+            val updates = updates1 ++ updates2
+            if (updates.isEmpty) UnitLiteral().setPos(cellSwap)
+            else
+              Let(temp, transform(ClassSelector(cell2, vFieldId).setPos(cellSwap), env),
+                Block(updates.init, updates.last).setPos(cellSwap)
+              ).setPos(cellSwap)
+
           case l @ Let(vd, e, b) if isMutableType(vd.tpe) =>
             // see https://github.com/epfl-lara/stainless/pull/920 for discussion
 

--- a/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/TransformerWithType.scala
@@ -53,6 +53,13 @@ trait TransformerWithType extends oo.TransformerWithType {
         transform(index2, s.Int32Type()),
       ).copiedFrom(expr)
 
+    case s.CellSwap(cell1, cell2) =>
+      val at = widen(cell1.getType): @unchecked
+      t.CellSwap(
+        transform(cell1, at),
+        transform(cell2, at),
+      ).copiedFrom(expr)
+
     case s.MutableMapWithDefault(from, to, default) =>
       t.MutableMapWithDefault(transform(from), transform(to),
         transform(default, s.FunctionType(Seq(), to))

--- a/core/src/main/scala/stainless/extraction/imperative/Trees.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/Trees.scala
@@ -33,6 +33,21 @@ trait Trees extends oo.Trees with Definitions { self =>
       }
   }
 
+  /* Cell Operations */
+
+    /** Swap values from two (not necessarily distinct) cells */
+  sealed case class CellSwap(cell1: Expr, cell2: Expr) extends Expr with CachingTyped {
+    override protected def computeType(using s: Symbols): Type =
+      val cellClassDef = s.lookup.get[ClassDef]("stainless.lang.Cell")
+      (cell1.getType, cell2.getType) match {
+        case (ClassType(id1, tps1), ClassType(id2, tps2)) if cellClassDef.isDefined && id1 == cellClassDef.get.id && id1 == id2 && tps1 == tps2 => {
+          UnitType() 
+        }
+        case _ =>
+          Untyped
+      }
+  }
+
   /** $encodingof `{ expr1; expr2; ...; exprn; last }` */
   case class Block(exprs: Seq[Expr], last: Expr) extends Expr with CachingTyped {
     protected def computeType(using Symbols): Type = if (exprs.forall(_.isTyped)) last.getType else Untyped
@@ -278,6 +293,9 @@ trait Printer extends oo.Printer {
     case Swap(array1, index1, array2, index2) =>
       p"swap($array1, $index1, $array2, $index2)"
 
+    case CellSwap(cell1, cell2) => 
+      p"swap($cell1, $cell2)"
+
     case LetVar(vd, value, expr) =>
       p"""|var $vd = $value
           |$expr"""
@@ -428,6 +446,9 @@ trait TreeDeconstructor extends oo.TreeDeconstructor {
 
     case s.Swap(array1, index1, array2, index2) =>
       (Seq(), Seq(), Seq(array1, index1, array2, index2), Seq(), Seq(), (_, _, es, _, _) => t.Swap(es(0), es(1), es(2), es(3)))
+
+    case s.CellSwap(cell1, cell2) =>
+      (Seq(), Seq(), Seq(cell1, cell2), Seq(), Seq(), (_, _, es, _, _) => t.CellSwap(es(0), es(1)))
 
     case s.MutableMapWithDefault(from, to, default) =>
       (Seq(), Seq(), Seq(default), Seq(from, to), Seq(), (_, _, es, tps, _) => t.MutableMapWithDefault(tps(0), tps(1), es(0)))

--- a/core/src/main/scala/stainless/extraction/termination/.scalafmt.conf
+++ b/core/src/main/scala/stainless/extraction/termination/.scalafmt.conf
@@ -1,2 +1,3 @@
+runner.dialect = "scala3"
 align = some
 maxColumn = 110

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -930,6 +930,23 @@ private class S2IRImpl(override val s: tt.type,
         CIR.Assign(CIR.ArrayAccess(a2, i2), tmp),
       ))
 
+    case CellSwap(cell1, cell2) =>
+      val cellBaseType = cell1.getType.asInstanceOf[ClassType].tps.head
+      val cellClassDef = symbols.lookup.get[ClassDef]("stainless.lang.Cell").get
+      val vFieldId: Identifier = cellClassDef.fields.head.id
+      val c1 = rec(cell1)
+      val c2 = rec(cell2)
+      val tmpId = rec(FreshIdentifier("tmp"))
+      val tmpVd = CIR.ValDef(tmpId, rec(cellBaseType), false)
+      val tmp = CIR.Binding(tmpVd)
+      throw new Exception(f"CellSwap to IR phase: cellBase type = $cellBaseType; vField Id = $vFieldId")
+      CIR.buildBlock(Seq(
+        CIR.Decl(tmpVd, Some(CIR.FieldAccess(c2, rec(vFieldId, withUnique = false)))),
+        CIR.Assign(CIR.FieldAccess(c2, rec(vFieldId, withUnique = false)), CIR.FieldAccess(c1, rec(vFieldId, withUnique = false))),
+        CIR.Assign(CIR.FieldAccess(c1, rec(vFieldId, withUnique = false)), tmp),
+      ))
+
+
     case array @ FiniteArray(elems, base) =>
       val arrayType = CIR.ArrayType(rec(base), None)
       val length = elems.size

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -939,7 +939,6 @@ private class S2IRImpl(override val s: tt.type,
       val tmpId = rec(FreshIdentifier("tmp"))
       val tmpVd = CIR.ValDef(tmpId, rec(cellBaseType), false)
       val tmp = CIR.Binding(tmpVd)
-      throw new Exception(f"CellSwap to IR phase: cellBase type = $cellBaseType; vField Id = $vFieldId")
       CIR.buildBlock(Seq(
         CIR.Decl(tmpVd, Some(CIR.FieldAccess(c2, rec(vFieldId, withUnique = false)))),
         CIR.Assign(CIR.FieldAccess(c2, rec(vFieldId, withUnique = false)), CIR.FieldAccess(c1, rec(vFieldId, withUnique = false))),

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -99,9 +99,9 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
   /** An extension to the set of registered classes in the `StainlessSerializer`.
     * occur within Stainless programs.
     *
-    * The new identifiers in the mapping range from 180 to 261.
+    * The new identifiers in the mapping range from 180 to 262.
     *
-    * NEXT ID: 262
+    * NEXT ID: 263
     */
   override protected def classSerializers: Map[Class[_], Serializer[_]] =
     super.classSerializers ++ Map(
@@ -146,6 +146,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       stainlessClassSerializer[MutableMapUpdated]      (252),
       stainlessClassSerializer[MutableMapDuplicate]    (253),
       stainlessClassSerializer[Swap]                   (259),
+      stainlessClassSerializer[Swap]                   (262),
       stainlessClassSerializer[FreshCopy]              (260),
       stainlessClassSerializer[Reads]                  (182),
       stainlessClassSerializer[Modifies]               (210),

--- a/core/src/main/scala/stainless/utils/Serialization.scala
+++ b/core/src/main/scala/stainless/utils/Serialization.scala
@@ -146,7 +146,7 @@ class XLangSerializer(override val trees: extraction.xlang.Trees, serializeProdu
       stainlessClassSerializer[MutableMapUpdated]      (252),
       stainlessClassSerializer[MutableMapDuplicate]    (253),
       stainlessClassSerializer[Swap]                   (259),
-      stainlessClassSerializer[Swap]                   (262),
+      stainlessClassSerializer[CellSwap]               (262),
       stainlessClassSerializer[FreshCopy]              (260),
       stainlessClassSerializer[Reads]                  (182),
       stainlessClassSerializer[Modifies]               (210),

--- a/frontends/benchmarks/imperative/valid/CellSwap.scala
+++ b/frontends/benchmarks/imperative/valid/CellSwap.scala
@@ -1,7 +1,8 @@
 import stainless.lang.swap
+import stainless.lang.Cell
 
 object CellSwap {
-  def test(c1: Cell[BigInt], c2: Cell[BigInt]): Unit = {
+  def test(c1: Cell[Int], c2: Cell[Int]): Unit = {
     require(c1.v == 1 && c2.v == 2)
 
     swap(c1, c2)

--- a/frontends/benchmarks/imperative/valid/CellSwap.scala
+++ b/frontends/benchmarks/imperative/valid/CellSwap.scala
@@ -1,0 +1,19 @@
+import stainless.lang.swap
+
+object CellSwap {
+  def test(c1: Cell[BigInt], c2: Cell[BigInt]): Unit = {
+    require(c1.v == 1 && c2.v == 2)
+
+    swap(c1, c2)
+    assert(c1.v == 2)
+    assert(c2.v == 1)
+    swap(c1, c1)
+    assert(c1.v == 2)
+    c1.v = 42
+    assert(c1.v == 42)
+    swap(c1, c2)
+    assert(c1.v == 1)
+    assert(c2.v == 42)
+  }
+
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -102,6 +102,7 @@ trait ASTExtractors {
   protected lazy val mutableMapSym  = classFromName("stainless.lang.MutableMap")
   protected lazy val bagSym         = classFromName("stainless.lang.Bag")
   protected lazy val realSym        = classFromName("stainless.lang.Real")
+   protected lazy val cellSym       = classFromName("stainless.lang.Cell")
 
   protected lazy val bvSym          = classFromName("stainless.math.BitVectors.BV")
 
@@ -196,6 +197,10 @@ trait ASTExtractors {
 
   def isRealSym(sym: Symbol) : Boolean = {
     getResolvedTypeSym(sym) == realSym
+  }
+
+  def isCellSym(sym: Symbol): Boolean = {
+    getResolvedTypeSym(sym) == cellSym
   }
 
   def isScalaSetSym(sym: Symbol) : Boolean = {
@@ -1399,6 +1404,23 @@ trait ASTExtractors {
           Some((array1, index1, array2, index2))
         case _ => None
       }
+    }
+
+    object ExCellSwapExpression {
+      def unapply(
+          tree: tpd.Apply
+      ): Option[(tpd.Tree, tpd.Tree)] =
+        tree match {
+          case Apply(
+                TypeApply(
+                  ExSymbol("stainless", "lang", "package$", "swap"),
+                  _
+                ),
+                cell1 :: cell2 :: Nil
+              ) =>
+            Some((cell1, cell2))
+          case _ => None
+        }
     }
 
     object ExForallExpression {

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -1530,6 +1530,8 @@ class CodeExtraction(inoxCtx: inox.Context, symbolMapping: SymbolMapping)(using 
     case ExSwapExpression(array1, index1, array2, index2) =>
       xt.Swap(extractTree(array1), extractTree(index1), extractTree(array2), extractTree(index2))
 
+    case ExCellSwapExpression(cell1, cell2) => xt.CellSwap(extractTree(cell1), extractTree(cell2))
+
     case ExForallExpression(fun) =>
       extractTree(fun) match {
         case l: xt.Lambda => xt.Forall(l.params, l.body).setPos(l)
@@ -1576,7 +1578,8 @@ class CodeExtraction(inoxCtx: inox.Context, symbolMapping: SymbolMapping)(using 
         case e => (xt.TupleSelect(e, 1).setPos(e), xt.TupleSelect(e, 2).setPos(e))
       }, extractType(tpt))
 
-    case ExClassConstruction(tpe, args) => extractType(tpe)(using dctx, tr.sourcePos) match {
+    case ExClassConstruction(tpe, args) => 
+      extractType(tpe)(using dctx, tr.sourcePos) match {
       case lct: xt.LocalClassType => xt.LocalClassConstructor(lct, args map extractTree)
       case ct: xt.ClassType => xt.ClassConstructor(ct, args map extractTree)
       case tt: xt.TupleType => xt.Tuple(args map extractTree)

--- a/frontends/library/stainless/lang/Cell.scala
+++ b/frontends/library/stainless/lang/Cell.scala
@@ -1,0 +1,14 @@
+/** Author: Samuel Chassot
+ * 
+ * Cell class
+ * 
+ * Used to provide better handling of mutable state
+ **/
+
+package stainless.lang
+
+import stainless.annotation._
+
+
+@library
+case class Cell[@mutable T](var v: T) 

--- a/frontends/library/stainless/lang/package.scala
+++ b/frontends/library/stainless/lang/package.scala
@@ -4,6 +4,7 @@ package stainless
 
 import stainless.annotation._
 import stainless.lang.StaticChecks._
+import stainless.lang.Cell
 
 package object lang {
 
@@ -179,6 +180,13 @@ package object lang {
     val t = a1(i1)
     a1(i1) = a2(i2)
     a2(i2) = t
+  }
+
+  @ignore @library
+    def swap[@mutable T](c1: Cell[T], c2: Cell[T]): Unit = {
+      val t = c2.v
+      c2.v = c1.v
+      c1.v = t
   }
 
   @extern @library @mutable @anyHeapRef

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/ASTExtractors.scala
@@ -73,6 +73,7 @@ trait ASTExtractors {
   protected lazy val mutableMapSym = classFromName("stainless.lang.MutableMap")
   protected lazy val bagSym        = classFromName("stainless.lang.Bag")
   protected lazy val realSym       = classFromName("stainless.lang.Real")
+  protected lazy val cellSym       = classFromName("stainless.lang.Cell")
 
   protected lazy val bvSym         = classFromName("stainless.math.BitVectors.BV")
 
@@ -130,6 +131,10 @@ trait ASTExtractors {
 
   def isRealSym(sym: Symbol) : Boolean = {
     getResolvedTypeSym(sym) == realSym
+  }
+
+  def isCellClassSym(sym: Symbol): Boolean = {
+    sym == cellSym
   }
 
   def isMapSym(sym: Symbol) : Boolean = {
@@ -909,6 +914,17 @@ trait ASTExtractors {
               TypeApply(ExSymbol("stainless", "lang", "swap"), _),
               array1 :: index1 :: array2 :: index2 :: Nil) =>
             Some((array1, index1, array2, index2))
+        case _ => None
+      }
+    }
+
+    object ExCellSwapExpression {
+      def unapply(tree: Apply): Option[(Tree, Tree)] = tree match {
+        case Apply(
+              TypeApply(ExSymbol("stainless", "lang", "swap"), _),
+              cell1 :: cell2 :: Nil
+            ) =>
+          Some((cell1, cell2))
         case _ => None
       }
     }

--- a/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
+++ b/frontends/scalac/src/main/scala/stainless/frontends/scalac/CodeExtraction.scala
@@ -1279,6 +1279,9 @@ trait CodeExtraction extends ASTExtractors {
 
     case swap @ ExSwapExpression(array1, index1, array2, index2) =>
       xt.Swap(extractTree(array1), extractTree(index1), extractTree(array2), extractTree(index2))
+    
+    case cellSwap @ ExCellSwapExpression(cell1, cell2) =>
+      xt.CellSwap(extractTree(cell1), extractTree(cell2))
 
     case l @ ExLambdaExpression(args, body) =>
       val vds = args map(vd => xt.ValDef(

--- a/libfiles.txt
+++ b/libfiles.txt
@@ -1,6 +1,7 @@
 stainless/util/Random.scala
 stainless/util/Timepoint.scala
 stainless/lang/Option.scala
+stainless/lang/Cell.scala
 stainless/lang/PartialFunction.scala
 stainless/lang/StaticChecks.scala
 stainless/lang/Real.scala


### PR DESCRIPTION
Add a new `Cell` feature with a `swap` to support more mutability, notably swapping 2 variables.

This adds a new `Cell` class in the library, and a `swap` function exchanging their values:

```scala
case class Cell[@mutable T](var v: T) 

def swap[@mutable T](c1: Cell[T], c2: Cell[T]): Unit = {
      val t = c2.v
      c2.v = c1.v
      c1.v = t
  }
```

These can be used as follows:

```scala
import stainless.lang._

object Test {

  def f(c1: Cell[Int], c2: Cell[Int]): Unit = {
    require(c1.v == 1)
    require(c2.v == 2)

    c1.v = 3
    swap(c1, c2)
    assert(c1.v == 2)
    assert(c2.v == 3)
  }
}
```


