### PR TITLE
Enforce purity for class invariants

### DIFF
--- a/frontends/benchmarks/extraction/invalid/ImpureInvariant.check
+++ b/frontends/benchmarks/extraction/invalid/ImpureInvariant.check
@@ -1,0 +1,5 @@
+[ Error  ] ImpureInvariant.scala:9:13: Invariants cannot have side-effects
+[ Error  ] Hint: the invariant calls the following impure functions:
+[ Error  ]   -take
+               require(mt.take(mic) == 0)
+                       ^^^^^^^^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/ImpureInvariant.scala
+++ b/frontends/benchmarks/extraction/invalid/ImpureInvariant.scala
@@ -1,0 +1,11 @@
+object ImpureInvariant {
+  case class MyImpureClass(var i: BigInt)
+
+  trait MyTrait {
+    def take(m: MyImpureClass): BigInt
+  }
+
+  case class HasImpureInvariant(mt: MyTrait, mic: MyImpureClass) {
+    require(mt.take(mic) == 0)
+  }
+}

--- a/frontends/benchmarks/extraction/invalid/Purity3.dotty.check
+++ b/frontends/benchmarks/extraction/invalid/Purity3.dotty.check
@@ -1,3 +1,6 @@
-[ Error  ] Purity3.scala:15:7: Function `mutation` has effect on @pure parameter `box`
+[ Error  ] Purity3.scala:15:7: Function `mutation` has effect on the following @pure parameters:
+[ Error  ]   -box
+[ Error  ] Hint: box is modified by the calls to the following functions:
+[ Error  ]   -doStuff
              def mutation(@pure box: Box): Boolean = {
                  ^

--- a/frontends/benchmarks/extraction/invalid/Purity3.scalac.check
+++ b/frontends/benchmarks/extraction/invalid/Purity3.scalac.check
@@ -1,3 +1,6 @@
-[ Error  ] Purity3.scala:15:7: Function `mutation` has effect on @pure parameter `box`
+[ Error  ] Purity3.scala:15:7: Function `mutation` has effect on the following @pure parameters:
+[ Error  ]   -box
+[ Error  ] Hint: box is modified by the calls to the following functions:
+[ Error  ]   -doStuff
              def mutation(@pure box: Box): Boolean = {
                  ^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/Purity4.dotty.check
+++ b/frontends/benchmarks/extraction/invalid/Purity4.dotty.check
@@ -1,0 +1,7 @@
+[ Error  ] Purity4.scala:7:7: Function `test` has effect on the following @pure parameters:
+[ Error  ]   -b2
+[ Error  ] Hint: b2 is modified by the calls to the following functions:
+[ Error  ]   -externFn (an @extern function)
+[ Error  ] Hint: @extern functions taking mutable types are considered as impure, unless annotated with @pure
+             def test(b1: Box, @pure b2: Box): Unit = {
+                 ^

--- a/frontends/benchmarks/extraction/invalid/Purity4.scala
+++ b/frontends/benchmarks/extraction/invalid/Purity4.scala
@@ -1,0 +1,16 @@
+import stainless.annotation._
+
+object Purity4 {
+
+  case class Box(var value: BigInt)
+
+  def test(b1: Box, @pure b2: Box): Unit = {
+    externFn(b1, b2)
+  }
+
+  @extern
+  def externFn(b1: Box, b2: Box): Unit = {
+    ???
+  }
+
+}

--- a/frontends/benchmarks/extraction/invalid/Purity4.scalac.check
+++ b/frontends/benchmarks/extraction/invalid/Purity4.scalac.check
@@ -1,0 +1,7 @@
+[ Error  ] Purity4.scala:7:7: Function `test` has effect on the following @pure parameters:
+[ Error  ]   -b2
+[ Error  ] Hint: b2 is modified by the calls to the following functions:
+[ Error  ]   -externFn (an @extern function)
+[ Error  ] Hint: @extern functions taking mutable types are considered as impure, unless annotated with @pure
+             def test(b1: Box, @pure b2: Box): Unit = {
+                 ^^^^

--- a/frontends/benchmarks/extraction/invalid/Purity5.dotty.check
+++ b/frontends/benchmarks/extraction/invalid/Purity5.dotty.check
@@ -1,0 +1,6 @@
+[ Error  ] Purity5.scala:9:7: Function `test` has effect on the following @pure parameters:
+[ Error  ]   -b2
+[ Error  ] Hint: b2 is modified by the calls to the following functions:
+[ Error  ]   -sum
+             def test(st: SomeTrait, b1: Box, @pure b2: Box): BigInt = st.sum(b1, b2)
+                 ^

--- a/frontends/benchmarks/extraction/invalid/Purity5.scala
+++ b/frontends/benchmarks/extraction/invalid/Purity5.scala
@@ -1,0 +1,10 @@
+import stainless.annotation._
+
+object Purity5 {
+  trait SomeTrait {
+    def sum(b1: Box, b2: Box): BigInt
+  }
+  case class Box(var value: BigInt)
+
+  def test(st: SomeTrait, b1: Box, @pure b2: Box): BigInt = st.sum(b1, b2)
+}

--- a/frontends/benchmarks/extraction/invalid/Purity5.scalac.check
+++ b/frontends/benchmarks/extraction/invalid/Purity5.scalac.check
@@ -1,0 +1,6 @@
+[ Error  ] Purity5.scala:9:7: Function `test` has effect on the following @pure parameters:
+[ Error  ]   -b2
+[ Error  ] Hint: b2 is modified by the calls to the following functions:
+[ Error  ]   -sum
+             def test(st: SomeTrait, b1: Box, @pure b2: Box): BigInt = st.sum(b1, b2)
+                 ^^^^

--- a/frontends/benchmarks/extraction/invalid/i1474.check
+++ b/frontends/benchmarks/extraction/invalid/i1474.check
@@ -1,0 +1,6 @@
+[ Error  ] i1474.scala:23:13: Invariants cannot have side-effects
+[ Error  ] Hint: the invariant calls the following impure functions:
+[ Error  ]   -getLast (an @extern function)
+[ Error  ] Hint: @extern functions taking mutable types are considered as impure, unless annotated with @pure
+               require(last == getLast(first))
+                       ^^^^^^^^^^^^^^^^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/i1474.scala
+++ b/frontends/benchmarks/extraction/invalid/i1474.scala
@@ -1,0 +1,32 @@
+object i1474 {
+  import stainless.lang._
+  import stainless.lang.StaticChecks._
+  import stainless.annotation._
+
+  @mutable
+  sealed abstract class Opt[@mutable T]
+  case class NONE[@mutable T]() extends Opt[T]
+  case class SOME[@mutable T](value: T) extends Opt[T]
+
+  final case class Node(var head: Int, var next: Cell[Opt[Node]])
+
+  @extern
+  def getLast(n: Node): Node = {
+    n.next.v match {
+      case NONE() => n
+      case SOME(next) => getLast(next)
+    }
+  }
+
+  final case class TList(var first: Node,
+                         var last: Node) {
+    require(last == getLast(first))
+  }
+
+  def mkEnd(head: Int): Node = Node(head, Cell(NONE[Node]()))
+
+  def test = {
+    val n1: Node = mkEnd(5)
+    val l: TList = TList(n1, freshCopy(n1))
+  }
+}


### PR DESCRIPTION
Also adds some explanation when purity is expected, specifying which impure functions were called.
Closes #1474