### PR TITLE
Equivalence checker: allows for let-binding in tests and output 'expected but got' results

### DIFF
--- a/frontends/benchmarks/equivalence/separate/Candidate1.scala
+++ b/frontends/benchmarks/equivalence/separate/Candidate1.scala
@@ -1,0 +1,15 @@
+import defs._
+
+object Candidate1 {
+  def separate(xs: List[Animal]): (List[Sheep], List[Goat]) = {
+    xs match {
+      case Nil => (Nil, Nil)
+      case (s: Sheep) :: t =>
+        val (s2, g2) = separate(t)
+        (s :: s2, g2)
+      case (g: Goat) :: t =>
+        val (s2, g2) = separate(t)
+        (s2, g :: g2)
+    }
+  }
+}

--- a/frontends/benchmarks/equivalence/separate/Candidate2.scala
+++ b/frontends/benchmarks/equivalence/separate/Candidate2.scala
@@ -1,0 +1,15 @@
+import defs._
+
+object Candidate2 {
+  def separate(xs: List[Animal]): (List[Sheep], List[Goat]) = {
+    xs match {
+      case Nil => (Nil, Nil)
+      case (s: Sheep) :: t =>
+        val (s2, g2) = separate(t)
+        (s :: s2, g2)
+      case (g: Goat) :: t =>
+        val (s2, g2) = separate(t)
+        (s2, g2) // oops, forgets g
+    }
+  }
+}

--- a/frontends/benchmarks/equivalence/separate/Model.scala
+++ b/frontends/benchmarks/equivalence/separate/Model.scala
@@ -1,0 +1,21 @@
+import stainless.lang._
+import stainless.collection.{List => SList}
+import defs._
+
+object Model {
+  def separate(xs: List[Animal]): (List[Sheep], List[Goat]) = {
+    xs match {
+      case Nil => (Nil, Nil)
+      case (s: Sheep) :: t =>
+        val (s2, g2) = separate(t)
+        (s :: s2, g2)
+      case (g: Goat) :: t =>
+        val (s2, g2) = separate(t)
+        (s2, g :: g2)
+    }
+  }
+
+  def test: SList[List[Animal]] = SList(
+    Goat(1) :: Sheep(2) :: Nil
+  )
+}

--- a/frontends/benchmarks/equivalence/separate/defs.scala
+++ b/frontends/benchmarks/equivalence/separate/defs.scala
@@ -1,0 +1,64 @@
+import stainless.lang._
+
+object defs {
+  sealed trait Animal
+  case class Sheep(id: BigInt) extends Animal
+  case class Goat(id: BigInt) extends Animal
+
+  sealed abstract class List[+T] {
+    def size: Int = {
+      this match {
+        case Nil => 0
+        case h :: t =>
+          val tLen = t.size
+          if (tLen == Int.MaxValue) tLen
+          else 1 + tLen
+      }
+    } ensuring(res => 0 <= res && res <= Int.MaxValue)
+
+    def length: Int = size
+
+    def ++[TT >: T](that: List[TT]): List[TT] = {
+      this match {
+        case Nil => that
+        case x :: xs => x :: (xs ++ that)
+      }
+    }
+
+    def head: T = {
+      require(this != Nil)
+      val h :: _ = this: @unchecked
+      h
+    }
+
+    def tail: List[T] = {
+      require(this != Nil)
+      val _ :: t = this: @unchecked
+      t
+    }
+
+    def apply(index: Int): T = {
+      require(0 <= index && index < size)
+      decreases(index)
+      if (index == 0) {
+        head
+      } else {
+        tail(index-1)
+      }
+    }
+
+    def :: [TT >: T](elem: TT): List[TT] = new ::(elem, this)
+
+    def :+[TT >: T](t: TT): List[TT] = {
+      this match {
+        case Nil => t :: this
+        case x :: xs => x :: (xs :+ t)
+      }
+    }
+  }
+
+  case object Nil extends List[Nothing]
+
+  final case class ::[+A](first: A, next: List[A]) extends List[A]
+
+}

--- a/frontends/benchmarks/equivalence/separate/test_conf_1.json
+++ b/frontends/benchmarks/equivalence/separate/test_conf_1.json
@@ -1,0 +1,28 @@
+{
+  "models": [
+    "Model.separate"
+  ],
+  "comparefuns": [
+    "Candidate1.separate",
+    "Candidate2.separate"
+  ],
+  "tests": [
+    "Model.test"
+  ],
+  "outcome": {
+    "equivalent": [
+      {
+        "model": "Model.separate",
+        "functions": [
+          "Candidate1.separate"
+        ]
+      }
+    ],
+    "unequivalent": [
+      "Candidate2.separate"
+    ],
+    "unsafe": [],
+    "timeout": [],
+    "wrong": []
+  }
+}

--- a/frontends/benchmarks/equivalence/separate/test_conf_2.json
+++ b/frontends/benchmarks/equivalence/separate/test_conf_2.json
@@ -1,0 +1,24 @@
+{
+  "models": [
+    "Model.separate"
+  ],
+  "comparefuns": [
+    "Candidate1.separate",
+    "Candidate2.separate"
+  ],
+  "tests": [],
+  "outcome": {
+    "equivalent": [
+      {
+        "model": "Model.separate",
+        "functions": [
+          "Candidate1.separate"
+        ]
+      }
+    ],
+    "unequivalent": [],
+    "unsafe": [],
+    "timeout": ["Candidate2.separate"],
+    "wrong": []
+  }
+}


### PR DESCRIPTION
This PR allows having introducing `val` for tests, which may get created by some phases (e.g. the test in `separate/Model` contains binding introduced by `RefinementLifting`).
For unequivalence, it also outputs the expected result as well as the result from the candidate function.