### PR TITLE
Add support for exported methods

### DIFF
--- a/frontends/benchmarks/dotty-specific/invalid/ExportedMethods1.scala
+++ b/frontends/benchmarks/dotty-specific/invalid/ExportedMethods1.scala
@@ -1,0 +1,20 @@
+object ExportedMethods1 {
+  case class Counter(var x: BigInt) {
+    def add(y: BigInt): Unit = {
+      require(y >= 0)
+      x += y
+    }
+  }
+
+  case class Base(cnt: Counter) {
+    export cnt.*
+  }
+
+  case class Wrapper(base: Base) {
+    export base.*
+
+    def addWith(y: BigInt): Unit = {
+      add(y) // invalid
+    }
+  }
+}

--- a/frontends/benchmarks/dotty-specific/invalid/ExportedMethods2.scala
+++ b/frontends/benchmarks/dotty-specific/invalid/ExportedMethods2.scala
@@ -1,0 +1,11 @@
+object ExportedMethods2 {
+  import ExportedMethodsExt.SimpleCounter.*
+
+  case class Wrapper(base: Base) {
+    export base.*
+
+    def addWith(y: BigInt): Unit = {
+      add(y) // invalid
+    }
+  }
+}

--- a/frontends/benchmarks/dotty-specific/invalid/ExportedMethods3.scala
+++ b/frontends/benchmarks/dotty-specific/invalid/ExportedMethods3.scala
@@ -1,0 +1,11 @@
+object ExportedMethods3 {
+  import ExportedMethodsExt.CounterWithInvariant.*
+
+  case class Wrapper(base: Base) {
+    export base.*
+
+    def addWith(y: BigInt): Unit = {
+      x = y
+    }
+  }
+}

