### PR TITLE
Fix GenC tail rec elimination for unit functions when body is not in Block

### DIFF
--- a/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
+++ b/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
@@ -111,11 +111,10 @@ final class TailRecTransformer(val ctx: inox.Context) extends Transformer(SIR, T
       val labelName = freshId("label")
       val bodyWithNewParams = replaceBindings(newParamMap, body)
       val bodyWithUnitReturn = bodyWithNewParams match {
-        case Block(stmts) =>
-          if fd.returnType.isUnitType then
-            Block(stmts :+ Return(Lit(UnitLit)))
-          else
-            bodyWithNewParams
+        case Block(stmts) if fd.returnType.isUnitType =>
+          Block(stmts :+ Return(Lit(UnitLit)))
+        case _ if fd.returnType.isUnitType =>
+          Block(Seq(bodyWithNewParams, Return(Lit(UnitLit))))
         case _ => bodyWithNewParams
       }
       val declarations = newParamMap.toList.map { case (old, nw) => Decl(nw, Some(Binding(old))) }


### PR DESCRIPTION
This is to fix a newly-discovered subtle bug, following #1626. Essentially for `Unit` functions without a `return` statement, we add a return statement at the end so that it is not rewritten into an infinite `while` loop. We assumed before that all functions have body wrapped in a `Block` object, but actually this may not be the case.

(Interestingly, we didn’t change any test case, and it was not an issue on our x86/64 laptops and on CI (function bodies were always wrapped in `Block`s). But I accidentally got an issue when I was testing things on a different Mac with Apple Silicon (ARM architecture), where sometimes if the function has, say, only an `If` statement, the body will simply be that `If` object instead of that `If` wrapped inside a `Block` object.)