### PR TITLE
Remove `fail_if_pull_request_is_draft` job

### DIFF
--- a/.github/workflows/stainless-CI.yml
+++ b/.github/workflows/stainless-CI.yml
@@ -50,10 +50,3 @@ jobs:
       run: ./stainless-ci.sh --skip-build --skip-tests --skip-bolts
     - name: Clean up
       run: rm -rf $JAVA_OPTS_TMP_DIR
-  fail_if_pull_request_is_draft:
-    if: github.event.pull_request.draft == true
-    runs-on: [self-hosted, linux]
-    steps:
-    - name: Fails in order to indicate that pull request needs to be marked as ready to review and tests workflows need to pass.
-      run: exit 1
-


### PR DESCRIPTION
What is the purpose of `fail_if_pull_request_is_draft`?

GitHub already prevents merging draft PRs:

<img width="868" height="152" alt="image" src="https://github.com/user-attachments/assets/e734ee30-b5d2-46d3-81f9-12bfdd95eb32" />
