### PR TITLE
Relax `isExpressionFresh` and improve aliasing error messages

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -698,8 +698,9 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       case Old(_) => true
 
       case fi @ FunctionInvocation(id, _, _) if !symbols.isRecursive(id) =>
-        BodyWithSpecs(symbols.simplifyLets(fi.inlined))
-          .bodyOpt
+        val specced = BodyWithSpecs(symbols.simplifyLets(fi.inlined))
+        specced.bodyOpt
+          .map(specced.wrapLets)
           .forall(isExpressionFresh)
 
       // other function invocations always return a fresh expression, by hypothesis (global assumption)
@@ -719,7 +720,9 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       // For `Let`, it is safe to add `vd` as a fresh binding because we disallow
       // `FieldAssignments` with non-fresh expressions in `EffetsChecker.check(fd: FunAbstraction)`.
       // See discussion on: https://github.com/epfl-lara/stainless/pull/985#discussion_r614583479
-      case Let(vd, e, b) => rec(e, bindings) && rec(b, bindings + vd)
+      case Let(vd, e, b) =>
+        val eFresh = rec(e, bindings)
+        rec(b, if (eFresh) bindings + vd else bindings)
 
       // A `LetVar` can be fresh if `vd` is only assigned fresh values both
       // here and in all subsequent Assign statements.
