### PR TITLE
Enhance unfold to work on bindings and imperative code as well

### DIFF
--- a/core/src/main/scala/stainless/extraction/inlining/UnfoldOpaque.scala
+++ b/core/src/main/scala/stainless/extraction/inlining/UnfoldOpaque.scala
@@ -13,32 +13,49 @@ class UnfoldOpaque(override val s: Trees, override val t: Trees)
 
   protected class TransformerContext(override val s: self.s.type,
                                      override val t: self.t.type,
-                                     val symbols: self.s.Symbols) extends inox.transformers.TreeTransformer {
+                                     val symbols: self.s.Symbols) extends inox.transformers.Transformer with inox.transformers.DefinitionTransformer {
     def this(symbols: self.s.Symbols) = this(self.s, self.t, symbols)
+    override type Env = Map[s.Variable, s.Expr]
 
     import s._
     import symbols.{given, _}
 
-    object UnfoldOpaque {
-      def unapply(e: s.Expr): Option[s.FunctionInvocation] = e match {
-        case s.FunctionInvocation(
-          ast.SymbolIdentifier("stainless.lang.unfold"),
-          Seq(_),
-          Seq(fi: s.FunctionInvocation)
-        ) => Some(fi)
-        case _ => None
+    override def initEnv: Env = Map.empty
+
+    override def transform(e: Expr, env: Env): t.Expr = {
+      e match {
+        case s.FunctionInvocation(ast.SymbolIdentifier("stainless.lang.unfold"), Seq(_), Seq(maybeFi)) =>
+          // Lookup the bindings recursively to unveil a call to a function which we would need to unfold
+          val r = dealiasedAndStripped(maybeFi, env)
+          r match {
+            case fi: FunctionInvocation =>
+              val newFi = transform(fi, env)
+              val inlined = transform(fi.inlined, env)
+              val specced = t.exprOps.BodyWithSpecs(inlined)
+              t.Assume(t.Equals(newFi, t.annotated(specced.letsAndBody, t.DropVCs)).setPos(e), t.UnitLiteral().setPos(e)).setPos(e)
+            case _ => super.transform(e, env)
+          }
+        case Let(v, e2, body) =>
+          val vRec = transform(v, env)
+          val eRec = transform(e2, env)
+          val eBody = transform(body, env + (v.toVariable -> e2))
+          t.Let(vRec, eRec, eBody).setPos(e)
+        case _ => super.transform(e, env)
       }
     }
 
-    override def transform(e: Expr): t.Expr = e match {
-      case UnfoldOpaque(fi) =>
-        val newFi = transform(fi)
-        val inlined = transform(fi.inlined)
-        val specced = t.exprOps.BodyWithSpecs(inlined)
-        t.Assume(t.Equals(newFi, t.annotated(specced.letsAndBody, t.DropVCs)).setPos(e), t.UnitLiteral().setPos(e)).setPos(e)
-      case _ => super.transform(e)
+    def dealiasedAndStripped(e: Expr, env: Env): Expr = {
+      e match {
+        case v: Variable => env.get(v).map(dealiasedAndStripped(_, env)).getOrElse(v)
+        case TupleSelect(tuple, index) =>
+          dealiasedAndStripped(tuple, env) match {
+            case Tuple(es) => dealiasedAndStripped(es(index - 1), env)
+            case _ => e
+          }
+        case Annotated(body, _) => dealiasedAndStripped(body, env)
+        case _ => e
+      }
     }
-
   }
 
   override protected def getContext(symbols: s.Symbols) = new TransformerContext(symbols)

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -49,7 +49,7 @@ package object extraction {
     "TypeEncoding"              -> "Encode non-ADT types",
     "FunctionClosure"           -> "Lift inner functions",
     "FunctionSpecialization"    -> "Specialize functions",
-    "UnfoldOpaque  "            -> "Injects equality assumption with inlined call for calls wrapped in unfold keyword",
+    "UnfoldOpaque"              -> "Injects equality assumption with inlined call for calls wrapped in unfold keyword",
     "CallSiteInline"            -> "Call-side inline for calls wrapped in inline keyword",
     "ChooseInjector"            -> "Insert chooses where necessary",
     "ChooseEncoder"             -> "Encodes chooses as functions",

--- a/frontends/benchmarks/imperative/valid/UnfoldOpaqueMutate.scala
+++ b/frontends/benchmarks/imperative/valid/UnfoldOpaqueMutate.scala
@@ -1,0 +1,30 @@
+import stainless.lang._
+import stainless.annotation._
+import StaticChecks._
+
+object UnfoldOpaqueMutate {
+  case class Box(var cnt: BigInt)
+
+  case class WrappedBox(var box: Box) {
+    @opaque
+    def opaqueMutMeth1(x: BigInt): Unit = {
+      box.cnt += x
+    }
+
+    @opaque
+    def opaqueMutMeth2(x: BigInt): Unit = {
+      box = Box(x * 2)
+    }
+  }
+
+  def test1(wb: WrappedBox, x: BigInt): Unit = {
+    @ghost val oldWb = snapshot(wb)
+    unfold(wb.opaqueMutMeth1(x))
+    assert(wb.box.cnt == oldWb.box.cnt + x)
+  }
+
+  def test2(wb: WrappedBox, x: BigInt): Unit = {
+    unfold(wb.opaqueMutMeth2(x))
+    assert(wb.box == Box(x * 2))
+  }
+}

--- a/frontends/benchmarks/verification/valid/UnfoldOpaqueVal.scala
+++ b/frontends/benchmarks/verification/valid/UnfoldOpaqueVal.scala
@@ -1,0 +1,13 @@
+import stainless.lang._
+import stainless.annotation._
+
+object UnfoldOpaqueVal {
+  @opaque
+  def opaqueFn(x: BigInt): BigInt = x + 1
+
+  def test(x: BigInt): Unit = {
+    val y = opaqueFn(x)
+    unfold(y)
+    assert(y == x + 1)
+  }
+}


### PR DESCRIPTION
Previously, performing an `unfold` on a `val` to a function or on an imperative function would do nothing.