### PR TITLE
Propagate ghost annotation from class to methods

### DIFF
--- a/frontends/benchmarks/extraction/invalid/GhostClass.dotty.check
+++ b/frontends/benchmarks/extraction/invalid/GhostClass.dotty.check
@@ -1,0 +1,3 @@
+[ Error  ] GhostClass.scala:6:31: Cannot access a ghost symbol outside of a ghost context. [ GhostClass.MyClass in method buildClass ]
+             def buildClass(x: BigInt) = MyClass(x, x)
+                                         ^^^^^^^

--- a/frontends/benchmarks/extraction/invalid/GhostClass.scala
+++ b/frontends/benchmarks/extraction/invalid/GhostClass.scala
@@ -1,0 +1,7 @@
+import stainless.annotation._
+object GhostClass {
+  @ghost
+  case class MyClass(x: BigInt, y: BigInt)
+
+  def buildClass(x: BigInt) = MyClass(x, x)
+}

--- a/frontends/benchmarks/extraction/invalid/GhostClass.scalac.check
+++ b/frontends/benchmarks/extraction/invalid/GhostClass.scalac.check
@@ -1,0 +1,3 @@
+[ Error  ] GhostClass.scala:6:31: Cannot access a ghost symbol outside of a ghost context. [ GhostClass.this.MyClass in method buildClass ]
+             def buildClass(x: BigInt) = MyClass(x, x)
+                                         ^^^^^^^

--- a/frontends/benchmarks/verification/valid/GhostClass.scala
+++ b/frontends/benchmarks/verification/valid/GhostClass.scala
@@ -1,0 +1,27 @@
+import stainless.annotation._
+import stainless.lang.{ghost => ghostExpr, _}
+
+object GhostClass {
+
+  @ghost
+  def ghostFn(x: BigInt): BigInt = x
+
+  @ghost
+  case class MyGhostClass(i: BigInt) {
+    // ghostMethod is treated as @ghost even though not explicitly
+    // annotated as so due to the class being ghost
+    def ghostMethod(x: BigInt): BigInt = ghostFn(x + i).ensuring(_ == x + i)
+  }
+
+  @ghost
+  def createGhostClass(i: BigInt): MyGhostClass = MyGhostClass(i).ensuring(_.i == i)
+
+  def useInGhost(i: BigInt): BigInt = {
+    @ghost val mgc = MyGhostClass(i)
+    ghostExpr {
+      val ii = mgc.ghostMethod(2 * i)
+      assert(ii == mgc.i + 2 * i)
+    }
+    3 * i
+  }
+}


### PR DESCRIPTION
PR #1472 changed the way propagation of annotation works, but I did not propagate `@ghost` annotation from `@ghost` class to methods. This PR fixes that.
Note that `@ghost` does not propagate to fields (see [here](https://github.com/epfl-lara/stainless/blob/106629548058cd72c31e965f05a415dc834d6abf/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala#L500) where we explicitly ignore owners).