--- a/frontends/benchmarks/dotty-specific/invalid/ExportedMethodsExt.scala
+++ b/frontends/benchmarks/dotty-specific/invalid/ExportedMethodsExt.scala
@@ -1,0 +1,87 @@
+object ExportedMethodsExt {
+
+  // This object is used for the other ExportedMethods
+  // but we need to have at least one invalid VC to pass the "invalid" test suite
+  def dummyInvalid(x: BigInt): Unit = {
+    assert(x == 0)
+  }
+
+  object SimpleCounter {
+    case class Counter(var x: BigInt) {
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    case class Base(cnt: Counter) {
+      export cnt.*
+    }
+  }
+
+  object CounterWithInvariant {
+    case class Counter(var x: BigInt) {
+      require(x >= 0)
+
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    case class Base(cnt: Counter) {
+      export cnt.*
+    }
+  }
+
+  object AbstractCounter {
+    abstract case class Counter() {
+      var x: BigInt
+
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    case class Base(cnt: Counter) {
+      export cnt.*
+    }
+  }
+
+  object AbstractBaseAndCounter {
+    abstract case class Counter() {
+      var x: BigInt
+
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    abstract case class Base() {
+      val cnt: Counter
+      export cnt.*
+    }
+  }
+}

--- a/frontends/benchmarks/dotty-specific/valid/ExportedMethods.scala
+++ b/frontends/benchmarks/dotty-specific/valid/ExportedMethods.scala
@@ -1,0 +1,384 @@
+object ExportedMethods {
+  object Local {
+    object SimpleCounter {
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      case class Counter(var x: BigInt) {
+        def add(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+        }
+
+        def parametricAdd[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          x += y
+        }
+      }
+
+      case class Base(cnt: Counter) {
+        export cnt.*
+
+        def useCounterFromBase(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+          val abc = x
+          add(y)
+        }
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+    object CounterWithInvariant {
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      case class Counter(var x: BigInt) {
+        require(x >= 0)
+        def add(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+        }
+
+        def parametricAdd[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          x += y
+        }
+      }
+
+      case class Base(cnt: Counter) {
+        export cnt.*
+
+        def useCounterFromBase(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+          val abc = x
+          add(y)
+        }
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+
+    object AbstractCounter {
+
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      abstract case class Counter() {
+        var x: BigInt
+
+        def add(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+        }
+
+        def parametricAdd[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          x += y
+        }
+      }
+
+      case class Base(cnt: Counter) {
+        export cnt.*
+
+        def useCounterFromBase(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+          val abc = x
+          add(y)
+        }
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+
+    object AbstractBaseAndCounter {
+
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      abstract case class Counter() {
+        var x: BigInt
+
+        def add(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+        }
+
+        def parametricAdd[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          x += y
+        }
+      }
+
+      abstract case class Base() {
+        val cnt: Counter
+        export cnt.*
+
+        def useCounterFromBase(y: BigInt): Unit = {
+          require(y >= 0)
+          x += y
+          val abc = x
+          add(y)
+        }
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+  }
+
+  object Ext {
+    object SimpleCounter {
+      import ExportedMethodsExt.SimpleCounter.*
+
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+
+    object CounterWithInvariant {
+      import ExportedMethodsExt.CounterWithInvariant.*
+
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+
+    object AbstractCounter {
+      import ExportedMethodsExt.AbstractCounter.*
+
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+
+    object AbstractBaseAndCounter {
+      import ExportedMethodsExt.AbstractBaseAndCounter.*
+
+      def accessExported(w: Wrapper, y: BigInt): Unit = {
+        require(y >= 0)
+        w.add(y)
+        val abc = w.x
+        w.x = y
+      }
+
+      def useCounterFromBaseOutside(b: Base, y: BigInt): Unit = {
+        require(y >= 0)
+        b.x += y
+        val abc = b.x
+        b.add(y)
+      }
+
+      case class Wrapper(base: Base) {
+        export base.*
+
+        def addWith(y: BigInt, z: BigInt): Unit = {
+          require(y >= 0)
+          require(z >= 0)
+          x = z
+          val abc = x
+          add(y)
+          add(z)
+        }
+
+        def parametricAddWith[T](y: BigInt, t: T): Unit = {
+          require(y >= 0)
+          parametricAdd(y, t)
+        }
+      }
+    }
+  }
+}

--- a/frontends/benchmarks/dotty-specific/valid/ExportedMethodsExt.scala
+++ b/frontends/benchmarks/dotty-specific/valid/ExportedMethodsExt.scala
@@ -1,0 +1,81 @@
+object ExportedMethodsExt {
+
+  object SimpleCounter {
+    case class Counter(var x: BigInt) {
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    case class Base(cnt: Counter) {
+      export cnt.*
+    }
+  }
+
+  object CounterWithInvariant {
+    case class Counter(var x: BigInt) {
+      require(x >= 0)
+
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    case class Base(cnt: Counter) {
+      export cnt.*
+    }
+  }
+
+  object AbstractCounter {
+    abstract case class Counter() {
+      var x: BigInt
+
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    case class Base(cnt: Counter) {
+      export cnt.*
+    }
+  }
+
+  object AbstractBaseAndCounter {
+    abstract case class Counter() {
+      var x: BigInt
+
+      def add(y: BigInt): Unit = {
+        require(y >= 0)
+        x += y
+      }
+
+      def parametricAdd[T](y: BigInt, t: T): Unit = {
+        require(y >= 0)
+        x += y
+      }
+    }
+
+    abstract case class Base() {
+      val cnt: Counter
+      export cnt.*
+    }
+  }
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/StainlessExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/StainlessExtraction.scala
@@ -14,17 +14,18 @@ import typer._
 
 import extraction.xlang.{trees => xt}
 import frontend.{CallBack, Frontend, FrontendFactory, ThreadedFrontend, UnsupportedCodeException}
+import Utils._
 
 case class ExtractedUnit(file: String, unit: xt.UnitDef, classes: Seq[xt.ClassDef], functions: Seq[xt.FunDef], typeDefs: Seq[xt.TypeDef])
 
 class StainlessExtraction(val inoxCtx: inox.Context) {
   private val symbolMapping = new SymbolMapping
 
-  def extractUnit(using ctx: DottyContext): Option[ExtractedUnit] = {
+  def extractUnit(exportedSymsMapping: ExportedSymbolsMapping)(using ctx: DottyContext): Option[ExtractedUnit] = {
     // Remark: the method `extractUnit` is called for each compilation unit (which corresponds more or less to a Scala file)
     // Therefore, the symbolMapping instances needs to be shared accross compilation unit.
     // Since `extractUnit` is called within the same thread, we do not need to synchronize accesses to symbolMapping.
-    val extraction = new CodeExtraction(inoxCtx, symbolMapping)
+    val extraction = new CodeExtraction(inoxCtx, symbolMapping, exportedSymsMapping)
     import extraction._
 
     val unit = ctx.compilationUnit

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/Utils.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/Utils.scala
@@ -1,0 +1,65 @@
+package stainless
+package frontends.dotc
+
+import dotty.tools.dotc
+import dotc._
+import core._
+import Symbols._
+import dotc.util._
+import Contexts.{Context => DottyContext}
+import ast.tpd
+import Flags._
+import transform._
+
+object Utils {
+
+  case class ExportedSymbolsMapping private(private val mapping: Map[Symbol, (Option[Symbol], Symbol)]) {
+    def add(from: Symbol, recv: Option[Symbol], to: Symbol): ExportedSymbolsMapping = {
+      val newMapping = mapping + (from -> (recv, to))
+      ExportedSymbolsMapping(newMapping)
+    }
+
+    def get(sym: Symbol): Option[Seq[Symbol]] = {
+      def loop(sym: Symbol, acc: Seq[Symbol]): Seq[Symbol] = {
+        mapping.get(sym) match {
+          case Some((recv, fwd)) =>
+            val newPath = acc ++ recv.toSeq
+            loop(fwd, newPath)
+          case None => acc :+ sym
+        }
+      }
+
+      if (mapping.contains(sym)) Some(loop(sym, Seq.empty))
+      else None
+    }
+  }
+
+  object ExportedSymbolsMapping {
+    def empty: ExportedSymbolsMapping = ExportedSymbolsMapping(Map.empty)
+  }
+
+  def exportedSymbolsMapping(ctx: inox.Context, start: Int, units: List[CompilationUnit])(using dottyCtx: DottyContext): ExportedSymbolsMapping = {
+    var mapping = ExportedSymbolsMapping.empty
+
+    class Traverser(override val dottyCtx: DottyContext) extends tpd.TreeTraverser with ASTExtractors {
+      import StructuralExtractors._
+      import ExpressionExtractors._
+
+      override def traverse(tree: tpd.Tree)(using DottyContext): Unit = {
+        tree match {
+          case ExFunctionDef(sym, _, _, _, ExCall(recv, fwd, _, _)) if sym is Exported =>
+            mapping = mapping.add(sym, recv.map(_.symbol), fwd)
+          case _ => traverseChildren(tree)
+        }
+      }
+    }
+
+    import dotty.tools.dotc.typer.ImportInfo.withRootImports
+    for (unit <- units) {
+      val newCtx = dottyCtx.fresh.setPhase(start).setCompilationUnit(unit).withRootImports
+      val traverser = new Traverser(newCtx)
+      traverser.traverse(unit.tpdTree)
+    }
+    mapping
+  }
+}


### PR DESCRIPTION
The Scala compiler generates a forwarder for each exported method, however the preconditions are not taken into account, which means the forwarder will be invalid.
The idea is to drop these forwarded method and "de-alias" the symbol to get the original method or field.