### PR TITLE
Fix `while` loops being mistakenly considered as ghost

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/GhostChecker.scala
@@ -81,6 +81,9 @@ trait GhostChecker { self: EffectsAnalyzer =>
       case FieldAssignment(_, _, _) => false
       case Block(_, e) => isGhostExpression(e)
 
+      // Invariants on `while` are allowed to be ghost
+      case While(cond, body, _, _, flags) => flags.contains(Ghost) || isGhostExpression(cond) || isGhostExpression(body)
+
       case Operator(es, _) => es.exists(isGhostExpression)
     }
 

--- a/frontends/benchmarks/imperative/valid/WhileInvGhost.scala
+++ b/frontends/benchmarks/imperative/valid/WhileInvGhost.scala
@@ -1,0 +1,17 @@
+import stainless.lang.{WhileDecorations => _, _}
+import stainless.annotation._
+import StaticChecks._
+
+object WhileInvGhost {
+  @ghost
+  def inv(x: BigInt): Boolean = x >= 0
+
+  def appendBits(x: BigInt): Unit = {
+    require(x >= 0)
+    var i: BigInt = 0
+    (while (i < x) {
+      decreases(x - i)
+      i += 1
+    }).invariant(inv(i))
+  }
+}


### PR DESCRIPTION
This PR fixes `while` loops being treated as ghost when they referred to ghost constructs in their `invariant`.