### PR TITLE
Add a SAT check for precondition

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -85,6 +85,7 @@ trait MainHelpers extends inox.MainHelpers { self =>
     equivchk.optInitScore -> Description(EquivChk, "Initial score for models"),
     equivchk.optInitWeights -> Description(EquivChk, "Initial weights for models, overriding the initial score"),
     equivchk.optMaxPerm -> Description(EquivChk, "Maximum number of permutations to be tested when matching auxiliary functions"),
+    optSatPrecond -> Description(General, "Generate VCs to check that preconditions are SAT")
   ) ++ MainHelpers.components.map { component =>
     val option = inox.FlagOptionDef(component.name, default = false)
     option -> Description(Pipelines, component.description)

--- a/core/src/main/scala/stainless/package.scala
+++ b/core/src/main/scala/stainless/package.scala
@@ -17,6 +17,9 @@ package object stainless {
     val usageRhs = "file"
   }
 
+  object optSatPrecond extends inox.FlagOptionDef("sat-precond", false)
+  def isoptSatPrecondOn(using ctx: inox.Context): Boolean = ctx.options.findOptionOrDefault(optSatPrecond)
+
   object optWatch extends inox.FlagOptionDef("watch", false)
   def isWatchModeOn(using ctx: inox.Context): Boolean = ctx.options.findOptionOrDefault(optWatch)
 

--- a/core/src/main/scala/stainless/verification/TypeChecker.scala
+++ b/core/src/main/scala/stainless/verification/TypeChecker.scala
@@ -3,12 +3,10 @@
 package stainless
 package verification
 
-import inox.solvers._
-
-import TypeCheckerUtils._
-import TypeCheckerDerivation._
-import TypeCheckerContext._
-
+import inox.solvers.*
+import TypeCheckerUtils.*
+import TypeCheckerDerivation.*
+import TypeCheckerContext.*
 import stainless.termination.optCheckMeasures
 
 import scala.collection.{immutable, mutable}
@@ -1285,7 +1283,7 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
 
     // The type of the arguments, the specifications, and the return type
     // need to be well-formed without the mutually recursive dependencies
-    val nonMutuallyRecursiveContext =
+    val nonMutuallyRecursiveContext: TypingContext =
       TypingContext.empty.
         withIdentifiers(deps -- mutuallyRecursiveDeps).
         withTypeVariables(fd.tparams.map(tpd => freshener.transformTp(tpd.tp)).toSet).
@@ -1296,9 +1294,9 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
     // arguments of the function
     // `trArgs` are the verification conditions for ensuring that the type of
     // the arguments are well-formed
-    val (tc0, trArgs) = fd.params.foldLeft(nonMutuallyRecursiveContext, TyperResult.valid) {
+    val (tc0, trArgs): (TypingContext, TyperResult) = fd.params.foldLeft(nonMutuallyRecursiveContext, TyperResult.valid) {
       case ((tcAcc, trAcc), vd) =>
-        val freshVd = freshener.transform(vd)
+        val freshVd: ValDef = freshener.transform(vd)
         (
           tcAcc.bind(freshVd),
           trAcc ++ isType(tcAcc, freshVd.tpe)
@@ -1307,7 +1305,7 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
 
     // `tcWithPre` is `tc0` to which we add the preconditions and lets
     // and `trPre` is the `TyperResult` corresponding to type-checking those
-    val (tcWithPre, trPre) = specced.specs.filter(spec => spec.kind == LetKind || spec.kind == PreconditionKind).foldLeft (tc0, TyperResult.valid) {
+    val (tcWithPre, trPre): (TypingContext, TyperResult) = specced.specs.filter(spec => spec.kind == LetKind || spec.kind == PreconditionKind).foldLeft (tc0, TyperResult.valid) {
       case ((tcAcc, trAcc), LetInSpec(vd, e)) =>
         val e2 = freshener.transform(e)
         val freshVd = freshener.transform(vd)
@@ -1317,6 +1315,26 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
         (tcAcc.withTruth(cond2), trAcc ++ checkType(tcAcc, cond2, BooleanType()))
       case _ => sys.error("shouldn't be possible because of the filtering above")
     }
+
+    // We check that the specification is SAT to avoid false => P(body(x)) type of proof
+    // We construct an `And` expr with all preconditions, and type check this expr with `checkSAT(true)`
+    val (tcPreForSat, preCondExprSeq): (TypingContext, Seq[Expr]) = specced.specs.filter(spec => spec.kind == LetKind || spec.kind == PreconditionKind).foldLeft(tc0, Seq.empty[Expr]) {
+      case ((tcAcc, seqAcc), LetInSpec(vd, e)) =>
+        val e2 = freshener.transform(e)
+        val freshVd = freshener.transform(vd)
+        (tcAcc.bindWithValue(freshVd, e2), seqAcc)
+      case ((tcAcc, seqAcc), Precondition(cond)) =>
+        val cond2: Expr = freshener.transform(cond)
+        (tcAcc, seqAcc ++ Seq(cond2))
+      case _ => sys.error("shouldn't be possible because of the filtering above")
+    }
+    val preCondExpr: Option[Expr] = preCondExprSeq.toList match
+      case ee1 :: ee2 :: tl => Some(And(preCondExprSeq))
+      case ee1 :: Nil => Some(ee1)
+      case Nil => None
+
+    val trPreSat: Option[TyperResult] = preCondExpr.map(expr => buildVC(tcPreForSat.withCheckSAT(true).withVCKind(VCKind.SATPrecondCheck), expr))
+
 
     val measureOpt = specced.getSpec(MeasureKind).map(measure => freshener.transform(measure.expr))
 
@@ -1336,7 +1354,7 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
 
     val postOpt = specced.getSpec(PostconditionKind).map(post => freshener.transform(post.expr))
 
-    val freshenedReturnType = freshener.transform(fd.returnType)
+    val freshenedReturnType: Type = freshener.transform(fd.returnType)
     val bodyOpt = specced.bodyOpt.map(freshener.transform)
 
     // The `TypingContext` for the body contains all dependencies, and the measure
@@ -1347,14 +1365,14 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
     val trBody = bodyOpt.fold(TyperResult.valid) { body =>
       postOpt.fold(checkType(tcBody, body, freshenedReturnType)) {
         case Lambda(Seq(retArg), postBody) =>
-          val refinedReturnType = RefinementType(retArg, postBody)
+          val refinedReturnType: RefinementType = RefinementType(retArg, postBody)
           val vcKind = if (fd.flags.contains(Law)) VCKind.Law else VCKind.Postcondition
 
           checkType(tcBody.withVCKind(vcKind), body, refinedReturnType)
         }
     }
 
-    (measureType, (trArgs ++ trPre ++ trMeasure ++ trBody).root(OKFunction(id)))
+    (measureType, (trArgs ++ trPre ++ trPreSat.getOrElse(TyperResult.valid) ++ trMeasure ++ trBody).root(OKFunction(id)))
   }
 
   def checkType(fids: Seq[Identifier]): Seq[StainlessVC] = {

--- a/core/src/main/scala/stainless/verification/TypeChecker.scala
+++ b/core/src/main/scala/stainless/verification/TypeChecker.scala
@@ -61,6 +61,7 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
   given givenDebugSection: DebugSectionTypeChecker.type = DebugSectionTypeChecker
 
   val checkMeasures = options.findOptionOrDefault(optCheckMeasures)
+  val checkSatPrecond = options.findOptionOrDefault(optSatPrecond)
 
   /* ====================================
    *     Polarity in ADT definitions
@@ -1318,23 +1319,26 @@ class TypeChecker(val program: StainlessProgram, val context: inox.Context, val 
 
     // We check that the specification is SAT to avoid false => P(body(x)) type of proof
     // We construct an `And` expr with all preconditions, and type check this expr with `checkSAT(true)`
-    val (tcPreForSat, preCondExprSeq): (TypingContext, Seq[Expr]) = specced.specs.filter(spec => spec.kind == LetKind || spec.kind == PreconditionKind).foldLeft(tc0, Seq.empty[Expr]) {
-      case ((tcAcc, seqAcc), LetInSpec(vd, e)) =>
-        val e2 = freshener.transform(e)
-        val freshVd = freshener.transform(vd)
-        (tcAcc.bindWithValue(freshVd, e2), seqAcc)
-      case ((tcAcc, seqAcc), Precondition(cond)) =>
-        val cond2: Expr = freshener.transform(cond)
-        (tcAcc, seqAcc ++ Seq(cond2))
-      case _ => sys.error("shouldn't be possible because of the filtering above")
-    }
-    val preCondExpr: Option[Expr] = preCondExprSeq.toList match
-      case ee1 :: ee2 :: tl => Some(And(preCondExprSeq))
-      case ee1 :: Nil => Some(ee1)
-      case Nil => None
-
-    val trPreSat: Option[TyperResult] = preCondExpr.map(expr => buildVC(tcPreForSat.withCheckSAT(true).withVCKind(VCKind.SATPrecondCheck), expr))
-
+    val trPreSat: Option[TyperResult] =
+      if (checkSatPrecond) {
+        val (tcPreForSat, preCondExprSeq): (TypingContext, Seq[Expr]) = specced.specs.filter(spec => spec.kind == LetKind || spec.kind == PreconditionKind).foldLeft(tc0, Seq.empty[Expr]) {
+          case ((tcAcc, seqAcc), LetInSpec(vd, e)) =>
+            val e2 = freshener.transform(e)
+            val freshVd = freshener.transform(vd)
+            (tcAcc.bindWithValue(freshVd, e2), seqAcc)
+          case ((tcAcc, seqAcc), Precondition(cond)) =>
+            val cond2: Expr = freshener.transform(cond)
+            (tcAcc, seqAcc ++ Seq(cond2))
+          case _ => sys.error("shouldn't be possible because of the filtering above")
+        }
+        val preCondExpr: Option[Expr] = preCondExprSeq.toList match
+          case ee1 :: ee2 :: tl => Some(And(preCondExprSeq))
+          case ee1 :: Nil => Some(ee1)
+          case Nil => None
+        preCondExpr.map(expr => buildVC(tcPreForSat.withCheckSAT(true).withVCKind(VCKind.SATPrecondCheck), expr))
+      } else {
+        None
+      }
 
     val measureOpt = specced.getSpec(MeasureKind).map(measure => freshener.transform(measure.expr))
 

--- a/core/src/main/scala/stainless/verification/VerificationConditions.scala
+++ b/core/src/main/scala/stainless/verification/VerificationConditions.scala
@@ -71,6 +71,7 @@ object VCKind {
   case object CoqMethod                     extends VCKind("coq function", "coq fun.")
   case class  Error(err: String)            extends VCKind(err, "error")
   case class  AdtInvariant(inv: Identifier) extends VCKind("class invariant", "class inv.")
+  case object SATPrecondCheck               extends VCKind("precondition satisfiability", "sat precond.")
 
   def fromErr(optErr: Option[String]) = {
     optErr.map { err =>


### PR DESCRIPTION
Add a SAT check for preconditions. Example of usage:
```
def f(x: Int) : Int = {
  require(x > 0)
  val z = x
  require(x <= 0)
  3
}.ensuring(res => res < 0)
```
outputs:

```
❯ stainless-dotty example/Demo.scala --config-file=stainless.conf
[  Info  ] Finished compiling                                       
[  Info  ] Preprocessing finished                                   
[  Info  ] Finished lowering the symbols                            
[  Info  ] Finished generating VCs                                  
[  Info  ] Starting verification...
[  Info  ] Verified: 0 / 2
[Warning ]  - Result for 'precondition satisfiability' VC for f @2:7:
[Warning ] false
[Warning ] example/Demo.scala:2:7:  => INVALID
             def f(x: Int) : Int = {
                 ^
[Warning ] Property wasn't satisfiable
[  Info  ] Verified: 1 / 2
[  Info  ] Done in 5.33s
[  Info  ]   ┌───────────────────┐
[  Info  ] ╔═╡ stainless summary ╞═════════════════════════════════════════════════════════════════════════════════╗
[  Info  ] ║ └───────────────────┘                                                                                 ║
[  Info  ] ║ example/Demo.scala:2:7:         f  postcondition                       trivial                   0.0  ║
[  Info  ] ║ example/Demo.scala:2:7:         f  precondition satisfiability         invalid    U:smt-cvc5     0.2  ║
[  Info  ] ╟┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄┄╢
[  Info  ] ║ total: 2    valid: 1    (0 from cache, 1 trivial) invalid: 1    unknown: 0    time:    0.18           ║
[  Info  ] ╚═══════════════════════════════════════════════════════════════════════════════════════════════════════╝
[  Info  ] Verification pipeline summary:
[  Info  ]   cache, smt-cvc4, smt-cvc5, smt-z3, batched
[  Info  ] Shutting down executor service.
```