### PR TITLE
Equivalence checker: add 'unknown safety' category

### DIFF
--- a/core/src/main/scala/stainless/equivchk/EquivalenceCheckingReport.scala
+++ b/core/src/main/scala/stainless/equivchk/EquivalenceCheckingReport.scala
@@ -44,7 +44,7 @@ object EquivalenceCheckingReport {
 
     def isInconclusive: Boolean = this match {
       case Verification(status) => status.isInconclusive
-      case Equivalence(EquivalenceStatus.Unknown) => true
+      case Equivalence(EquivalenceStatus.UnknownSafety | EquivalenceStatus.UnknownEquivalence) => true
       case _ => false
     }
   }
@@ -54,7 +54,8 @@ object EquivalenceCheckingReport {
     case Unequivalent
     case Unsafe
     case Wrong
-    case Unknown
+    case UnknownSafety
+    case UnknownEquivalence
   }
 
   case class Record(id: Identifier, pos: inox.utils.Position, time: Long,
@@ -90,7 +91,8 @@ class EquivalenceCheckingReport(override val results: Seq[EquivalenceCheckingRep
         case Status.Equivalence(EquivalenceStatus.Wrong) => "signature mismatch"
         case Status.Equivalence(EquivalenceStatus.Unequivalent) => "not equivalent"
         case Status.Equivalence(EquivalenceStatus.Unsafe) => "unsafe"
-        case Status.Equivalence(EquivalenceStatus.Unknown) => "unknown"
+        case Status.Equivalence(EquivalenceStatus.UnknownSafety) => "unknown safety"
+        case Status.Equivalence(EquivalenceStatus.UnknownEquivalence) => "unknown equivalence"
       }
       val level = levelOf(status)
       val solver = solverName getOrElse ""

--- a/frontends/benchmarks/equivalence/addHorn/test_conf.json
+++ b/frontends/benchmarks/equivalence/addHorn/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/boardgame/test_conf_1.json
+++ b/frontends/benchmarks/equivalence/boardgame/test_conf_1.json
@@ -26,7 +26,8 @@
       "Candidate4.validCitySettlement"
     ],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/boardgame/test_conf_2.json
+++ b/frontends/benchmarks/equivalence/boardgame/test_conf_2.json
@@ -33,7 +33,8 @@
     "unsafe": [
       "Candidate3.adjacencyBonus"
     ],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/cloudSculpting/test_conf.json
+++ b/frontends/benchmarks/equivalence/cloudSculpting/test_conf.json
@@ -18,7 +18,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/dup/test_conf.json
+++ b/frontends/benchmarks/equivalence/dup/test_conf.json
@@ -26,7 +26,8 @@
       "Candidate4.dup"
     ],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": [
       "Candidate3.dup"
     ]

--- a/frontends/benchmarks/equivalence/factorial/test_conf.json
+++ b/frontends/benchmarks/equivalence/factorial/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/fibonacci/test_conf.json
+++ b/frontends/benchmarks/equivalence/fibonacci/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/foolproof/test_conf.json
+++ b/frontends/benchmarks/equivalence/foolproof/test_conf.json
@@ -19,7 +19,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/fullAlternation/test_conf.json
+++ b/frontends/benchmarks/equivalence/fullAlternation/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/funnyarith1/test_conf.json
+++ b/frontends/benchmarks/equivalence/funnyarith1/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/funnyarith2/test_conf.json
+++ b/frontends/benchmarks/equivalence/funnyarith2/test_conf.json
@@ -17,7 +17,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/funnyarith3/test_conf.json
+++ b/frontends/benchmarks/equivalence/funnyarith3/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/halfAlternation/test_conf.json
+++ b/frontends/benchmarks/equivalence/halfAlternation/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/i1264/test_conf.json
+++ b/frontends/benchmarks/equivalence/i1264/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/inlining/test_conf.json
+++ b/frontends/benchmarks/equivalence/inlining/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/isSorted/test_conf.json
+++ b/frontends/benchmarks/equivalence/isSorted/test_conf.json
@@ -26,7 +26,8 @@
       "IsSorted.isSortedA"
     ],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/iseven1/test_conf.json
+++ b/frontends/benchmarks/equivalence/iseven1/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/iseven2/test_conf.json
+++ b/frontends/benchmarks/equivalence/iseven2/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/limit1/test_conf.json
+++ b/frontends/benchmarks/equivalence/limit1/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/limit2/test_conf.json
+++ b/frontends/benchmarks/equivalence/limit2/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/limit3/test_conf.json
+++ b/frontends/benchmarks/equivalence/limit3/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/max1/test_conf.json
+++ b/frontends/benchmarks/equivalence/max1/test_conf.json
@@ -23,7 +23,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/max2/test_conf.json
+++ b/frontends/benchmarks/equivalence/max2/test_conf.json
@@ -27,7 +27,8 @@
       "Candidate5.max"
     ],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/pascal/test_conf.json
