### PR TITLE
Scala version bump to 3.3.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -39,7 +39,7 @@ lazy val nTestSuiteParallelism = {
 }
 
 // The Scala version with which Stainless is compiled.
-val stainlessScalaVersion = "3.3.0"
+val stainlessScalaVersion = "3.3.3"
 // Stainless supports Scala 2.13 and Scala 3.3 programs.
 val frontendScalacVersion = "2.13.12"
 val frontendDottyVersion = stainlessScalaVersion

--- a/frontends/benchmarks/extraction/invalid/Initialization5.dotty.check
+++ b/frontends/benchmarks/extraction/invalid/Initialization5.dotty.check
@@ -1,12 +1,7 @@
-[ Error  ] Initialization5.scala:6:17: Cannot prove the method argument is hot. Only hot values are safe to leak.
-[ Error  ] Found = ThisRef[class NoThis].
-[ Error  ] Non initialized field(s): value nothis1, value nothis2. Calling trace:
-[ Error  ] -> case class NoThis() {	[ Initialization5.scala:2 ]
-[ Error  ]    ^
-[ Error  ] -> val nothis1 = f()	[ Initialization5.scala:3 ]
-[ Error  ]                  ^^^
-[ Error  ] -> def f() = g(this)	[ Initialization5.scala:6 ]
-[ Error  ]                ^^^^
-[ Error  ]
-               def f() = g(this)
-                           ^
+[ Error  ] Initialization5.scala:3:9: Not well formed definition @field
+[ Error  ] @fieldDefPosition(8)
+[ Error  ] @method(NoThis)
+[ Error  ] def nothis1: Int = this.f
+[ Error  ] 	because field `nothis1` can only refer to previous fields, not to `nothis2`
+               val nothis1 = f()
+                   ^

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -96,7 +96,7 @@ class CodeExtraction(inoxCtx: inox.Context,
 
     def isVariable(s: Symbol) = (vars contains s) || (mutableVars contains s)
 
-    def withNewTypeParams(ntparams: Traversable[(Symbol, xt.TypeParameter)]) = {
+    def withNewTypeParams(ntparams: Iterable[(Symbol, xt.TypeParameter)]) = {
       copy(tparams = tparams ++ ntparams)
     }
 
@@ -104,7 +104,7 @@ class CodeExtraction(inoxCtx: inox.Context,
       copy(tparams = tparams + tparam)
     }
 
-    def withNewVars(nvars: Traversable[(Symbol, () => xt.Expr)]) = {
+    def withNewVars(nvars: Iterable[(Symbol, () => xt.Expr)]) = {
       copy(vars = vars ++ nvars)
     }
 
@@ -116,7 +116,7 @@ class CodeExtraction(inoxCtx: inox.Context,
       copy(mutableVars = mutableVars + nvar)
     }
 
-    def withNewMutableVars(nvars: Traversable[(Symbol, () => xt.Variable)]) = {
+    def withNewMutableVars(nvars: Iterable[(Symbol, () => xt.Variable)]) = {
       copy(mutableVars = mutableVars ++ nvars)
     }
 
@@ -128,7 +128,7 @@ class CodeExtraction(inoxCtx: inox.Context,
       copy(localClasses = this.localClasses + (lcd.id -> lcd))
     }
 
-    def withDepParams(dps: Traversable[(TermName, xt.ValDef)]) = {
+    def withDepParams(dps: Iterable[(TermName, xt.ValDef)]) = {
       copy(depParams = depParams ++ dps)
     }
 
@@ -2391,7 +2391,7 @@ class CodeExtraction(inoxCtx: inox.Context,
       case AppliedType(tr: TypeRef, Seq(tp)) if isArrayClassSym(tr.symbol) =>
         xt.ArrayType(extractType(tp))
 
-      case fo @ defn.FunctionOf(from, to, _, _) =>
+      case fo @ defn.FunctionOf(from, to, _) =>
         xt.FunctionType(from map extractType, extractType(to))
 
       case tr @ TypeRef(_, _) if dctx.tparams contains tr.symbol =>


### PR DESCRIPTION
- FunctionOf tree changed
- Use Iterable instead of Traversable