### PR TITLE
Fix `EffectsAnalyzer` missing effects on arguments

### DIFF
--- a/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
+++ b/core/src/main/scala/stainless/extraction/imperative/EffectsAnalyzer.scala
@@ -871,8 +871,8 @@ trait EffectsAnalyzer extends oo.CachingPhase {
           case FunctionInvocation(id, _, _) => Outer(getFunction(id))
           case ApplyLetRec(id, _, _, _, _) => result.locals(id)
         }
-
-        if (fun.flags.contains(IsPure)) Set()
+        val argsEff = args.flatMap(rec(_, env)).toSet
+        if (fun.flags.contains(IsPure)) argsEff
         else {
           val currentEffects: Set[Effect] = result.effects(fun)
           val paramSubst = (fun.params.map(_.toVariable) zip args).toMap
@@ -883,7 +883,7 @@ trait EffectsAnalyzer extends oo.CachingPhase {
 
           val effectsOnLocalFreeVars = currentEffects.filterNot(e => paramSubst contains e.receiver)
 
-          invocEffects ++ effectsOnLocalFreeVars ++ args.flatMap(rec(_, env))
+          invocEffects ++ effectsOnLocalFreeVars ++ argsEff
         }
 
       case Operator(es, _) => es.flatMap(rec(_, env)).toSet

--- a/frontends/benchmarks/imperative/valid/ArgsEffect1.scala
+++ b/frontends/benchmarks/imperative/valid/ArgsEffect1.scala
@@ -1,0 +1,18 @@
+import stainless.annotation._
+
+object ArgsEffect1 {
+
+  case class BitStream(bits: Array[Byte]) {
+    @pure
+    def validate_offset_bits(i: Int): Boolean = true
+  }
+
+  @mutable
+  trait Codec {
+    def bitStream: BitStream
+
+    def peekBit(): Unit = {
+      val isValidPrecondition = bitStream.validate_offset_bits(1)
+    }
+  }
+}

--- a/frontends/benchmarks/imperative/valid/ArgsEffect2.scala
+++ b/frontends/benchmarks/imperative/valid/ArgsEffect2.scala
@@ -1,0 +1,19 @@
+import stainless.annotation._
+
+object ArgsEffect2 {
+
+  case class MutClass(var i: BigInt) {
+    def inc: MutClass = {
+      i += 1
+      this
+    }
+    @pure
+    def isEqual(j: BigInt): Boolean = i == j
+  }
+
+  def test(mc: MutClass): Unit = {
+    val old = mc.i
+    val res = mc.inc.isEqual(old + 1)
+    assert(res)
+  }
+}


### PR DESCRIPTION
`@pure` annotated functions were having their arguments exempt from effects analysis, which caused a crash on the two provided test cases. 