### PR TITLE
AntiAliasing: avoid rebuilding mutated objects when possible

### DIFF
--- a/frontends/benchmarks/imperative/invalid/OpaqueMutation1.scala
+++ b/frontends/benchmarks/imperative/invalid/OpaqueMutation1.scala
@@ -1,0 +1,32 @@
+import stainless.lang.{ghost => ghostExpr, _}
+import stainless.proof._
+import stainless.annotation._
+import StaticChecks._
+
+object OpaqueMutation1 {
+
+  case class Box(var cnt: BigInt, var other: BigInt) {
+    @opaque // Note the opaque
+    def secretSauce(x: BigInt): BigInt = cnt + x // Nobody thought of it!
+
+    @opaque // Note the opaque here as well
+    def increment(): Unit = {
+      @ghost val oldBox = snapshot(this)
+      cnt += 1
+      ghostExpr {
+        unfold(secretSauce(other))
+        unfold(oldBox.secretSauce(other))
+        check(oldBox.secretSauce(other) + 1 == this.secretSauce(other))
+      }
+    }.ensuring(_ => old(this).secretSauce(other) + 1 == this.secretSauce(other))
+  }
+
+  def test(b: Box): Unit = {
+    @ghost val oldBox = snapshot(b)
+    b.increment()
+    // Note that, even though the implementation of `increment` does not alter `other`,
+    // we do not have that knowledge here since the function is marked as opaque.
+    // Therefore, the following is incorrect (but it holds for `b.other`, see the other `valid/OpaqueMutation`)
+    assert(oldBox.secretSauce(oldBox.other) + 1 == b.secretSauce(oldBox.other))
+  }
+}

--- a/frontends/benchmarks/imperative/invalid/OpaqueMutation2.scala
+++ b/frontends/benchmarks/imperative/invalid/OpaqueMutation2.scala
@@ -1,0 +1,33 @@
+import stainless.lang.{ghost => ghostExpr, _}
+import stainless.proof._
+import stainless.annotation._
+import StaticChecks._
+
+object OpaqueMutation2 {
+  case class SmallerBox(var otherCnt: BigInt)
+
+  case class Box(var cnt: BigInt, var smallerBox: SmallerBox) {
+    @opaque // Note the opaque
+    def secretSauce(x: BigInt): BigInt = cnt + x // Nobody thought of it!
+
+    @opaque // Note the opaque here as well
+    def increment(): Unit = {
+      @ghost val oldBox = snapshot(this)
+      cnt += 1
+      ghostExpr {
+        unfold(secretSauce(smallerBox.otherCnt))
+        unfold(oldBox.secretSauce(smallerBox.otherCnt))
+        check(oldBox.secretSauce(smallerBox.otherCnt) + 1 == this.secretSauce(smallerBox.otherCnt))
+      }
+    }.ensuring(_ => old(this).secretSauce(smallerBox.otherCnt) + 1 == this.secretSauce(smallerBox.otherCnt))
+  }
+
+  def test(b: Box): Unit = {
+    @ghost val oldBox = snapshot(b)
+    b.increment()
+    // Note that, even though the implementation of `increment` does not alter `smallerBox`,
+    // we do not have that knowledge here since the function is marked as opaque.
+    // Therefore, the following is incorrect (but it holds for `b.other`, see the other `valid/OpaqueMutation`)
+    assert(oldBox.secretSauce(oldBox.smallerBox.otherCnt) + 1 == b.secretSauce(oldBox.smallerBox.otherCnt))
+  }
+}

--- a/frontends/benchmarks/imperative/valid/ExternMutation.scala
+++ b/frontends/benchmarks/imperative/valid/ExternMutation.scala
@@ -1,6 +1,4 @@
-import stainless.lang._
 import stainless.annotation._
