### PR TITLE
Fix a bug in extraction for method calls with multiple list of arguments

### DIFF
--- a/frontends/benchmarks/extraction/valid/ClassTagMethodCalls.scala
+++ b/frontends/benchmarks/extraction/valid/ClassTagMethodCalls.scala
@@ -1,0 +1,19 @@
+import stainless.collection.List
+import scala.reflect.ClassTag
+
+object ClassTagMethodCalls:
+  trait Interface:
+    def pred[C: ClassTag](l: List[C]): Boolean = true
+    def f[C: ClassTag](l: List[C]): List[C]
+  end Interface
+
+  case object Impl extends Interface:
+    override def f[C: ClassTag](l: List[C]): List[C] = {
+      require(pred(l))
+      l
+    }
+  end Impl
+
+  @main def classTagMethodCallsMain(): Unit =
+    val res = Impl.f(List(1, 2, 3))
+end ClassTagMethodCalls

--- a/frontends/benchmarks/extraction/valid/MethodCallsWithMultipleArgsLists.scala
+++ b/frontends/benchmarks/extraction/valid/MethodCallsWithMultipleArgsLists.scala
@@ -1,0 +1,18 @@
+import stainless.collection.List
+
+object MethodCallsWithMultipleArgsLists:
+  trait Interface:
+    def pred[C](l: List[C])(x: Int)(y: Int): Boolean = true
+    def f[C](l: List[C]): List[C]
+  end Interface
+
+  case object Impl extends Interface:
+    override def f[C](l: List[C]): List[C] = {
+      require(pred(l)(0)(0))
+      l
+    }
+  end Impl
+
+  @main def methodCallsWithMultipleArgsListsMain(): Unit =
+    val res = Impl.f(List(1, 2, 3))
+end MethodCallsWithMultipleArgsLists

--- a/frontends/benchmarks/extraction/valid/MethodCallsWithMultipleArgsLists.scala
+++ b/frontends/benchmarks/extraction/valid/MethodCallsWithMultipleArgsLists.scala
@@ -11,8 +11,14 @@ object MethodCallsWithMultipleArgsLists:
       require(pred(l)(0)(0))
       l
     }
+
+    def g(l: List[Int]): List[Int] = {
+      require(pred[Int](l)(1)(2))
+      l
+    }
   end Impl
 
   @main def methodCallsWithMultipleArgsListsMain(): Unit =
     val res = Impl.f(List(1, 2, 3))
+    val res2 = Impl.g(List(4, 5, 6))
 end MethodCallsWithMultipleArgsLists

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -445,6 +445,7 @@ trait ASTExtractors {
         val optCall = tree match {
           case id @ Ident(_) => Some((id, Nil, Nil))
           case Apply(id @ Ident(_), args) => Some((id, Nil, args))
+          case Apply(Apply(id @ Ident(_), args), args2) => Some((id, Nil, args ++ args2))
           case TypeApply(id @ Ident(_), tps) => Some((id, tps, Nil))
           case Apply(TypeApply(id @ Ident(_), tps), args) => Some((id, tps, args))
           case _ => None
@@ -526,6 +527,7 @@ trait ASTExtractors {
           case tree @ Apply(select @ Select(qualifier, _), args) => Some((Some(qualifier), select.symbol, Nil, args))
           case tree @ TypeApply(id: tpd.Ident, tps) => Some((None, id.symbol, tps, Nil))
           case tree @ TypeApply(select @ Select(qualifier, _), tps) => Some((Some(qualifier), select.symbol, tps, Nil))
+          case tree @ Apply(ExThisCall(tt, sym, tps, args), newArgs) => Some((Some(tpd.This(tt.cls)), sym, tps, args ++ newArgs))
           case tree @ Apply(ExCall(caller, sym, tps, args), newArgs) => Some((caller, sym, tps, args ++ newArgs))
           case tree @ TypeApply(ExCall(caller, sym, tps, args), newTps) => Some((caller, sym, tps ++ newTps, args))
           case _ => None

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -445,7 +445,6 @@ trait ASTExtractors {
         val optCall = tree match {
           case id @ Ident(_) => Some((id, Nil, Nil))
           case Apply(id @ Ident(_), args) => Some((id, Nil, args))
-          case Apply(Apply(id @ Ident(_), args), args2) => Some((id, Nil, args ++ args2))
           case TypeApply(id @ Ident(_), tps) => Some((id, tps, Nil))
           case Apply(TypeApply(id @ Ident(_), tps), args) => Some((id, tps, args))
           case _ => None


### PR DESCRIPTION
Fixes a problem in the extraction of method calls with multiple lists of arguments. Previously, the receiver (i.e., probably `this`) was lost as it was extracted as a function call without receiver.

Fixes #1692 

Was discovered while working on class tags, as they add implicitly a new list of parameters to methods.

Example:

```scala
trait Interface:
  def pred[C: ClassTag](l: List[C]): Boolean = true
  def f[C: ClassTag](l: List[C]): List[C]
end Interface

case object Impl extends Interface:
  override def f[C: ClassTag](l: List[C]): List[C] = {
    require(pred(l))
    l
  }
end Impl
```

Here, the call to `pred` in the `require` of `f` was extracted as: 

```scala
@final
@method(Impl)
def f[C](l: List[C]): List[C] = {
  require(pred[C](l))
  l
}
```

instead of 


```scala
@final
@method(Impl)
def f[C](l: List[C]): List[C] = {
  require(this.pred[C](l))
  l
}
```


See #1692 for more details.