### PR TITLE
Quote paths correctly to fix problems with paths containing spaces

### DIFF
--- a/bin/launcher-noscalaz3.tmpl.bat
+++ b/bin/launcher-noscalaz3.tmpl.bat
@@ -5,7 +5,7 @@ pushd %~dp0
 set script_dir=%CD%
 popd
 
-set PATH=%PATH%;%script_dir%\z3
-set PATH=%PATH%;%script_dir%\cvc5
+set PATH=%PATH%;"%script_dir%\z3"
+set PATH=%PATH%;"%script_dir%\cvc5"
 
-java -jar %script_dir%\lib\{STAINLESS_JAR_BASENAME} %*
+java -jar "%script_dir%\lib\{STAINLESS_JAR_BASENAME}" %*


### PR DESCRIPTION
The current release fails when invoked from paths that contain spaces, because the current path was not escaped. This PR adds quotes around the current path