-import StaticChecks._
 
 object ExternMutation {
   case class Box(var value: BigInt)
@@ -10,8 +8,8 @@ object ExternMutation {
   def f2(b: Container[Box]): Unit = ???
 
   def g2(b: Container[Box]) = {
-    @ghost val b0 = snapshot(b)
+    val b0 = b
     f2(b)
-    assert(b == b0) // fails because `Container` is mutable
+    assert(b == b0) // Ok, even though `b` is assumed to be modified because `b0` is an alias of `b`
   }
 }

--- a/frontends/benchmarks/imperative/valid/MutableTuple.scala
+++ b/frontends/benchmarks/imperative/valid/MutableTuple.scala
@@ -24,8 +24,8 @@ object MutableTuple {
   }
 
   def t3(): (Foo, Bar) = {
-    val bar = Bar(1)
-    val foo = Foo(2)
+    val bar = Bar(10)
+    val foo = Foo(20)
     (foo, bar)
   }
 

--- a/frontends/benchmarks/imperative/valid/OpaqueMutation1.scala
+++ b/frontends/benchmarks/imperative/valid/OpaqueMutation1.scala
@@ -1,0 +1,70 @@
+import stainless.lang.{ghost => ghostExpr, _}
+import stainless.proof._
+import stainless.annotation._
+import StaticChecks._
+
+object OpaqueMutation1 {
+  case class Box(var cnt: BigInt, var other: BigInt) {
+    @opaque // Note the opaque
+    def secretSauce(x: BigInt): BigInt = cnt + x // Nobody thought of it!
+
+    @opaque // Note the opaque here as well
+    def increment(): Unit = {
+      @ghost val oldBox = snapshot(this)
+      cnt += 1
+      ghostExpr {
+        unfold(secretSauce(other))
+        unfold(oldBox.secretSauce(other))
+        check(oldBox.secretSauce(other) + 1 == this.secretSauce(other))
+      }
+    }.ensuring(_ => old(this).secretSauce(other) + 1 == this.secretSauce(other))
+
+    // What `increment` looks like after `AntiAliasing`
+    @opaque @pure
+    def incrementPure(): (Unit, Box) = {
+      val newThis = Box(cnt + 1, other)
+      ghostExpr {
+        unfold(newThis.secretSauce(other))
+        unfold(this.secretSauce(other))
+        check(this.secretSauce(other) + 1 == newThis.secretSauce(other))
+      }
+      ((), newThis)
+    }.ensuring { case (_, newThis) => this.secretSauce(newThis.other) + 1 == newThis.secretSauce(newThis.other) }
+  }
+
+  def test1(b: Box, cond: Boolean): Unit = {
+    @ghost val oldBox = snapshot(b)
+    val b2 = if (cond) b else Box(1, 1)
+    b.increment()
+    assert(oldBox.secretSauce(b.other) + 1 == b.secretSauce(b.other))
+    assert(cond ==> (oldBox.secretSauce(b2.other) + 1 == b2.secretSauce(b.other)))
+  }
+
+  // What `test1` looks like after `AntiAliasing`
+  def test1Pure(b: Box, cond: Boolean): Unit = {
+    val oldBox = b
+    val b2 = if (cond) b else Box(1, 1)
+    val (_, newB) = b.incrementPure()
+    val newB2 = if (cond) newB else b2
+    assert(oldBox.secretSauce(newB.other) + 1 == newB.secretSauce(newB.other))
+    assert(cond ==> (oldBox.secretSauce(newB2.other) + 1 == newB2.secretSauce(newB.other)))
+  }
+
+  def test2(b: Box, cond: Boolean): Unit = {
+    val b2 = if (cond) b else Box(1, 1)
+    @ghost val oldB2 = snapshot(b2)
+    b2.increment()
+    assert(oldB2.secretSauce(b2.other) + 1 == b2.secretSauce(b2.other))
+    assert(cond ==> (oldB2.secretSauce(b.other) + 1 == b.secretSauce(b.other)))
+  }
+
+  // What `test2` looks like after `AntiAliasing`
+  def test2Pure(b: Box, cond: Boolean): Unit = {
+    val b2 = if (cond) b else Box(1, 1)
+    val oldB2 = b2
+    val (_, newB2) = b2.incrementPure()
+    val newB = if (cond) newB2 else b
+    assert(oldB2.secretSauce(newB2.other) + 1 == newB2.secretSauce(newB2.other))
+    assert(cond ==> (oldB2.secretSauce(newB.other) + 1 == newB.secretSauce(newB.other)))
+  }
+}

--- a/frontends/benchmarks/imperative/valid/OpaqueMutation2.scala
+++ b/frontends/benchmarks/imperative/valid/OpaqueMutation2.scala
@@ -1,0 +1,44 @@
+import stainless.lang.{ghost => ghostExpr, _}
+import stainless.proof._
+import stainless.annotation._
+import StaticChecks._
+
+object OpaqueMutation2 {
+  case class SmallerBox(var otherCnt: BigInt)
+
+  case class Box(var cnt: BigInt, var smallerBox: SmallerBox) {
+    @opaque // Note the opaque
+    def secretSauce(x: BigInt): BigInt = cnt + x // Nobody thought of it!
+
+    @opaque // Note the opaque here as well
+    def increment(): Unit = {
+      @ghost val oldBox = snapshot(this)
+      cnt += 1
+      ghostExpr {
+        unfold(secretSauce(smallerBox.otherCnt))
+        unfold(oldBox.secretSauce(smallerBox.otherCnt))
+        check(oldBox.secretSauce(smallerBox.otherCnt) + 1 == this.secretSauce(smallerBox.otherCnt))
+      }
+    }.ensuring(_ => old(this).secretSauce(smallerBox.otherCnt) + 1 == this.secretSauce(smallerBox.otherCnt))
+  }
+
+  def test1(b: Box, cond: Boolean): Unit = {
+    @ghost val oldBox = snapshot(b)
+    val b2 = if (cond) b else Box(1, SmallerBox(123))
+    val smallerBoxAlias = b.smallerBox
+    b.increment()
+    assert(b.smallerBox.otherCnt == smallerBoxAlias.otherCnt)
+    assert(oldBox.secretSauce(b.smallerBox.otherCnt) + 1 == b.secretSauce(b.smallerBox.otherCnt))
+    assert(oldBox.secretSauce(smallerBoxAlias.otherCnt) + 1 == b.secretSauce(smallerBoxAlias.otherCnt))
+    assert(cond ==> (oldBox.secretSauce(b2.smallerBox.otherCnt) + 1 == b2.secretSauce(b.smallerBox.otherCnt)))
+    assert(cond ==> (oldBox.secretSauce(smallerBoxAlias.otherCnt) + 1 == b2.secretSauce(smallerBoxAlias.otherCnt)))
+  }
+
+  def test2(b: Box, cond: Boolean): Unit = {
+    val b2 = if (cond) b else Box(1, SmallerBox(123))
+    @ghost val oldB2 = snapshot(b2)
+    b2.increment()
+    assert(oldB2.secretSauce(b2.smallerBox.otherCnt) + 1 == b2.secretSauce(b2.smallerBox.otherCnt))
+    assert(cond ==> (oldB2.secretSauce(b.smallerBox.otherCnt) + 1 == b.secretSauce(b.smallerBox.otherCnt)))
+  }
+}

--- a/frontends/benchmarks/imperative/valid/PassByRef.scala
+++ b/frontends/benchmarks/imperative/valid/PassByRef.scala
@@ -1,0 +1,12 @@
+object PassByRef {
+  case class Box(var value: BigInt)
+  case class Container(b: Box)
+
+  def f2(b: Container): Unit = b.b.value = 3
+
+  def g2(b: Container) = {
+    val b0 = b
+    f2(b)
+    assert(b == b0) // Yes, because `b` and `b0` are aliases
+  }
+}

--- a/frontends/benchmarks/imperative/valid/TargetMutation10.scala
+++ b/frontends/benchmarks/imperative/valid/TargetMutation10.scala
@@ -1,0 +1,193 @@
+import stainless.lang.{ghost => ghostExpr, _}
+import stainless.proof._
+import stainless.annotation._
+import StaticChecks._
+
+object TargetMutation10 {
+  case class EvenSmallerBox(var lastCnt: BigInt)
+
+  case class SmallerBox(var otherCnt: BigInt, var evenSmallerBox: EvenSmallerBox) {
+    def increment(): Unit = {
+      otherCnt += 1
+      evenSmallerBox.lastCnt += 1
+    }
+  }
+
+  case class Box(var cnt: BigInt, var smallerBox: SmallerBox) {
+    def increment(): Unit = {
+      cnt += 1
+      smallerBox.otherCnt += 1
+      smallerBox.evenSmallerBox.lastCnt += 1
+    }
+    def replaceSmallerBox(): Unit = {
+      cnt += 1
+      smallerBox = SmallerBox(-1, EvenSmallerBox(-2))
+    }
+  }
+
+  def test1(b: Box, cond: Boolean): Unit = {
+    @ghost val oldBox = snapshot(b)
+    val b2 = if (cond) b else Box(1, SmallerBox(123, EvenSmallerBox(10)))
+    val smallerBoxAlias = b.smallerBox
+    val smallerBoxAlias2 = if (cond) b.smallerBox else SmallerBox(456, EvenSmallerBox(20))
+    val evenSmallerBoxAlias = b.smallerBox.evenSmallerBox
+    val evenSmallerBoxAliasBis = smallerBoxAlias.evenSmallerBox
+    val evenSmallerBoxAlias2 = if (cond) b.smallerBox.evenSmallerBox else EvenSmallerBox(456)
+    val evenSmallerBoxAlias2Bis = if (cond) smallerBoxAlias.evenSmallerBox else EvenSmallerBox(456)
+    b.increment()
+    assert(cond ==> (b2.cnt == b.cnt))
+    assert(!cond ==> (b2.cnt == 1))
+    assert(oldBox.cnt + 1 == b.cnt)
+    assert(b.smallerBox.otherCnt == smallerBoxAlias.otherCnt)
+    assert(b.smallerBox.evenSmallerBox.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(evenSmallerBoxAliasBis.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(cond ==> (b2.smallerBox.otherCnt == smallerBoxAlias.otherCnt))
+    assert(cond ==> (evenSmallerBoxAlias2.lastCnt == b.smallerBox.evenSmallerBox.lastCnt))
+    assert(evenSmallerBoxAlias2.lastCnt == evenSmallerBoxAlias2Bis.lastCnt)
+    assert(!cond ==> (b2.smallerBox.otherCnt == 123))
+    assert(!cond ==> (evenSmallerBoxAlias2.lastCnt == 456))
+    assert(cond ==> (smallerBoxAlias2.otherCnt == b.smallerBox.otherCnt))
+    assert(!cond ==> (smallerBoxAlias2.otherCnt == 456))
+  }
+
+  def test2(b: Box, cond: Boolean): Unit = {
+    @ghost val oldb = snapshot(b)
+    val b2 = if (cond) b else Box(1, SmallerBox(123, EvenSmallerBox(10)))
+    @ghost val oldb2 = snapshot(b2)
+    val smallerBoxAlias = b.smallerBox
+    val smallerBoxAlias2 = if (cond) b.smallerBox else SmallerBox(456, EvenSmallerBox(20))
+    val evenSmallerBoxAlias = b.smallerBox.evenSmallerBox
+    val evenSmallerBoxAliasBis = smallerBoxAlias.evenSmallerBox
+    val evenSmallerBoxAlias2 = if (cond) b.smallerBox.evenSmallerBox else EvenSmallerBox(456)
+    val evenSmallerBoxAlias2Bis = if (cond) smallerBoxAlias.evenSmallerBox else EvenSmallerBox(456)
+    b2.increment()
+    assert(cond ==> (b2.cnt == b.cnt))
+    assert(!cond ==> (b2.cnt == 2))
+    assert(!cond ==> (oldb.cnt == b.cnt))
+    assert(b.smallerBox.otherCnt == smallerBoxAlias.otherCnt)
+    assert(b.smallerBox.evenSmallerBox.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(evenSmallerBoxAliasBis.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(cond ==> (b2.smallerBox.otherCnt == smallerBoxAlias.otherCnt))
+    assert(cond ==> (evenSmallerBoxAlias2.lastCnt == b.smallerBox.evenSmallerBox.lastCnt))
+    assert(evenSmallerBoxAlias2.lastCnt == evenSmallerBoxAlias2Bis.lastCnt)
+    assert(!cond ==> (b.smallerBox.otherCnt == oldb.smallerBox.otherCnt))
+    assert(cond ==> (smallerBoxAlias2.otherCnt == b.smallerBox.otherCnt))
+  }
+
+  def test3(b: Box, cond: Boolean): Unit = {
+    @ghost val oldBox = snapshot(b)
+    val b2 = if (cond) b else Box(1, SmallerBox(123, EvenSmallerBox(10)))
+    val smallerBoxAlias = b.smallerBox
+    val smallerBoxAlias2 = if (cond) b.smallerBox else SmallerBox(456, EvenSmallerBox(20))
+    val evenSmallerBoxAlias = b.smallerBox.evenSmallerBox
+    val evenSmallerBoxAliasBis = smallerBoxAlias.evenSmallerBox
+    val evenSmallerBoxAlias2 = if (cond) b.smallerBox.evenSmallerBox else EvenSmallerBox(456)
+    val evenSmallerBoxAlias2Bis = if (cond) smallerBoxAlias.evenSmallerBox else EvenSmallerBox(456)
+    b.smallerBox.increment()
+    assert(b.smallerBox.otherCnt == smallerBoxAlias.otherCnt)
+    assert(b.smallerBox.evenSmallerBox.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(evenSmallerBoxAliasBis.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(cond ==> (b2.smallerBox.otherCnt == smallerBoxAlias.otherCnt))
+    assert(cond ==> (evenSmallerBoxAlias2.lastCnt == b.smallerBox.evenSmallerBox.lastCnt))
+    assert(evenSmallerBoxAlias2.lastCnt == evenSmallerBoxAlias2Bis.lastCnt)
+    assert(!cond ==> (b2.smallerBox.otherCnt == 123))
+    assert(!cond ==> (evenSmallerBoxAlias2.lastCnt == 456))
+    assert(cond ==> (smallerBoxAlias2.otherCnt == b.smallerBox.otherCnt))
+    assert(!cond ==> (smallerBoxAlias2.otherCnt == 456))
+  }
+
+  def test4(b: Box, cond: Boolean): Unit = {
+    @ghost val oldb = snapshot(b)
+    val b2 = if (cond) b else Box(1, SmallerBox(123, EvenSmallerBox(10)))
+    @ghost val oldb2 = snapshot(b2)
+    val smallerBoxAlias = b.smallerBox
+    val smallerBoxAlias2 = if (cond) b.smallerBox else SmallerBox(456, EvenSmallerBox(20))
+    val evenSmallerBoxAlias = b.smallerBox.evenSmallerBox
+    val evenSmallerBoxAliasBis = smallerBoxAlias.evenSmallerBox
+    val evenSmallerBoxAlias2 = if (cond) b.smallerBox.evenSmallerBox else EvenSmallerBox(456)
+    val evenSmallerBoxAlias2Bis = if (cond) smallerBoxAlias.evenSmallerBox else EvenSmallerBox(456)
+    b2.smallerBox.increment()
+    assert(b.smallerBox.otherCnt == smallerBoxAlias.otherCnt)
+    assert(b.smallerBox.evenSmallerBox.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(evenSmallerBoxAliasBis.lastCnt == evenSmallerBoxAlias.lastCnt)
+    assert(cond ==> (b2.smallerBox.otherCnt == smallerBoxAlias.otherCnt))
+    assert(cond ==> (evenSmallerBoxAlias2.lastCnt == b.smallerBox.evenSmallerBox.lastCnt))
+    assert(evenSmallerBoxAlias2.lastCnt == evenSmallerBoxAlias2Bis.lastCnt)
+    assert(!cond ==> (b.smallerBox.otherCnt == oldb.smallerBox.otherCnt))
+    assert(cond ==> (smallerBoxAlias2.otherCnt == b.smallerBox.otherCnt))
+  }
+
+  def test5(b: Box, cond: Boolean): Unit = {
+    @ghost val oldBox = snapshot(b)
+    val oldOtherCnt = b.smallerBox.otherCnt
+    val oldLastCnt = b.smallerBox.evenSmallerBox.lastCnt
+    val b2 = if (cond) b else Box(1, SmallerBox(123, EvenSmallerBox(10)))
+    val smallerBoxAlias = b.smallerBox
+    val smallerBoxAlias2 = if (cond) b.smallerBox else SmallerBox(456, EvenSmallerBox(20))
+    val evenSmallerBoxAlias = b.smallerBox.evenSmallerBox
+    val evenSmallerBoxAliasBis = smallerBoxAlias.evenSmallerBox
+    val evenSmallerBoxAlias2 = if (cond) b.smallerBox.evenSmallerBox else EvenSmallerBox(456)
+    val evenSmallerBoxAlias2Bis = if (cond) smallerBoxAlias.evenSmallerBox else EvenSmallerBox(456)
+
+    b.replaceSmallerBox()
+
+    assert(cond ==> (b2.cnt == b.cnt))
+    assert(!cond ==> (b2.cnt == 1))
+    assert(oldBox.cnt + 1 == b.cnt)
+
+    assert(b.smallerBox.otherCnt == -1)
+    assert(b.smallerBox.evenSmallerBox.lastCnt == -2)
+
+    assert(oldBox.smallerBox.otherCnt == oldOtherCnt)
+    assert(oldBox.smallerBox.evenSmallerBox.lastCnt == oldLastCnt)
+
+    assert(smallerBoxAlias.otherCnt == oldOtherCnt)
+    assert(evenSmallerBoxAlias.lastCnt == oldLastCnt)
+
+    assert(cond ==> (smallerBoxAlias.otherCnt == oldOtherCnt))
+    assert(cond ==> (evenSmallerBoxAlias.lastCnt == oldLastCnt))
+    assert(cond ==> (b2.smallerBox.otherCnt == -1))
+    assert(cond ==> (b2.smallerBox.evenSmallerBox.lastCnt == -2))
+
+    assert(!cond ==> (b2.smallerBox.otherCnt == 123))
+    assert(!cond ==> (evenSmallerBoxAlias2.lastCnt == 456))
+    assert(!cond ==> (smallerBoxAlias2.otherCnt == 456))
+  }
+
+  def test6(b: Box, cond: Boolean): Unit = {
+    @ghost val oldb = snapshot(b)
+    val b2 = if (cond) b else Box(1, SmallerBox(123, EvenSmallerBox(10)))
+    val oldOtherCnt = b2.smallerBox.otherCnt
+    val oldLastCnt = b2.smallerBox.evenSmallerBox.lastCnt
+    @ghost val oldb2 = snapshot(b2)
+    val smallerBoxAlias = b2.smallerBox
+    val smallerBoxAlias2 = if (cond) b2.smallerBox else SmallerBox(456, EvenSmallerBox(20))
+    val evenSmallerBoxAlias = b2.smallerBox.evenSmallerBox
+    val evenSmallerBoxAliasBis = smallerBoxAlias.evenSmallerBox
+    val evenSmallerBoxAlias2 = if (cond) b2.smallerBox.evenSmallerBox else EvenSmallerBox(456)
+    val evenSmallerBoxAlias2Bis = if (cond) smallerBoxAlias.evenSmallerBox else EvenSmallerBox(456)
+
+    b2.replaceSmallerBox()
+
+    assert(cond ==> (b2.cnt == b.cnt))
+    assert(oldb2.cnt + 1 == b2.cnt)
+
+    assert(b2.smallerBox.otherCnt == -1)
+    assert(b2.smallerBox.evenSmallerBox.lastCnt == -2)
+    assert(cond ==> (b.smallerBox.otherCnt == -1))
+    assert(cond ==> (b.smallerBox.evenSmallerBox.lastCnt == -2))
+
+    assert(oldb2.smallerBox.otherCnt == oldOtherCnt)
+    assert(oldb2.smallerBox.evenSmallerBox.lastCnt == oldLastCnt)
+
+    assert(smallerBoxAlias.otherCnt == oldOtherCnt)
+    assert(evenSmallerBoxAlias.lastCnt == oldLastCnt)
+
+    assert(cond ==> (smallerBoxAlias.otherCnt == oldOtherCnt))
+    assert(cond ==> (evenSmallerBoxAlias.lastCnt == oldLastCnt))
+
+    assert(!cond ==> (evenSmallerBoxAlias2.lastCnt == 456))
+    assert(!cond ==> (smallerBoxAlias2.otherCnt == 456))
+  }
+
+}

--- a/frontends/benchmarks/imperative/valid/TargetMutation4.scala
+++ b/frontends/benchmarks/imperative/valid/TargetMutation4.scala
@@ -77,4 +77,23 @@ object TargetMutation4 {
     assert(y.value == 111)
     assert(z.value == 111)
   }
+
+  def h4(x: Box, z: Box, cond: Boolean): Unit = {
+    val oldX = x.value
+    val y = if (cond) x else z
+    y.value = 456
+    assert(y.value == 456)
+    assert(cond ==> (x.value == 456))
+    assert(!cond ==> (x.value == oldX))
+  }
+
+  def h4Mutate(x: Box, z: Box, cond: Boolean): Unit = {
+    val oldX = x.value
+    val y = if (cond) x else z
+    mutate(y, 456)
+    assert(y.value == 456)
+    assert(cond ==> (x.value == 456))
+    assert(!cond ==> (x.value == oldX))
+  }
+
 }

--- a/frontends/benchmarks/imperative/valid/TargetMutation6.scala
+++ b/frontends/benchmarks/imperative/valid/TargetMutation6.scala
@@ -9,6 +9,10 @@ object TargetMutation6 {
     rr.lhs = Ref(v)
   }
 
+  def modifyLhs(rr: RefRef, v: Int): Unit = {
+    rr.lhs.x = v
+  }
+
   def t1(arr1: Array[Ref], arr2: Array[Ref], i: Int, j: Int, k: Int, cond: Boolean, gra: Ref): Unit = {
     require(arr1.length >= 10)
     require(arr2.length >= arr1.length)
@@ -27,6 +31,7 @@ object TargetMutation6 {
     val oldLhs = lhs.x
     refref.lhs = Ref(123)
     assert(lhs.x == oldLhs)
+    assert(refref.lhs.x == 123)
   }
 
   def t3(refref: RefRef): Unit = {
@@ -34,5 +39,17 @@ object TargetMutation6 {
     val oldLhs = lhs.x
     replaceLhs(refref, 123)
     assert(lhs.x == oldLhs)
+    assert(refref.lhs.x == 123)
+  }
+
+  def t4(refref: RefRef): Unit = {
+    val lhs = refref.lhs
+    val oldLhs = lhs.x
+    modifyLhs(refref, 123)
+    assert(lhs.x == 123)
+    assert(refref.lhs.x == 123)
+    refref.lhs.x = 456
+    assert(lhs.x == 456)
+    assert(refref.lhs.x == 456)
   }
 }

--- a/frontends/benchmarks/verification/false-valid/i1506.scala
+++ b/frontends/benchmarks/verification/false-valid/i1506.scala
@@ -1,0 +1,21 @@
+// Unsoundness due to an incorrect AntiAliasing transformation
+// See https://github.com/epfl-lara/stainless/issues/1506
+object i1506 {
+  case class Ref(var x: Int)
+  case class RefRef(var lhs: Ref, var rhs: Ref)
+
+  def replaceLhs(rr: RefRef, v: Int): Unit = {
+    rr.lhs = Ref(v)
+  }
+
+  def t3(refref: RefRef): Unit = {
+    val lhs = refref.lhs
+    val oldLhs = lhs.x
+    replaceLhs(refref, 123)
+    assert(lhs.x == oldLhs)
+    assert(refref.lhs.x == 123)
+    refref.lhs.x = 456
+    assert(lhs.x == 456) // Incorrect because `lhs` and `refref.lhs` become unrelated after the call to `replaceLhs`
+    assert(refref.lhs.x == 456)
+  }
+}


### PR DESCRIPTION
`AntiAliasing#mapApplication` used to "rebuild" the mutated object(s) from function calls where a reassignment could be possible.
For instance, if we have:
```scala
case class Ref(var x: Int, var y: Int)
case class RefRef(var lhs: Ref, var rhs: Ref)

def modifyLhs(rr: RefRef, v: Int): Unit = {
  rr.lhs.x = v
  rr.lhs.y = v
}
def test(testRR: RefRef): Unit = {
  val rrAlias = testRR
  val lhsAlias = testRR.lhs
  modifyLhs(testRR, 123)
  // ...
}
```
Then before this PR, `mapApplication` would transform `test` as follows:
```scala
def modifyLhs(rr: RefRef, v: Int): (Unit, RefRef) = 
  ((), RefRef(Ref(v, v), rr.rhs))

def test(testRR: RefRef) = {
  var rrAlias: RefRef = testRR
  var lhsAlias: Ref = testRR.lhs
  val res: (Unit, RefRef) = modifyLhs(testRR, 123)
  testRR = RefRef(Ref(res._2.lhs.x, testRR.lhs.y), testRR.rhs)
  lhsAlias = testRR.lhs
  rrAlias = testRR
  testRR = RefRef(Ref(testRR.lhs.x, res._2.lhs.y), testRR.rhs)
  lhsAlias = testRR.lhs
  rrAlias = testRR
  // ...
}
```
This is due to applying each effect individually.
With this PR, `test` is transformed as follows:
```scala
def test(testRR: RefRef) = {
  var rrAlias: RefRef = testRR
  var lhsAlias: Ref = testRR.lhs
  val res: (Unit, RefRef) = modifyLhs(testRR, 123)
  testRR = res._2
  rrAlias = testRR
  lhsAlias = testRR.lhs
  // ...
}
```
This in part resolves the issue when an `@opaque` function mutates an argument and uses the mutated argument in a `ensuring`, causing a discrepancy between the "updated" object used in the `ensuring` and the "rebuilt" object (for which we would like to use the `ensuring` property, but fail to do so; see `valid/OpaqueMutation` which used to fail).