@@ -736,7 +739,12 @@ trait EffectsAnalyzer extends oo.CachingPhase {
       case Block(_, e) => rec(e, bindings)
 
       case IfExpr(_, e1, e2) => rec(e1, bindings) && rec(e2, bindings)
-      case MatchExpr(_, cases) => cases.forall(cse => rec(cse.rhs, bindings))
+      case MatchExpr(scrut, cases) =>
+        val scrutFresh = rec(scrut, bindings)
+        cases.forall {  cse =>
+          val extraBdgs = if (scrutFresh) cse.pattern.binders else Set.empty
+          rec(cse.rhs, bindings ++ extraBdgs)
+        }
 
       //any other expression is conservatively assumed to be non-fresh if
       //any sub-expression is non-fresh

--- a/frontends/benchmarks/extraction/invalid/AliasedFreshExpr.check
+++ b/frontends/benchmarks/extraction/invalid/AliasedFreshExpr.check
@@ -1,0 +1,3 @@
+[ Error  ] AliasedFreshExpr.scala:14:5: Illegal passing of aliased parameters c1 (with target: Target(c1, None, )) and c1 (with target: Target(c1, None, ))
+               Trout(c1, c1)
+               ^^^^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/AliasedFreshExpr.scala
+++ b/frontends/benchmarks/extraction/invalid/AliasedFreshExpr.scala
@@ -1,0 +1,16 @@
+object AliasedFreshExpr {
+  case class C1(var c2: C2)
+  case class C2(var c3: C3)
+  case class C3(var bi: BigInt)
+
+  sealed trait Fish
+  case class Trout(c11: C1, c12: C1) extends Fish
+  case class Cod(c1: C1, c2: C2) extends Fish
+  case class Salmon(c1: C1, c3: C3) extends Fish
+
+  def test1(x: BigInt): Fish = {
+    val c1 = C1(C2(C3(x)))
+    // This expression is fresh, but is not alias-free
+    Trout(c1, c1)
+  }
+}

--- a/frontends/benchmarks/extraction/invalid/ArrayShenanigans1.check
+++ b/frontends/benchmarks/extraction/invalid/ArrayShenanigans1.check
@@ -1,3 +1,3 @@
-[ Error  ] ArrayShenanigans1.scala:13:14: Illegal aliasing: arrij
+[ Error  ] ArrayShenanigans1.scala:13:14: Cannot update an array whose element type (Ref) is mutable with a non-fresh expression
                arr(i) = arrij
                         ^^^^^

--- a/frontends/benchmarks/extraction/invalid/ArrayShenanigans2.check
+++ b/frontends/benchmarks/extraction/invalid/ArrayShenanigans2.check
@@ -1,3 +1,3 @@
-[ Error  ] ArrayShenanigans2.scala:13:14: Illegal aliasing: arrj
+[ Error  ] ArrayShenanigans2.scala:13:14: Cannot update an array whose element type (Ref) is mutable with a non-fresh expression
                arr(i) = arrj
                         ^^^^

--- a/frontends/benchmarks/extraction/invalid/ArrayShenanigans3.check
+++ b/frontends/benchmarks/extraction/invalid/ArrayShenanigans3.check
@@ -1,3 +1,3 @@
-[ Error  ] ArrayShenanigans3.scala:14:31: Illegal aliasing: arrjk
+[ Error  ] ArrayShenanigans3.scala:14:31: Cannot update an array whose element type (Ref) is mutable with a non-fresh expression
                val arr2 = arr.updated(i, arrjk)
                                          ^^^^^

--- a/frontends/benchmarks/extraction/invalid/ArrayShenanigans4.check
+++ b/frontends/benchmarks/extraction/invalid/ArrayShenanigans4.check
@@ -1,3 +1,3 @@
-[ Error  ] ArrayShenanigans4.scala:12:31: Illegal aliasing: arr(j)
+[ Error  ] ArrayShenanigans4.scala:12:31: Cannot update an array whose element type (Ref) is mutable with a non-fresh expression
                val arr2 = arr.updated(i, arr(j))
                                          ^^^^^^

--- a/frontends/benchmarks/extraction/invalid/ArrayShenanigans5.check
+++ b/frontends/benchmarks/extraction/invalid/ArrayShenanigans5.check
@@ -1,3 +1,3 @@
-[ Error  ] ArrayShenanigans5.scala:11:31: Illegal aliasing: r
+[ Error  ] ArrayShenanigans5.scala:11:31: Cannot update an array whose element type (Ref) is mutable with a non-fresh expression
                val arr2 = arr.updated(i, r)
                                          ^

--- a/frontends/benchmarks/extraction/invalid/BadAliasing1.check
+++ b/frontends/benchmarks/extraction/invalid/BadAliasing1.check
@@ -1,3 +1,3 @@
-[ Error  ] BadAliasing1.scala:9:5: Illegal aliasing: a
+[ Error  ] BadAliasing1.scala:9:5: Cannot update a field whose type (A) is mutable with a non-fresh expression
                a.x = 0
                ^

--- a/frontends/benchmarks/extraction/invalid/BadAliasing2.check
+++ b/frontends/benchmarks/extraction/invalid/BadAliasing2.check
@@ -1,3 +1,3 @@
-[ Error  ] BadAliasing2.scala:10:5: Illegal aliasing: a
+[ Error  ] BadAliasing2.scala:10:5: Cannot update an array whose element type (A) is mutable with a non-fresh expression
                a.x = 0
                ^

--- a/frontends/benchmarks/extraction/invalid/IllegalAliasing.check
+++ b/frontends/benchmarks/extraction/invalid/IllegalAliasing.check
@@ -1,3 +1,10 @@
 [ Error  ] IllegalAliasing.scala:9:13: Illegal aliasing: Mut[S](a)
+[ Error  ] Hint: this error occurs due to:
+[ Error  ]   -the type of b (Mut[S]) being mutable
+[ Error  ]   -the definition of b not being fresh
+[ Error  ]   -the definition of b containing variables of mutable types
+[ Error  ]   that also appear after the declaration of b:
+[ Error  ]     -a (of type S)
+[ Error  ]
                val b = Mut(a)
                        ^^^^^^

--- a/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.check
+++ b/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.check
@@ -1,0 +1,3 @@
+[ Error  ] InnerClassesInvariants2.scala:13:20: Local classes cannot close over mutable variables
+                   assert(0 < y.value && y.value < 10)
+                              ^

--- a/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.dotty.check
+++ b/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.dotty.check
@@ -1,3 +1,0 @@
-[ Error  ] InnerClassesInvariants2.scala:6:21: value value is not a member of ref
-               require(0 < ref.value && ref.value < 10)
-                               ^

--- a/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.scala
+++ b/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.scala
@@ -3,18 +3,18 @@ object InnerClassesInvariants1 {
   case class Ref(var value: BigInt)
 
   def rejected(x: Ref): Unit = {
-    require(0 < ref.value && ref.value < 10)
+    require(0 < x.value && x.value < 10)
     var y = x
     val z = y
 
     case class Local() {
       def smth: Unit = {
         assert(0 < x.value && x.value < 10)
-        assert(0 < y.value && y.value < 10)
+        assert(0 < y.value && y.value < 10)  // Local classes cannot close over mutable variables
         assert(0 < z.value && z.value < 10)
       }
     }
     val local = Local()
-    y.value = 42 // Illegal aliasing
+    y.value = 42
   }
 }

--- a/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.scalac.check
+++ b/frontends/benchmarks/extraction/invalid/InnerClassesInvariants2.scalac.check
@@ -1,6 +1,0 @@
-[ Error  ] InnerClassesInvariants2.scala:6:21: object value is not a member of package ref
-               require(0 < ref.value && ref.value < 10)
-                               ^
-[ Error  ] InnerClassesInvariants2.scala:6:34: object value is not a member of package ref
-               require(0 < ref.value && ref.value < 10)
-                                            ^

--- a/frontends/benchmarks/extraction/invalid/MutateInside11.check
+++ b/frontends/benchmarks/extraction/invalid/MutateInside11.check
@@ -1,3 +1,10 @@
 [ Error  ] MutateInside11.scala:14:15: Illegal aliasing: Mut[Thing[Int]](thing)
+[ Error  ] Hint: this error occurs due to:
+[ Error  ]   -the type of mut (Mut[Thing[Int]]) being mutable
+[ Error  ]   -the definition of mut not being fresh
+[ Error  ]   -the definition of mut containing variables of mutable types
+[ Error  ]   that also appear after the declaration of mut:
+[ Error  ]     -thing (of type Thing[Int])
+[ Error  ]
                val mut = Mut(thing)
                          ^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/MutateInside12.check
+++ b/frontends/benchmarks/extraction/invalid/MutateInside12.check
@@ -1,3 +1,10 @@
 [ Error  ] MutateInside12.scala:14:15: Illegal aliasing: Mut[Thing[Int]](thing)
+[ Error  ] Hint: this error occurs due to:
+[ Error  ]   -the type of mut (Mut[Thing[Int]]) being mutable
+[ Error  ]   -the definition of mut not being fresh
+[ Error  ]   -the definition of mut containing variables of mutable types
+[ Error  ]   that also appear after the declaration of mut:
+[ Error  ]     -thing (of type Thing[Int])
+[ Error  ]
                val mut = Mut(thing)
                          ^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/RottenExpr1.check
+++ b/frontends/benchmarks/extraction/invalid/RottenExpr1.check
@@ -1,0 +1,10 @@
+[ Error  ] RottenExpr1.scala:14:17: Illegal aliasing: buildFromC2Rotten(c1.c2)
+[ Error  ] Hint: this error occurs due to:
+[ Error  ]   -the type of c2Cpy (C2) being mutable
+[ Error  ]   -the definition of c2Cpy not being fresh
+[ Error  ]   -the definition of c2Cpy containing variables of mutable types
+[ Error  ]   that also appear after the declaration of c2Cpy:
+[ Error  ]     -c1 (of type C1)
+[ Error  ]
+               val c2Cpy = buildFromC2Rotten(c1.c2)
+                           ^^^^^^^^^^^^^^^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/RottenExpr1.scala
+++ b/frontends/benchmarks/extraction/invalid/RottenExpr1.scala
@@ -1,0 +1,17 @@
+object RottenExpr1 {
+  case class C1(var c2: C2)
+  case class C2(var c3: C3)
+  case class C3(var bi: BigInt)
+
+  // This creates a C2 by sharing c2.c3 (which is mutable),
+  // therefore, this expression is not fresh
+  def buildFromC2Rotten(c2: C2) = C2(c2.c3)
+
+  def test(x: BigInt): Unit = {
+    val c1 = C1(C2(C3(x)))
+    // This is not a fresh expression: we are not allowed to
+    // refer to `c1` in the body (illegal aliasing).
+    val c2Cpy = buildFromC2Rotten(c1.c2)
+    c1.c2.c3.bi = 3
+  }
+}

--- a/frontends/benchmarks/extraction/invalid/RottenExpr2.check
+++ b/frontends/benchmarks/extraction/invalid/RottenExpr2.check
@@ -1,0 +1,11 @@
+[ Error  ] RottenExpr2.scala:23:19: Illegal aliasing: Trout(c11, c12)
+[ Error  ] Hint: this error occurs due to:
+[ Error  ]   -the type of f (Fish) being mutable
+[ Error  ]   -the definition of f not being fresh
+[ Error  ]   -the definition of f containing variables of mutable types
+[ Error  ]   that also appear after the declaration of f:
+[ Error  ]     -c11 (of type C1)
+[ Error  ]     -c12 (of type C1)
+[ Error  ]
+               val f: Fish = Trout(c11, c12)
+                             ^^^^^^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/RottenExpr2.scala
+++ b/frontends/benchmarks/extraction/invalid/RottenExpr2.scala
@@ -1,0 +1,29 @@
+object RottenExpr2 {
+  case class C1(var c2: C2)
+  case class C2(var c3: C3)
+  case class C3(var bi: BigInt)
+
+  sealed trait Fish
+  case class Trout(c11: C1, c12: C1) extends Fish
+  case class Cod(c1: C1, c2: C2) extends Fish
+  case class Salmon(c1: C1, c3: C3) extends Fish
+
+  def swapped(c1: C1): C1 = C1(C2(C3(-c1.c2.c3.bi)))
+
+  def pickC2(c1: C1): C2 = c1.c2
+
+  def test(x: BigInt): Fish = {
+    val c11 = C1(C2(C3(x)))
+    val c12 = swapped(c11)
+    // `test` returns a fresh fish.
+    // However, we are not allowed to refer to `c11` or `c12`
+    // in the remaining of the function, because val-binding require the value
+    // to be bound *fresh w.r.t. an empty context* -- which is note the case
+    // (`c11` and `c12` are to be considered abstract as if we were to "forget" their values).
+    val f: Fish = Trout(c11, c12)
+    // "Illegal aliasing" triggered due to these lines
+    val c11bis = c11
+    val c12bis = c12
+    f
+  }
+}

--- a/frontends/benchmarks/extraction/invalid/RottenExpr3.dotty.check
+++ b/frontends/benchmarks/extraction/invalid/RottenExpr3.dotty.check
@@ -1,0 +1,3 @@
+[ Error  ] RottenExpr3.scala:11:7: Illegal recursive functions returning non-fresh result
+             def test(c11: C1, x: BigInt): Fish = {
+                 ^

--- a/frontends/benchmarks/extraction/invalid/RottenExpr3.scala
+++ b/frontends/benchmarks/extraction/invalid/RottenExpr3.scala
@@ -1,0 +1,19 @@
+object RottenExpr3 {
+  case class C1(var c2: C2)
+  case class C2(var c3: C3)
+  case class C3(var bi: BigInt)
+
+  sealed trait Fish
+  case class Trout(c11: C1, c12: C1) extends Fish
+  case class Cod(c1: C1, c2: C2) extends Fish
+  case class Salmon(c1: C1, c3: C3) extends Fish
+
+  def test(c11: C1, x: BigInt): Fish = {
+    require(x >= 0)
+    val c12 = C1(C2(C3(x)))
+    // This is not a fresh fish, therefore `test` cannot be recursive
+    val f: Fish = Trout(c11, c12)
+    if (x == 0) f
+    else test(c11, x - 1)
+  }
+}

--- a/frontends/benchmarks/extraction/invalid/RottenExpr3.scalac.check
+++ b/frontends/benchmarks/extraction/invalid/RottenExpr3.scalac.check
@@ -1,0 +1,3 @@
+[ Error  ] RottenExpr3.scala:11:3: Illegal recursive functions returning non-fresh result
+             def test(c11: C1, x: BigInt): Fish = {
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^...

--- a/frontends/benchmarks/extraction/invalid/i1218.check
+++ b/frontends/benchmarks/extraction/invalid/i1218.check
@@ -1,3 +1,10 @@
 [ Error  ] i1218.scala:6:16: Illegal aliasing: arr.updated(1, B(42))
+[ Error  ] Hint: this error occurs due to:
+[ Error  ]   -the type of arr2 (Array[B]) being mutable
+[ Error  ]   -the definition of arr2 not being fresh
+[ Error  ]   -the definition of arr2 containing variables of mutable types
+[ Error  ]   that also appear after the declaration of arr2:
+[ Error  ]     -arr (of type Array[B])
+[ Error  ]
                val arr2 = arr.updated(1, B(42))
                           ^^^^^^^^^^^^^^^^^^^^^

--- a/frontends/benchmarks/imperative/valid/FreshExpr.scala
+++ b/frontends/benchmarks/imperative/valid/FreshExpr.scala
@@ -1,0 +1,73 @@
+import stainless.lang._
+
+object FreshExpr {
+  case class C1(var c2: C2)
+  case class C2(var c3: C3)
+  case class C3(var bi: BigInt)
+
+  // This builds a fresh C2 because we build a fresh C3
+  def buildCopyFromC2(c2: C2): C2 = C2(buildCopyFromC3(c2.c3))
+
+  def buildCopyFromC3(c3: C3): C3 = C3(c3.bi)
+
+  def test1(x: BigInt): Unit = {
+    val c1 = C1(C2(C3(x)))
+    // This is a fresh expression, so we can refer to
+    // `c1` and `c2Cpy` freely in the remaining body
+    val c2Cpy = buildCopyFromC2(c1.c2)
+    c1.c2.c3.bi = 3
+    assert(c1.c2.c3.bi == 3)
+    assert(c2Cpy.c3.bi == x)
+  }
+
+  sealed trait Fish
+  case class Trout(c11: C1, c12: C1) extends Fish
+  case class Cod(c1: C1, c2: C2) extends Fish
+  case class Salmon(c1: C1, c3: C3) extends Fish
+
+  def swapped(c1: C1): C1 = C1(C2(C3(-c1.c2.c3.bi)))
+
+  def pickC2(c1: C1): C2 = c1.c2
+
+  def test2(x: BigInt): Fish = {
+    require(x >= 0)
+    decreases(x)
+    val c11 = C1(C2(C3(x)))
+    val c12 = swapped(c11)
+    // `test2` returns a fresh fish therefore, it is allowed to be recursive.
+    // However, note that we are not allowed to refer to `c11` or `c12`
+    // in the remaining of the function, because val-binding require the value
+    // to be bound *fresh w.r.t. an empty context* (i.e. `c11` and `c12` are
+    // considered abstract because we "forget" their values).
+    val f: Fish = Trout(c11, c12)
+    val c2 = f match {
+      case Trout(c11, _) => pickC2(c11)
+    }
+    c2.c3.bi = 3
+    assert(f match {
+      case Trout(c11, _) => c11.c2.c3.bi == 3
+    })
+    if (x == 0) f
+    else test2(x - 1)
+  }
+
+  // Similar to `test2` but tests pattern matching freshness propagation
+  def test3(x: BigInt): C1 = {
+    require(x >= 0)
+    decreases(x)
+    val c11 = C1(C2(C3(x)))
+    val c12 = swapped(c11)
+    val f: Fish = Trout(c11, c12)
+    val c2 = f match {
+      case Trout(c11, _) => pickC2(c11)
+    }
+    c2.c3.bi = 3
+    assert(f match {
+      case Trout(c11, _) => c11.c2.c3.bi == 3
+    })
+    if (x == 0) f match {
+      case Trout(c11, _) => c11
+    }
+    else test3(x - 1)
+  }
+}


### PR DESCRIPTION
Relax the condition over which an expression is considered to be "fresh" to include bindings of `match` expression and seeing through non-recursive function. 
It also changes the rule for `Let` for which I'm not so sure about:
Before: `Let(vd, e, b)` expression fresh iff `e` is fresh and *b* as well, where we consider `vd` as fresh when recurring on `b`
Now: `Let(vd, e, b)` fresh iff `b` is fresh, where we add `vd` as a fresh binding when recurring on `b` provided `e` is fresh.
These changes allows to accept [`FreshExpr.scala`](https://github.com/epfl-lara/stainless/blob/5ad0b33443a8c79671f30c84689d18d0cae25c5b/frontends/benchmarks/imperative/valid/FreshExpr.scala) (which was rejected before).

It also improves a bit the "illegal aliasing" error messages.