+++ b/frontends/benchmarks/equivalence/pascal/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/separate/test_conf_1.json
+++ b/frontends/benchmarks/equivalence/separate/test_conf_1.json
@@ -22,7 +22,8 @@
       "Candidate2.separate"
     ],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/separate/test_conf_2.json
+++ b/frontends/benchmarks/equivalence/separate/test_conf_2.json
@@ -18,7 +18,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": ["Candidate2.separate"],
+    "unknownSafety": [],
+    "unknownEquivalence": ["Candidate2.separate"],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/sigma/test_conf.json
+++ b/frontends/benchmarks/equivalence/sigma/test_conf.json
@@ -10,7 +10,8 @@
     "equivalent": [],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": ["Candidate.sigma"],
+    "unknownSafety": [],
+    "unknownEquivalence": ["Candidate.sigma"],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/sum/test_conf.json
+++ b/frontends/benchmarks/equivalence/sum/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/unfoldingSorted/test_conf.json
+++ b/frontends/benchmarks/equivalence/unfoldingSorted/test_conf.json
@@ -24,7 +24,8 @@
       "Candidate4.unfoldingSorted"
     ],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": [
       "Candidate2.unfoldingSorted"
     ]

--- a/frontends/benchmarks/equivalence/uniq1/test_conf.json
+++ b/frontends/benchmarks/equivalence/uniq1/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/uniq2/test_conf.json
+++ b/frontends/benchmarks/equivalence/uniq2/test_conf.json
@@ -26,7 +26,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/unknownSafety/Candidate.scala
+++ b/frontends/benchmarks/equivalence/unknownSafety/Candidate.scala
@@ -1,0 +1,52 @@
+import stainless.lang._
+import stainless.collection._
+
+object Candidate {
+
+  def zero(x: BigInt): BigInt = {
+    require(x >= 0)
+    if (x > 0) zero(x - 1)
+    else x
+  }
+
+  def add(x: BigInt, y: BigInt): BigInt = {
+    if (x >= 0) {
+      val z = zero(x)
+      assert(z == 0) // timeout
+    }
+    x + y
+  }
+
+  /////////////////////////////////////
+
+  def isEvenTopLvl(x: BigInt): Boolean = isEven(x)
+
+  def isEven(x: BigInt): Boolean = {
+    decreases(if (x <= 0) BigInt(0) else x)
+    if (x >= 0) {
+      assert(zero(x) == 0) // timeout
+    }
+    if (x < 0) false
+    else if (x == 0) true
+    else !isOdd(x - 1)
+  }
+
+  def isOdd(x: BigInt): Boolean = {
+    decreases(if (x <= 0) BigInt(0) else x)
+    if (x <= 0) false
+    else if (x == 1) true
+    else !isEven(x - 1)
+  }
+
+  /////////////////////////////////////
+
+  def isSorted(xs: List[BigInt]): Boolean = xs match {
+    case Nil() => true
+    case Cons(h, Nil()) =>
+      if (h >= 0) {
+        assert(zero(h) == 0) // timeout
+      }
+      true
+    case Cons(h1, Cons(h2, t)) => h1 <= h2 && isSorted(t)
+  }
+}

--- a/frontends/benchmarks/equivalence/unknownSafety/Model.scala
+++ b/frontends/benchmarks/equivalence/unknownSafety/Model.scala
@@ -1,0 +1,33 @@
+import stainless.lang._
+import stainless.collection._
+
+object Model {
+
+  def add(x: BigInt, y: BigInt): BigInt = x + y
+
+  /////////////////////////////////////
+
+  def isEvenTopLvl(x: BigInt): Boolean = isEven(x)
+
+  def isEven(x: BigInt): Boolean = {
+    decreases(if (x <= 0) BigInt(0) else x)
+    if (x < 0) false
+    else if (x == 0) true
+    else !isOdd(x - 1)
+  }
+
+  def isOdd(x: BigInt): Boolean = {
+    decreases(if (x <= 0) BigInt(0) else x)
+    if (x <= 0) false
+    else if (x == 1) true
+    else !isEven(x - 1)
+  }
+
+  /////////////////////////////////////
+
+  def isSorted(xs: List[BigInt]): Boolean = xs match {
+    case Nil() => true
+    case Cons(_, Nil()) => true
+    case Cons(h1, Cons(h2, t)) => h1 <= h2 && isSorted(t)
+  }
+}

