### PR TITLE
Add AUR package reference and instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,7 +131,7 @@ For quick reference, with `yay` (or other AUR helpers accordingly):
 yay -S stainless-git
 ```
 
-and manually, assuming `sbt`, `git`, and a `java` runtime are available:
+and manually:
 
 ```shell
 git clone https://aur.archlinux.org/stainless-git.git
@@ -139,7 +139,8 @@ cd stainless-git
 makepkg -si
 ```
 
-Omit the `-si` to avoid installing system-wide, and only perform a local build in the directory.
+The option `-s` acquires dependencies (`java`, `git`, `sbt`) using `pacman`, `-i` installs Stainless system-wide. 
+Omit `-i` to avoid installing system-wide, and only perform a local build in the directory.
 
 Issues with the package build should ideally be reported on the [AUR package page](https://aur.archlinux.org/packages/stainless-git) itself. 
 

--- a/README.md
+++ b/README.md
@@ -124,15 +124,16 @@ A package for Stainless is available on the Arch User Repository (AUR) for ArchL
 You can use your favorite AUR helper (we've tried `yay`, see [AUR Helpers](https://wiki.archlinux.org/title/AUR_helpers)), 
 or follow the [detailed instructions as on the ArchWiki](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages) to install the package.
 
-With `yay` (or other AUR helpers accordingly):
 
-```console
+For quick reference, with `yay` (or other AUR helpers accordingly):
+
+```shell
 yay -S stainless-git
 ```
 
-Manually, assuming `sbt`, `git`, and a `java` runtime are available:
+and manually, assuming `sbt`, `git`, and a `java` runtime are available:
 
-```console
+```shell
 git clone https://aur.archlinux.org/stainless-git.git
 cd stainless-git
 makepkg -si

--- a/README.md
+++ b/README.md
@@ -142,6 +142,8 @@ makepkg -si
 The option `-s` acquires dependencies (`java`, `git`, `sbt`) using `pacman`, `-i` installs Stainless system-wide. 
 Omit `-i` to avoid installing system-wide, and only perform a local build in the directory.
 
+The solver packages `z3`, `cvc4`, and `cvc5`<sup>AUR</sup> can be added as optional dependencies, and having at least one is recommended for general use.
+
 Issues with the package build should ideally be reported on the [AUR package page](https://aur.archlinux.org/packages/stainless-git) itself. 
 
 ## Further Documentation and Learning Materials

--- a/README.md
+++ b/README.md
@@ -118,6 +118,30 @@ If you have access to a remote machine over SSH, this is the recommended way to 
 Github Codespaces
 To allow running Stainless with only a browser, we have provided a sample repository to use Stainless with Github Codespaces. Github Codespaces are cloud machines that can be access via Visual Studio Code locally or in the browser. In our experience (as of October 2023), this flow works well, given the provided Ubuntu Linux virtual machines with 16GB of RAM and substantial processing power. Please see [this repository](https://github.com/samuelchassot/Stainless-codespaces) for further details.
 
+### Arch User Repository
+
+A package for Stainless is available on the Arch User Repository (AUR) for ArchLinux as [`stainless-git`](https://aur.archlinux.org/packages/stainless-git), which follows the latest commit on the `main` branch.
+You can use your favorite AUR helper (we've tried `yay`, see [AUR Helpers](https://wiki.archlinux.org/title/AUR_helpers)), 
+or follow the [detailed instructions as on the ArchWiki](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages) to install the package.
+
+With `yay` (or other AUR helpers accordingly):
+
+```console
+yay -S stainless-git
+```
+
+Manually, assuming `sbt`, `git`, and a `java` runtime are available:
+
+```console
+git clone https://aur.archlinux.org/stainless-git.git
+cd stainless-git
+makepkg -si
+```
+
+Omit the `-si` to avoid installing system-wide, and only perform a local build in the directory.
+
+Issues with the package build should ideally be reported on the [AUR package page](https://aur.archlinux.org/packages/stainless-git) itself. 
+
 ## Further Documentation and Learning Materials
 
 To get started, see videos:


### PR DESCRIPTION
Adds the following section to the README, describing the AUR package, copied to be rendered here:

==========================================================

### Arch User Repository

A package for Stainless is available on the Arch User Repository (AUR) for ArchLinux as [`stainless-git`](https://aur.archlinux.org/packages/stainless-git), which follows the latest commit on the `main` branch. You can use your favorite AUR helper (we've tried `yay`, see [AUR Helpers](https://wiki.archlinux.org/title/AUR_helpers)),  or follow the [detailed instructions as on the ArchWiki](https://wiki.archlinux.org/title/Arch_User_Repository#Installing_and_upgrading_packages) to install the package.


For quick reference, with `yay` (or other AUR helpers accordingly):

```shell
yay -S stainless-git
```

and manually:

```shell
git clone https://aur.archlinux.org/stainless-git.git
cd stainless-git
makepkg -si
```

The option `-s` acquires dependencies (`java`, `git`, `sbt`) using `pacman`, `-i` installs Stainless system-wide.  Omit `-i` to avoid installing system-wide, and only perform a local build in the directory.

The solver packages `z3`, `cvc4`, and `cvc5`<sup>AUR</sup> can be added as optional dependencies, and having at least one is recommended for general use.

Issues with the package build should ideally be reported on the [AUR package page](https://aur.archlinux.org/packages/stainless-git) itself. 

==========================================================