### PR TITLE
AntiAliasing: restore var binding in mapApplication

### DIFF
--- a/.larabot.conf
+++ b/.larabot.conf
@@ -1,6 +1,6 @@
 commands = [
     "sbt -batch -Dtestsuite-parallelism=5 test"
-    "sbt -batch -Dtestsuite-parallelism=3 -Dtestcase-parallelism=5 \"stainless-dotty / IntegrationTest / testOnly stainless.GhostRewriteSuite stainless.GenCSuite stainless.LibrarySuite stainless.verification.VerificationSuite stainless.verification.UncheckedSuite stainless.verification.TerminationVerificationSuite stainless.verification.ImperativeSuite stainless.verification.FullImperativeSuite stainless.verification.StrictArithmeticSuite stainless.termination.TerminationSuite stainless.evaluators.EvaluatorComponentTest\""
+    "sbt -batch -Dtestsuite-parallelism=3 -Dtestcase-parallelism=5 \"stainless-dotty / IntegrationTest / testOnly stainless.DottyExtractionSuite stainless.GhostRewriteSuite stainless.GenCSuite stainless.LibrarySuite stainless.verification.VerificationSuite stainless.verification.UncheckedSuite stainless.verification.TerminationVerificationSuite stainless.verification.ImperativeSuite stainless.verification.FullImperativeSuite stainless.verification.StrictArithmeticSuite stainless.termination.TerminationSuite stainless.evaluators.EvaluatorComponentTest\""
 ]
 
 nightly {


### PR DESCRIPTION
PR #1507 made some changes to `mapApplication`, and one I made by negligence (in the diff line) turned out to unveil an issue in the `Let` case handling of `AntiAliasing` ([line in question](https://github.com/epfl-lara/stainless/blob/c4b33d13d21c3bf5657d32d498e788b4783bfe5c/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala#L675)).

Here, we compute the targets of the *transformed* binding. If this binding happens to contain a function call, the returned targets may be invalid because `getTargets` works on functions prior to the `AntiAliasing` function purification, not after (as it's done here).

The reason this issue did not arise before is the `var` introduced by `mapApplication` prevented target computation, which ultimately resulted in [rejection](https://github.com/epfl-lara/stainless/blob/c4b33d13d21c3bf5657d32d498e788b4783bfe5c/core/src/main/scala/stainless/extraction/imperative/AntiAliasing.scala#L786-L790).

This PR simply reverts the changed lines but the underlying issue is still here (though it cannot be triggered). To properly fix this, we would need to distinguish pre/post transformation `getTargets` computation, which would require significant changes to `EffectsAnalyzer`.