### PR TITLE
Disable test `i1306b`

### DIFF
--- a/frontends/benchmarks/imperative/valid/i1306b.scala
+++ b/frontends/benchmarks/imperative/valid/i1306b.scala
@@ -3,7 +3,7 @@ import stainless.lang._
 import stainless.annotation._
 
 object i1306b {
-  def root(a: BigInt): BigInt = {
+  def root1(a: BigInt): BigInt = {
     require(a >= 0)
     var i: BigInt = 0
     def nextSquare = ((i + 1) * (i + 1))
@@ -14,8 +14,28 @@ object i1306b {
       val z = accessI(a, nextSquare)
       assert(z == i + a + (i + 1) * (i + 1))
       val w = accessI(a, i)
+      modifyI(a, -a)
       assert(w == i + a + i)
       i = i + 1
+    }) invariant { i >= 0 && ((i * i) <= a) }
+    i
+  } ensuring { root => (root * root) <= a && a < ((root + 1) * (root + 1)) }
+
+  // Variant that increments `i` with `modifyI`
+  def root2(a: BigInt): BigInt = {
+    require(a >= 0)
+    var i: BigInt = 0
+    def nextSquare = ((i + 1) * (i + 1))
+    def accessI(x: BigInt, y: BigInt) = i + x + y
+    def modifyI(x: BigInt, y: BigInt) = { i += x + y }
+    (while (nextSquare <= a) {
+      decreases(a - nextSquare)
+      val z = accessI(a, nextSquare)
+      assert(z == i + a + (i + 1) * (i + 1))
+      val w = accessI(a, i)
+      modifyI(a, -a)
+      assert(w == i + a + i)
+      modifyI(0, 1)
     }) invariant { i >= 0 && ((i * i) <= a) }
     i
   } ensuring { root => (root * root) <= a && a < ((root + 1) * (root + 1)) }

--- a/frontends/benchmarks/imperative/valid/i1306c.scala
+++ b/frontends/benchmarks/imperative/valid/i1306c.scala
@@ -1,0 +1,43 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+
+object i1306c {
+  // Like coal power plants, lot of energy lost for little gain...
+  def laboriousIdentity1(a: BigInt): BigInt = {
+    require(a >= 0)
+    var i: BigInt = 0
+    def nextIncrement = i + 1
+    def accessI(x: BigInt, y: BigInt) = i + x + y
+    def modifyI(x: BigInt, y: BigInt) = { i += x + y }
+    (while (nextIncrement <= a) {
+      decreases(a - nextIncrement)
+      val z = accessI(a, nextIncrement)
+      assert(z == i + a + i + 1)
+      val w = accessI(a, i)
+      modifyI(a, -a)
+      assert(w == i + a + i)
+      i = i + 1
+    }) invariant { i >= 0 && i <= a }
+    i
+  } ensuring { _ == a }
+
+  // Variant that increments `i` with `modifyI`
+  def laboriousIdentity2(a: BigInt): BigInt = {
+    require(a >= 0)
+    var i: BigInt = 0
+    def nextIncrement = i + 1
+    def accessI(x: BigInt, y: BigInt) = i + x + y
+    def modifyI(x: BigInt, y: BigInt) = { i += x + y }
+    (while (nextIncrement <= a) {
+      decreases(a - nextIncrement)
+      val z = accessI(a, nextIncrement)
+      assert(z == i + a + i + 1)
+      val w = accessI(a, i)
+      modifyI(a, -a)
+      assert(w == i + a + i)
+      modifyI(0, 1)
+    }) invariant { i >= 0 && i <= a }
+    i
+  } ensuring { _ == a }
+}

--- a/frontends/common/src/it/scala/stainless/termination/TerminationSuite.scala
+++ b/frontends/common/src/it/scala/stainless/termination/TerminationSuite.scala
@@ -30,6 +30,8 @@ class TerminationSuite extends VerificationComponentTestSuite {
     case "verification/valid/BitsTricksSlow" => Skip
     // Flaky
     case "verification/valid/PackedFloat8" => Ignore
+    // Succeeds most of the time, but unsuitable for CI due to its flakiness
+    case "imperative/valid/i1306b" => Ignore
     case _ => super.filter(ctx, name)
   }
 

--- a/frontends/common/src/it/scala/stainless/verification/ImperativeSuite.scala
+++ b/frontends/common/src/it/scala/stainless/verification/ImperativeSuite.scala
@@ -12,6 +12,8 @@ class ImperativeSuite extends VerificationComponentTestSuite {
   override def filter(ctx: inox.Context, name: String): FilterStatus = name match {
     // Unstable on 4.8.12, but works in non-incremental mode
     case "imperative/valid/WhileAsFun2" => Ignore
+    // Succeeds most of the time, but unsuitable for CI due to its flakiness
+    case "imperative/valid/i1306b" => Ignore
 
     case _ => super.filter(ctx, name)
   }


### PR DESCRIPTION
`i1306b` is a nice test to ensure we do not regress on #1306 but it is sadly quite flaky.
I have disabled it (not deleted it) and have added a variant `i1306c` that does not make use of non-linear arithmetic (which seems to be the cause of the issue).