### PR TITLE
Fix type alias of opaque triggering missing dependencies

### DIFF
--- a/frontends/benchmarks/dotty-specific/valid/TypeAliasOpaque.scala
+++ b/frontends/benchmarks/dotty-specific/valid/TypeAliasOpaque.scala
@@ -1,0 +1,26 @@
+object TypeAliasOpaque {
+  object OpaqueLongWrap {
+    opaque type OpaqueLong = Long
+    extension (ol: OpaqueLong) {
+      def toLong: Long = ol
+    }
+    object OpaqueLong {
+      def fromLong(l: Long): OpaqueLong = l
+    }
+  }
+
+  import OpaqueLongWrap.*
+
+  type AliasedOpaqueLong = OpaqueLong
+  type Tayst = Int
+
+  def test1(x: AliasedOpaqueLong): Unit = {
+    assert(OpaqueLong.fromLong(x.toLong) == x)
+  }
+
+  def test2(x: Long): Unit = {
+    assert(OpaqueLong.fromLong(x).toLong == x)
+  }
+
+  def mkAliasedOpaqueLong(x: Long): AliasedOpaqueLong = OpaqueLong.fromLong(x).ensuring(res => res.toLong == x)
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -429,11 +429,8 @@ class CodeExtraction(inoxCtx: inox.Context, symbolMapping: SymbolMapping)(using 
         (Seq.empty, extractType(tpt), false)
     }
 
-    // Opaque types are referenced from their opaque right-hand side for some reason.
-    val realId = if (td.rhs.symbol is Opaque) getIdentifier(td.rhs.symbol) else id
-
     new xt.TypeDef(
-      realId,
+      id,
       tparams.map(xt.TypeParameterDef(_)),
       body,
       flags ++ (if (isAbstract) Seq(xt.IsAbstract) else Seq.empty)


### PR DESCRIPTION
Apparently the oddity about opaque types as mentioned in the (deleted) comment is now gone, the special handling is no longer necessary (and would actually cause problem for aliases of opaque types).