### PR TITLE
Fix positions for inlined functions

### DIFF
--- a/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/FunctionInlining.scala
@@ -125,18 +125,24 @@ class FunctionInlining(override val s: Trees, override val t: trace.Trees)
             case None => context.reporter.fatalError("In FunctionInlining, all functions should have bodies thanks to ChooseEncoder running before.")
           }
 
+          exprOps.preTraversal {
+            // Set the position of all occurrences of parameters to the position of their argument
+            // For other expressions, we set the position to the call site
+            case v: Variable =>
+              val ix = argBinders.indexWhere(_.id == v.id)
+              if (ix >= 0) {
+                // An `argBinder`
+                v.setPos(argBinders(ix))
+              } else {
+                // Some local variable
+                v.setPos(fi)
+              }
+            case e => e.setPos(fi)
+          }(inlined)
           val result = (argBinders zip args).foldRight(inlined) {
-            case ((vd, e), body) => let(vd, e, body).setPos(fi)
+            case ((vd, e), body) => let(vd.copiedFrom(e), e, body).setPos(fi)
           }
-          val freshened = exprOps.freshenLocals(result)
-
-          // For some common shims, fill in missing positions with the position of the inlined call site
-          if (isSynthetic && hasInlineOnceFlag) {
-            exprOps.preTraversal {
-              case e if !e.getPos.isDefined => e.setPos(fi)
-              case _ =>
-            }(freshened)
-          }
+          val freshened = exprOps.freshenLocals(result).copiedFrom(fi)
 
           val inliner = new Inliner(if (hasInlineOnceFlag) inlinedOnce + tfd.id else inlinedOnce)
           inliner.transform(freshened)

--- a/frontends/benchmarks/verification/invalid/InvalidInvariantCopy.scala
+++ b/frontends/benchmarks/verification/invalid/InvalidInvariantCopy.scala
@@ -1,0 +1,7 @@
+object InvalidInvariantCopy {
+  case class MyClass(x: BigInt) {
+    require(x >= 0)
+  }
+
+  def copyClass(mc: MyClass, x: BigInt): MyClass = mc.copy(x + x)
+}


### PR DESCRIPTION
In some cases, VCs positions could be incorrect when using inline functions.
This is particularly the case for synthetic `copy` methods which are always inlined.
For instance, in the following snippet, the VC generated for `mc.copy(x = y)` would incorrectly point at the definition of `MyClass`. This PR fixes this issue and the correct position is now reported.
```scala
case class MyClass(x: BigInt, y: BigInt)

def buildClass(mc: MyClass, x: BigInt): MyClass = {
  mc.copy(x = y)
}.ensuring(_.x >= 0)
```
