### PR TITLE
New reporter message for measure missing VC failing

### DIFF
--- a/core/src/main/scala/stainless/verification/VerificationChecker.scala
+++ b/core/src/main/scala/stainless/verification/VerificationChecker.scala
@@ -379,8 +379,13 @@ trait VerificationChecker { self =>
               reporter.warning(vc.getPos, " => INVALID")
               reason match {
                 case VCStatus.CounterExample(cex) =>
-                  reporter.warning("Found counter-example:")
-                  reporter.warning("  " + cex.asString.replaceAll("\n", "\n  "))
+                  vc.kind match {
+                    case VCKind.MeasureMissing =>
+                      reporter.warning("Measure is missing, cannot check termination")
+                    case _ =>
+                      reporter.warning("Found counter-example:")
+                      reporter.warning("  " + cex.asString.replaceAll("\n", "\n  "))
+                  }
 
                 case VCStatus.Unsatisfiable =>
                   reporter.warning("Property wasn't satisfiable")


### PR DESCRIPTION
the new message reports that the measure is missing instead of an empty counterexample.
ex:
```
[Warning ]  - Result for 'measure missing' VC for leftPad @33:7:
[Warning ] false
[Warning ] LeftPad.scala:33:7:  => INVALID
             def leftPad[T](c: T, n: BigInt, s: List[T]): List[T] = {
                 ^
[Warning ] Measure is missing, cannot check termination
```