### PR TITLE
Equivalence Component: norm can change the return type

### DIFF
--- a/core/src/main/scala/stainless/equivchk/EquivalenceChecker.scala
+++ b/core/src/main/scala/stainless/equivchk/EquivalenceChecker.scala
@@ -1418,13 +1418,13 @@ object EquivalenceChecker {
 
   // To be compatible:
   // -norm's first n-1 params must be compatible with the model params
-  // -norm return type must be compatible with return type of model
-  // -norm last param must be the same as its return type (i.e. compatible with the return type of model)
+  // -norm's last param must be compatible with the return type of model
+  // -norm's return type does **not** need to be compatible with return type of model
   private def checkArgsNorm(ts: Trees)(symbols: ts.Symbols, model: Identifier, norm: Identifier): Boolean = {
     val m = symbols.functions(model)
     val n = symbols.functions(norm)
-    n.params.nonEmpty && n.params.last.tpe == n.returnType &&
-      areSignaturesCompatibleModuloPerm(ts)(m.params, m.tparams, m.returnType, n.params.init, n.tparams, n.returnType, ArgPermutation(m.params.indices))
+    n.params.nonEmpty &&
+      areSignaturesCompatibleModuloPerm(ts)(m.params, m.tparams, m.returnType, n.params.init, n.tparams, n.params.last.tpe, ArgPermutation(m.params.indices))
   }
 
   //////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/frontends/benchmarks/equivalence/binSum/Candidate.scala
+++ b/frontends/benchmarks/equivalence/binSum/Candidate.scala
@@ -1,0 +1,24 @@
+import stainless.lang._
+import stainless.collection._
+
+object Candidate:
+
+  def binSum(l1: List[Boolean], l2: List[Boolean], c: Boolean): List[Boolean] =
+    (l1, l2, c) match
+      case (Nil(), Nil(), _) => List(false)
+      case (Cons(true, t1), Cons(false, t2), false) => true::binSum(t1, t2, false)
+      case (Cons(true, t1), Cons(false, t2), true) => false::binSum(t1, t2, true)
+      case (Cons(false, t1), Cons(true, t2), false) => true::binSum(t1, t2, false)
+      case (Cons(false, t1), Cons(true, t2), true) => false::binSum(t1, t2, true)
+      case (Cons(false, t1), Cons(false, t2), false) => false::binSum(t1, t2, false)
+      case (Cons(false, t1), Cons(false, t2), true) => true::binSum(t1, t2, false)
+      case (Cons(true, t1), Cons(true, t2), false) => false::binSum(t1, t2, true)
+      case (Cons(true, t1), Cons(true, t2), true) => true::binSum(t1, t2, true)
+      case (Cons(true, t1), Nil(), true) => false::binSum(t1, Nil(), true)
+      case (Cons(true, t1), Nil(), false) => true::binSum(t1, Nil(), false)
+      case (Cons(false, t1), Nil(), true) => true::binSum(t1, Nil(), false)
+      case (Cons(false, t1), Nil(), false) => false::binSum(t1, Nil(), false)
+      case (Nil(), Cons(true, t1), true) => false::binSum(t1, Nil(), true)
+      case (Nil(), Cons(true, t1), false) => true::binSum(t1, Nil(), false)
+      case (Nil(), Cons(false, t1), true) => true::binSum(t1, Nil(), false)
+      case (Nil(), Cons(false, t1), false) => false::binSum(t1, Nil(), false)

--- a/frontends/benchmarks/equivalence/binSum/Model.scala
+++ b/frontends/benchmarks/equivalence/binSum/Model.scala
@@ -1,0 +1,25 @@
+import stainless.lang._
+import stainless.collection._
+
+// This tests the normalization function where the return type is changed
+
+object Model:
+
+  def binSum(l1: List[Boolean], l2: List[Boolean], c: Boolean): List[Boolean] =
+    (l1, l2) match
+      case (Nil(), Nil()) => Nil()
+      case (Cons(true, t1), Cons(false, t2)) => !c::binSum(t1, t2, c)
+      case (Cons(false, t1), Cons(true, t2)) => !c::binSum(t1, t2, c)
+      case (Cons(false, t1), Cons(false, t2)) => c::binSum(t1, t2, false)
+      case (Cons(true, t1), Cons(true, t2)) => c::binSum(t1, t2, true)
+      case (Cons(true, t1), Nil()) => !c::binSum(t1, Nil(), c)
+      case (Cons(false, t1), Nil()) => c::binSum(t1, Nil(), false)
+      case (Nil(), Cons(true, t2)) => !c::binSum(t2, Nil(), c)
+      case (Nil(), Cons(false, t2)) => c::binSum(t2, Nil(), false)
+
+  def norm(l1: List[Boolean], l2: List[Boolean], c: Boolean, res: List[Boolean]) =
+    listToInt(res) // transform the semi-specified output to absorb trailing 0s
+  def listToInt(l: List[Boolean]): BigInt = l match
+    case Nil() => 0
+    case Cons(true, tl) => 1 + 2 * listToInt(tl)
+    case Cons(false, tl) => 2 * listToInt(tl)

--- a/frontends/benchmarks/equivalence/binSum/test_conf.json
+++ b/frontends/benchmarks/equivalence/binSum/test_conf.json
@@ -1,0 +1,24 @@
+{
+  "models": [
+    "Model.binSum"
+  ],
+  "comparefuns": [
+    "Candidate.binSum"
+  ],
+  "norm": "Model.norm",
+  "outcome": {
+    "equivalent": [
+      {
+        "model": "Model.binSum",
+        "functions": [
+          "Candidate.binSum"
+        ]
+      }
+    ],
+    "unequivalent": [],
+    "unsafe": [],
+    "unknownSafety": [],
+    "unknownEquivalence": [],
+    "wrong": []
+  }
+}


### PR DESCRIPTION
Removing the requirement that `norm` function has to preserve the return type of model/candidate programs.

One example of such useful type transformation is in `frontends/benchmarks/equivalence/binSum`, where `List[Boolean]` is normalized to `BigInt`.