--- a/frontends/benchmarks/equivalence/unknownSafety/test_conf_1.json
+++ b/frontends/benchmarks/equivalence/unknownSafety/test_conf_1.json
@@ -1,18 +1,19 @@
 {
   "models": [
-    "Model.max"
+    "Model.add"
   ],
   "comparefuns": [
-    "Candidate.max"
+    "Candidate.add"
   ],
   "tests": [],
-  "norm": "Model.norm",
   "outcome": {
     "equivalent": [],
     "unequivalent": [],
     "unsafe": [],
-    "unknownSafety": [],
-    "unknownEquivalence": ["Candidate.max"],
+    "unknownSafety": [
+      "Candidate.add"
+    ],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/unknownSafety/test_conf_2.json
+++ b/frontends/benchmarks/equivalence/unknownSafety/test_conf_2.json
@@ -1,18 +1,19 @@
 {
   "models": [
-    "Model.max"
+    "Model.isEvenTopLvl"
   ],
   "comparefuns": [
-    "Candidate.max"
+    "Candidate.isEvenTopLvl"
   ],
   "tests": [],
-  "norm": "Model.norm",
   "outcome": {
     "equivalent": [],
     "unequivalent": [],
     "unsafe": [],
-    "unknownSafety": [],
-    "unknownEquivalence": ["Candidate.max"],
+    "unknownSafety": [
+      "Candidate.isEvenTopLvl"
+    ],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/unknownSafety/test_conf_3.json
+++ b/frontends/benchmarks/equivalence/unknownSafety/test_conf_3.json
@@ -1,18 +1,19 @@
 {
   "models": [
-    "Model.max"
+    "Model.isSorted"
   ],
   "comparefuns": [
-    "Candidate.max"
+    "Candidate.isSorted"
   ],
   "tests": [],
-  "norm": "Model.norm",
   "outcome": {
     "equivalent": [],
     "unequivalent": [],
     "unsafe": [],
-    "unknownSafety": [],
-    "unknownEquivalence": ["Candidate.max"],
+    "unknownSafety": [
+      "Candidate.isSorted"
+    ],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/unrolling/test_conf.json
+++ b/frontends/benchmarks/equivalence/unrolling/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/unused/test_conf.json
+++ b/frontends/benchmarks/equivalence/unused/test_conf.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/test_conf_1.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/test_conf_1.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/test_conf_2.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/test_conf_2.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/test_conf_3.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/test_conf_3.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/test_conf_4.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/test_conf_4.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/test_conf_5.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/test_conf_5.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/benchmarks/equivalence/whac-a-fun/test_conf_6.json
+++ b/frontends/benchmarks/equivalence/whac-a-fun/test_conf_6.json
@@ -16,7 +16,8 @@
     ],
     "unequivalent": [],
     "unsafe": [],
-    "timeout": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
     "wrong": []
   }
 }

--- a/frontends/common/src/it/scala/stainless/equivchk/EquivChkSuite.scala
+++ b/frontends/common/src/it/scala/stainless/equivchk/EquivChkSuite.scala
@@ -74,7 +74,8 @@ class EquivChkSuite extends ComponentTestSuite {
               acc.copy(equiv = acc.equiv + (mod.fullName -> (currCluster + fn)))
             case Status.Equivalence(EquivalenceStatus.Unequivalent) => acc.copy(unequivalent = acc.unequivalent + fn)
             case Status.Equivalence(EquivalenceStatus.Unsafe) => acc.copy(unsafe = acc.unsafe + fn)
-            case Status.Equivalence(EquivalenceStatus.Unknown) => acc.copy(timeout = acc.timeout + fn)
+            case Status.Equivalence(EquivalenceStatus.UnknownSafety) => acc.copy(unknownSafety = acc.unknownSafety + fn)
+            case Status.Equivalence(EquivalenceStatus.UnknownEquivalence) => acc.copy(unknownEquivalence = acc.unknownEquivalence + fn)
             case Status.Equivalence(EquivalenceStatus.Wrong) => acc.copy(wrong = acc.wrong + fn)
             case Status.Verification(_) => acc
           }
@@ -88,12 +89,13 @@ object EquivChkSuite extends ConfigurableTests {
   case class Results(equiv: Map[String, Set[String]],
                      unequivalent: Set[String],
                      unsafe: Set[String],
-                     timeout: Set[String],
+                     unknownSafety: Set[String],
+                     unknownEquivalence: Set[String],
                      wrong: Set[String])
 
   object Results {
     def empty: Results =
-      Results(Map.empty, Set.empty, Set.empty, Set.empty, Set.empty)
+      Results(Map.empty, Set.empty, Set.empty, Set.empty, Set.empty, Set.empty)
   }
 
   case class TestConf(models: Set[String],
@@ -135,8 +137,9 @@ object EquivChkSuite extends ConfigurableTests {
     }.toMap
     val unequivalent = jsonObj.getStringArrayOrCry("unequivalent").toSet
     val unsafe = jsonObj.getStringArrayOrCry("unsafe").toSet
-    val timeout = jsonObj.getStringArrayOrCry("timeout").toSet
+    val unknownSafety = jsonObj.getStringArrayOrCry("unknownSafety").toSet
+    val unknownEquiv = jsonObj.getStringArrayOrCry("unknownEquivalence").toSet
     val wrong = jsonObj.getStringArrayOrCry("wrong").toSet
-    Results(equiv, unequivalent, unsafe, timeout, wrong)
+    Results(equiv, unequivalent, unsafe, unknownSafety, unknownEquiv, wrong)
   }
 }


### PR DESCRIPTION
"unknown safety" refers to inconclusive VCs that are unrelated to equivalence checking.