### PR TITLE
Add golden-file snapshots of generated C to GenCSuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -114,6 +114,10 @@ project/project/
 *.c
 *.h
 *.out
+# ... but keep the GenC golden snapshots (named `.expected.c` / `.expected.h` for
+# syntax highlighting) under version control.
+!*.expected.c
+!*.expected.h
 
 # LZW GenC benchmarks files
 input.txt

--- a/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
+++ b/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
@@ -68,53 +68,54 @@ final class TailRecTransformer(val ctx: inox.Context) extends Transformer(SIR, T
     functionRefs.contains(fd) && functionRefs.filter(_ == fd).size == tailFunctionRefs.filter(_ == fd).size
   }
 
-  /* Rewrite a tail recursive function to a while loop
+  /* Rewrite a tail recursive function to a labelled block iterated with `goto`.
   *  Example:
   *  def fib(n: Int, i: Int = 0, j: Int = 1): Int =
   *    if (n == 0)
   *      return i
   *    else
   *      return fib(n-1, j, i+j)
-  * 
+  *
   *  ==>
   *
   *  def fib(n: Int, i: Int = 0, j: Int = 1): Int = {
-  * 
+  *
   *    var n$ = n
   *    var i$ = i
   *    var j$ = j
-  *    while (true) {
-  *      someLabel:
-  *        if (n$ == 0) {
-  *          return i$
-  *        } else {
-  *          val n$1 = n$ - 1
-  *          val i$1 = j$
-  *          val j$1 = i$ + j$
-  *          n$ = n$1
-  *          i$ = i$1
-  *          j$ = j$1
-  *          goto someLabel
-  *        }
-  *    }
+  *    someLabel:
+  *      if (n$ == 0) {
+  *        return i$
+  *      } else {
+  *        val n$1 = n$ - 1
+  *        val i$1 = j$
+  *        val j$1 = i$ + j$
+  *        n$ = n$1
+  *        i$ = i$1
+  *        j$ = j$1
+  *        goto someLabel
+  *      }
   * }
   * Steps:
   * - Create a new variable for each parameter of the function
   * - Replace existing parameter references with the new variables
-  * - Create a while loop with a condition true
-  * - Replace the recursive return with a variable assignments (updating the state) and a continue statement
+  * - Replace the recursive return with variable assignments (updating the state) and a `goto`
+  *
+  * Note: no enclosing `while (true)` is needed — every path ends in either a `goto` back to
+  * the label (a recursive step) or a `return` (the base case), so the backward `goto` alone
+  * drives the iteration. Emitting a `while (true)` would be redundant and, worse, would turn a
+  * missing base-case `return` into an infinite loop rather than a benign fall-through return.
   */
-  private def rewriteToAWhileLoop(fd: FunDef): FunDef = fd.body match {
+  private def rewriteToALabelledLoop(fd: FunDef): FunDef = fd.body match {
     case FunBodyAST(body) =>
       val newParams = fd.params.map(p => ValDef(freshId(p.id), p.typ, isVar = true))
       val newParamMap = fd.params.zip(newParams).toMap
       val labelName = freshId("label")
       val bodyWithNewParams = replaceBindings(newParamMap, body)
-      // For a Unit-returning function, make the implicit `()` on the base-case path
-      // explicit by appending a `return;`. Without it, the `while (true)` loop introduced
-      // below never terminates when the base case (i.e. no recursive/goto call) is reached.
-      // This must be done for any body shape, not only a Block: e.g. a bare
-      // `if (c) recurse()` body would otherwise loop forever.
+      // For a Unit-returning function, make the implicit `()` on the base-case path explicit
+      // by appending a `return;`, so control leaves the function instead of falling through
+      // past the label. This must be done for any body shape, not only a Block: e.g. a bare
+      // `if (c) recurse()` body would otherwise have no return on its base-case path.
       val bodyWithUnitReturn =
         if fd.returnType.isUnitType then
           val stmts = bodyWithNewParams match {
@@ -126,8 +127,7 @@ final class TailRecTransformer(val ctx: inox.Context) extends Transformer(SIR, T
       val declarations = newParamMap.toList.map { case (old, nw) => Decl(nw, Some(Binding(old))) }
       val newBody = replaceRecursiveCalls(fd, bodyWithUnitReturn, newParams.toList, labelName)
       val newBodyWithALabel = Labeled(labelName, newBody)
-      val newBodyWithAWhileLoop = While(True, newBodyWithALabel)
-      FunDef(fd.id, fd.returnType, fd.ctx, fd.params, FunBodyAST(Block(declarations :+ newBodyWithAWhileLoop)), fd.isExported, fd.isPure)
+      FunDef(fd.id, fd.returnType, fd.ctx, fd.params, FunBodyAST(Block(declarations :+ newBodyWithALabel)), fd.isExported, fd.isPure)
     case _ => fd
   }
 
@@ -170,7 +170,7 @@ final class TailRecTransformer(val ctx: inox.Context) extends Transformer(SIR, T
       val newFdsMap = prog.functions.map { fd => 
         val fdWithTailRecUnitInReturn = putTailRecursiveUnitCallInReturn(fd)
         if isTailRecursive(fdWithTailRecUnitInReturn) then
-          val fdRewrittenToLoop = rewriteToAWhileLoop(fdWithTailRecUnitInReturn)
+          val fdRewrittenToLoop = rewriteToALabelledLoop(fdWithTailRecUnitInReturn)
           // val irPrinter = IRPrinter(SIR)
           // print(irPrinter.apply(newFd)(using irPrinter.Context(0)))
           fd -> fdRewrittenToLoop

--- a/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
+++ b/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
@@ -110,14 +110,19 @@ final class TailRecTransformer(val ctx: inox.Context) extends Transformer(SIR, T
       val newParamMap = fd.params.zip(newParams).toMap
       val labelName = freshId("label")
       val bodyWithNewParams = replaceBindings(newParamMap, body)
-      val bodyWithUnitReturn = bodyWithNewParams match {
-        case Block(stmts) =>
-          if fd.returnType.isUnitType then
-            Block(stmts :+ Return(Lit(UnitLit)))
-          else
-            bodyWithNewParams
-        case _ => bodyWithNewParams
-      }
+      // For a Unit-returning function, make the implicit `()` on the base-case path
+      // explicit by appending a `return;`. Without it, the `while (true)` loop introduced
+      // below never terminates when the base case (i.e. no recursive/goto call) is reached.
+      // This must be done for any body shape, not only a Block: e.g. a bare
+      // `if (c) recurse()` body would otherwise loop forever.
+      val bodyWithUnitReturn =
+        if fd.returnType.isUnitType then
+          val stmts = bodyWithNewParams match {
+            case Block(ss) => ss
+            case other     => List(other)
+          }
+          Block(stmts :+ Return(Lit(UnitLit)))
+        else bodyWithNewParams
       val declarations = newParamMap.toList.map { case (old, nw) => Decl(nw, Some(Binding(old))) }
       val newBody = replaceRecursiveCalls(fd, bodyWithUnitReturn, newParams.toList, labelName)
       val newBodyWithALabel = Labeled(labelName, newBody)

--- a/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
+++ b/core/src/main/scala/stainless/genc/ir/TailRecTransformer.scala
@@ -112,20 +112,11 @@ final class TailRecTransformer(val ctx: inox.Context) extends Transformer(SIR, T
       val newParamMap = fd.params.zip(newParams).toMap
       val labelName = freshId("label")
       val bodyWithNewParams = replaceBindings(newParamMap, body)
-      // For a Unit-returning function, make the implicit `()` on the base-case path explicit
-      // by appending a `return;`, so control leaves the function instead of falling through
-      // past the label. This must be done for any body shape, not only a Block: e.g. a bare
-      // `if (c) recurse()` body would otherwise have no return on its base-case path.
-      val bodyWithUnitReturn =
-        if fd.returnType.isUnitType then
-          val stmts = bodyWithNewParams match {
-            case Block(ss) => ss
-            case other     => List(other)
-          }
-          Block(stmts :+ Return(Lit(UnitLit)))
-        else bodyWithNewParams
+      // No terminating `return` is added on the base-case path: a Unit-returning function
+      // becomes a C `void` function, and reaching the end of its body is already a normal
+      // return. (Non-Unit functions have an explicit `return <value>` on every base-case path.)
       val declarations = newParamMap.toList.map { case (old, nw) => Decl(nw, Some(Binding(old))) }
-      val newBody = replaceRecursiveCalls(fd, bodyWithUnitReturn, newParams.toList, labelName)
+      val newBody = replaceRecursiveCalls(fd, bodyWithNewParams, newParams.toList, labelName)
       val newBodyWithALabel = Labeled(labelName, newBody)
       FunDef(fd.id, fd.returnType, fd.ctx, fd.params, FunBodyAST(Block(declarations :+ newBodyWithALabel)), fd.isExported, fd.isPure)
     case _ => fd

--- a/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/IR2CPhase.scala
@@ -77,8 +77,11 @@ private class IR2CImpl()(using ctx: inox.Context) {
         )
     }}
 
-    prog.functions foreach rec
-    prog.classes foreach rec
+    // Process functions and classes in a deterministic (id-sorted) order: datatypes are
+    // registered on first encounter (see `dataTypes`), so a stable traversal order gives a
+    // stable — and still dependency-correct — declaration order in the generated C.
+    prog.functions.sortBy(_.id) foreach rec
+    prog.classes.sortBy(_.id) foreach rec
 
     val enums = enumCache.values.toSet
     val functions = funCache.values.toSet
@@ -496,8 +499,9 @@ private class IR2CImpl()(using ctx: inox.Context) {
     require(cd.isAbstract && cd.parent.isEmpty) // Top of hierarchy
 
     // List all (concrete) leaves of the class hierarchy as fields of the union.
-    val leaves = cd.getHierarchyLeaves
-    val fields = leaves.toSeq map { c => (C.Var(getUnionFieldFor(c), getStructFor(c)), Seq.empty) }
+    // `getHierarchyLeaves` returns a Set; sort by id so the field order is deterministic.
+    val leaves = cd.getHierarchyLeaves.toSeq.sortBy(_.id)
+    val fields = leaves map { c => (C.Var(getUnionFieldFor(c), getStructFor(c)), Seq.empty) }
     val id = rec("union_" + cd.id)
 
     val union = C.Union(id, fields, cd.isExported)
@@ -511,8 +515,9 @@ private class IR2CImpl()(using ctx: inox.Context) {
   // Build the enum used in the "tagged union" structure that is representing a class hierarchy.
   private def getEnumFor(cd: ClassDef): C.Enum = enumCache.getOrElseUpdate(cd, {
     // List all (concrete) leaves of the class hierarchy as fields of the union.
-    val leaves = cd.getHierarchyLeaves
-    val literals = leaves.toSeq map getEnumLiteralFor
+    // Sort by id (getHierarchyLeaves is a Set) so the enum literal order is deterministic.
+    val leaves = cd.getHierarchyLeaves.toSeq.sortBy(_.id)
+    val literals = leaves map getEnumLiteralFor
     val id = rec("enum_" + cd.id)
 
     C.Enum(id, literals)

--- a/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/Scala2IRPhase.scala
@@ -38,10 +38,15 @@ class Scala2IRPhase(val arrayLengthsMap: Map[Identifier, Int])
     val impl = new S2IRImpl(tt, tt, ctxDB, syms, arrayLengthsMap)
     impl.run()
 
+    // Sort functions and classes by their (unique) id so that the IR — and therefore the
+    // generated C — is deterministic. `funResults`/`classResults` are mutable maps whose
+    // `values` iteration order is not stable across JVM runs; leaving it unsorted makes
+    // downstream output (e.g. fresh-variable numbering in the Normaliser, which shares a
+    // counter across functions, and datatype declaration order in IR2C) non-deterministic.
     CIR.Prog(
       impl.declResults.toList,
-      impl.funResults.values.toList,
-      impl.classResults.filter { case ((ct, _), _) => !isGlobal(ct)(using syms) }.values.toList,
+      impl.funResults.values.toList.sortBy(_.id),
+      impl.classResults.filter { case ((ct, _), _) => !isGlobal(ct)(using syms) }.values.toList.sortBy(_.id),
     )
   }
 }

--- a/frontends/benchmarks/genc/valid/ArgumentsEffects.expected.c
+++ b/frontends/benchmarks/genc/valid/ArgumentsEffects.expected.c
@@ -1,0 +1,75 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "ArgumentsEffects.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static void f(int32_t x1, int32_t x2, int32_t x3);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static void f(int32_t x1, int32_t x2, int32_t x3) {
+    print(x1);
+    print(x2);
+    println(x3);
+}
+
+void main(void) {
+    int32_t x = 0;
+    x = x + 1;
+    int32_t norm_0 = x;
+    int32_t norm_1 = x;
+    x = x + 2;
+    int32_t norm_2 = x;
+    f(norm_0, norm_1, norm_2);
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/ArgumentsEffects.expected.h
+++ b/frontends/benchmarks/genc/valid/ArgumentsEffects.expected.h
@@ -1,0 +1,40 @@
+#ifndef __ARGUMENTSEFFECTS_H__
+#define __ARGUMENTSEFFECTS_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/FixedArray.expected.c
+++ b/frontends/benchmarks/genc/valid/FixedArray.expected.c
@@ -1,0 +1,85 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "FixedArray.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+int32_t f(W* w) {
+    assert((0 <= w->a[0] && w->a[0] <= 1000));
+    assert((0 <= w->a[1] && w->a[1] <= 1000));
+    assert((0 <= w->a[2] && w->a[2] <= 1000));
+    assert((0 <= w->a[3] && w->a[3] <= 1000));
+    assert((0 <= w->a[4] && w->a[4] <= 1000));
+    w->a[0] = 155;
+    return (((((w->a[0] + w->a[1]) + w->a[2]) + w->a[3]) + w->a[4]) + w->x) + w->y;
+}
+
+void g(array_int32 a) {
+    assert((a.length > 0));
+    assert((0 <= a.data[0] && a.data[0] <= 1000));
+    a.data[0] = a.data[0] + 1;
+}
+
+void main(void) {
+    W w = (W) { .x = 30, .a = { 10, 20, 30, 20, 42 }, .y = 100 };
+    w.a[0] = w.a[0] + 1;
+    W w2 = (W) { .x = 30, .a = { 10, 20, 30, 20, 42 }, .y = 100 };
+    g((array_int32) { .data = w.a, .length = 5 });
+    array_int32 a2 = (array_int32) { .data = w.a, .length = 5 };
+    g(a2);
+    int32_t z = f(&w);
+    println(z);
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/FixedArray.expected.h
+++ b/frontends/benchmarks/genc/valid/FixedArray.expected.h
@@ -1,0 +1,55 @@
+#ifndef __FIXEDARRAY_H__
+#define __FIXEDARRAY_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+/* ---------------------- data type definitions ----- */
+
+typedef struct {
+  int32_t* data;
+  int32_t length;
+} array_int32;
+
+typedef struct {
+  int32_t x;
+  int32_t a[5];
+  int32_t y;
+} W;
+
+
+
+/* ---------------------- function declarations ----- */
+
+int32_t f(W* w);
+void g(array_int32 a);
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/GhostElim.expected.c
+++ b/frontends/benchmarks/genc/valid/GhostElim.expected.c
@@ -1,0 +1,36 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "GhostElim.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+
+/* ----------------------- function definitions ----- */
+
+STAINLESS_FUNC_PURE void main(void) {
+    
+}
+
+STAINLESS_FUNC_PURE void test(int32_t x) {
+    
+}

--- a/frontends/benchmarks/genc/valid/GhostElim.expected.h
+++ b/frontends/benchmarks/genc/valid/GhostElim.expected.h
@@ -1,0 +1,39 @@
+#ifndef __GHOSTELIM_H__
+#define __GHOSTELIM_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+STAINLESS_FUNC_PURE void main(void);
+STAINLESS_FUNC_PURE void test(int32_t x);
+
+#endif

--- a/frontends/benchmarks/genc/valid/Global.expected.c
+++ b/frontends/benchmarks/genc/valid/Global.expected.c
@@ -1,0 +1,91 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "Global.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* --------------------------- global variables ----- */
+
+int32_t data[100] = { 0 };
+bool stable = true;
+int32_t x = 5;
+int32_t y = 7;
+
+
+/* ---------------------- function declarations ----- */
+
+static void move(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x_1);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+void main(void) {
+    print(x);
+    print(y);
+    move();
+    print(data[6]);
+    print(data[7]);
+    print(x);
+    println(y);
+}
+
+static void move(void) {
+    while (true) {
+        label_0: ;
+            stable = false;
+            x = x + 1;
+            y = y - 1;
+            data[y] = 1;
+            stable = true;
+            if (y > 0) {
+                goto label_0;
+            }
+            return;;
+    }
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x_1) {
+    print(x_1);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/Global.expected.c
+++ b/frontends/benchmarks/genc/valid/Global.expected.c
@@ -63,8 +63,7 @@ static void move(void) {
         stable = true;
         if (y > 0) {
             goto label_0;
-        }
-        return;;
+        };
 }
 
 

--- a/frontends/benchmarks/genc/valid/Global.expected.c
+++ b/frontends/benchmarks/genc/valid/Global.expected.c
@@ -55,18 +55,16 @@ void main(void) {
 }
 
 static void move(void) {
-    while (true) {
-        label_0: ;
-            stable = false;
-            x = x + 1;
-            y = y - 1;
-            data[y] = 1;
-            stable = true;
-            if (y > 0) {
-                goto label_0;
-            }
-            return;;
-    }
+    label_0: ;
+        stable = false;
+        x = x + 1;
+        y = y - 1;
+        data[y] = 1;
+        stable = true;
+        if (y > 0) {
+            goto label_0;
+        }
+        return;;
 }
 
 

--- a/frontends/benchmarks/genc/valid/Global.expected.h
+++ b/frontends/benchmarks/genc/valid/Global.expected.h
@@ -1,0 +1,40 @@
+#ifndef __GLOBAL_H__
+#define __GLOBAL_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.c
+++ b/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.c
@@ -58,18 +58,16 @@ void main(void) {
 }
 
 static void move(void) {
-    while (true) {
-        label_0: ;
-            stable = false;
-            x = x + 1;
-            y = y - 1;
-            data[y] = 1;
-            stable = true;
-            if (y > 0) {
-                goto label_0;
-            }
-            return;;
-    }
+    label_0: ;
+        stable = false;
+        x = x + 1;
+        y = y - 1;
+        data[y] = 1;
+        stable = true;
+        if (y > 0) {
+            goto label_0;
+        }
+        return;;
 }
 
 

--- a/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.c
+++ b/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.c
@@ -66,8 +66,7 @@ static void move(void) {
         stable = true;
         if (y > 0) {
             goto label_0;
-        }
-        return;;
+        };
 }
 
 

--- a/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.c
+++ b/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.c
@@ -1,0 +1,94 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "GlobalUninitialized.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* --------------------------- global variables ----- */
+
+int32_t data[100];
+bool stable;
+int32_t x;
+int32_t y;
+
+
+/* ---------------------- function declarations ----- */
+
+static void move(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x_1);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+void main(void) {
+    x = 8;
+    y = 4;
+    stable = true;
+    print(x);
+    print(y);
+    move();
+    print(data[3]);
+    print(data[4]);
+    print(x);
+    println(y);
+}
+
+static void move(void) {
+    while (true) {
+        label_0: ;
+            stable = false;
+            x = x + 1;
+            y = y - 1;
+            data[y] = 1;
+            stable = true;
+            if (y > 0) {
+                goto label_0;
+            }
+            return;;
+    }
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x_1) {
+    print(x_1);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.h
+++ b/frontends/benchmarks/genc/valid/GlobalUninitialized.expected.h
@@ -1,0 +1,40 @@
+#ifndef __GLOBALUNINITIALIZED_H__
+#define __GLOBALUNINITIALIZED_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/ImageProcessing.expected.c
+++ b/frontends/benchmarks/genc/valid/ImageProcessing.expected.c
@@ -1125,25 +1125,23 @@ static bool writeBytes(FileOutputStream fos, int8_t byte, int32_t count) {
     FileOutputStream fos_0 = fos;
     int8_t byte_0 = byte;
     int32_t count_0 = count;
-    while (true) {
-        label_0: ;
-            if (count_0 == 0) {
-                return true;
+    label_0: ;
+        if (count_0 == 0) {
+            return true;
+        } else {
+            bool ok1 = write(fos_0, byte_0);
+            if (ok1) {
+                FileOutputStream fos_0_0 = fos_0;
+                int8_t byte_0_0 = byte_0;
+                int32_t count_0_0 = count_0 - 1;
+                fos_0 = fos_0_0;
+                byte_0 = byte_0_0;
+                count_0 = count_0_0;
+                goto label_0;
             } else {
-                bool ok1 = write(fos_0, byte_0);
-                if (ok1) {
-                    FileOutputStream fos_0_0 = fos_0;
-                    int8_t byte_0_0 = byte_0;
-                    int32_t count_0_0 = count_0 - 1;
-                    fos_0 = fos_0_0;
-                    byte_0 = byte_0_0;
-                    count_0 = count_0_0;
-                    goto label_0;
-                } else {
-                    return false;
-                }
-            };
-    }
+                return false;
+            }
+        };
 }
 
 static bool writeDword(FileOutputStream fos, int32_t dword) {

--- a/frontends/benchmarks/genc/valid/ImageProcessing.expected.c
+++ b/frontends/benchmarks/genc/valid/ImageProcessing.expected.c
@@ -1,0 +1,1250 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "ImageProcessing.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+typedef FILE* FileInputStream;
+typedef FILE* FileOutputStream;
+
+
+/* -------------------------------------- enums ----- */
+
+typedef enum {
+  tag_Failure_BitmapHeader,
+  tag_Result_BitmapHeader
+} enum_MaybeResult_BitmapHeader;
+
+typedef enum {
+  tag_Failure_FileHeader,
+  tag_Result_FileHeader
+} enum_MaybeResult_FileHeader;
+
+typedef enum {
+  tag_Failure_Tuple_FileHeader_BitmapHeader,
+  tag_Result_Tuple_FileHeader_BitmapHeader
+} enum_MaybeResult_Tuple_FileHeader_BitmapHeader;
+
+typedef enum {
+  tag_Failure_Tuple_Tuple_int32_int32_int32,
+  tag_Result_Tuple_Tuple_int32_int32_int32
+} enum_MaybeResult_Tuple_Tuple_int32_int32_int32;
+
+typedef enum {
+  tag_Failure_Tuple_Tuple_int32_int32_int32_int32,
+  tag_Result_Tuple_Tuple_int32_int32_int32_int32
+} enum_MaybeResult_Tuple_Tuple_int32_int32_int32_int32;
+
+typedef enum {
+  tag_Failure_Tuple_int32_int32,
+  tag_Result_Tuple_int32_int32
+} enum_MaybeResult_Tuple_int32_int32;
+
+typedef enum {
+  tag_Failure_Tuple_int32_int32_int32,
+  tag_Result_Tuple_int32_int32_int32
+} enum_MaybeResult_Tuple_int32_int32_int32;
+
+typedef enum {
+  tag_Failure_Tuple_int32_int32_int32_int32,
+  tag_Result_Tuple_int32_int32_int32_int32
+} enum_MaybeResult_Tuple_int32_int32_int32_int32;
+
+typedef enum {
+  tag_Failure_int32,
+  tag_Result_int32
+} enum_MaybeResult_int32;
+
+typedef enum {
+  tag_None_int8,
+  tag_Some_int8
+} enum_Option_int8;
+
+typedef enum {
+  tag_CorruptedDataError,
+  tag_DomainError,
+  tag_ImageTooBigError,
+  tag_InvalidBitmapHeaderError,
+  tag_InvalidFileHeaderError,
+  tag_NotImplementedError,
+  tag_OpenError,
+  tag_ReadError,
+  tag_Success,
+  tag_WriteError
+} enum_Status;
+
+
+/* ---------------------- data type definitions ----- */
+
+typedef struct {
+  int32_t* data;
+  int32_t length;
+} array_int32;
+
+typedef struct {
+  int32_t size;
+  int32_t scale;
+  array_int32 kernel;
+} Kernel;
+
+typedef struct {
+  int8_t r[262144];
+  int8_t g[262144];
+  int8_t b[262144];
+  int32_t w;
+  int32_t h;
+} Image;
+
+typedef struct {
+  int8_t* data;
+  int32_t length;
+} array_int8;
+
+typedef struct {
+  enum_Status status;
+} Failure_Tuple_FileHeader_BitmapHeader;
+
+typedef struct {
+  int32_t size;
+  int32_t offset;
+} FileHeader;
+
+typedef struct {
+  int32_t width;
+  int32_t height;
+} BitmapHeader;
+
+typedef struct {
+  FileHeader _1;
+  BitmapHeader _2;
+} Tuple_FileHeader_BitmapHeader;
+
+typedef struct {
+  Tuple_FileHeader_BitmapHeader result;
+} Result_Tuple_FileHeader_BitmapHeader;
+
+typedef union {
+  Failure_Tuple_FileHeader_BitmapHeader Failure_Tuple_FileHeader_BitmapHeader_v;
+  Result_Tuple_FileHeader_BitmapHeader Result_Tuple_FileHeader_BitmapHeader_v;
+} union_MaybeResult_Tuple_FileHeader_BitmapHeader;
+
+typedef struct {
+  enum_MaybeResult_Tuple_FileHeader_BitmapHeader tag;
+  union_MaybeResult_Tuple_FileHeader_BitmapHeader value;
+} MaybeResult_Tuple_FileHeader_BitmapHeader;
+
+typedef struct {
+  enum_Status status;
+} Failure_FileHeader;
+
+typedef struct {
+  FileHeader result;
+} Result_FileHeader;
+
+typedef union {
+  Failure_FileHeader Failure_FileHeader_v;
+  Result_FileHeader Result_FileHeader_v;
+} union_MaybeResult_FileHeader;
+
+typedef struct {
+  enum_MaybeResult_FileHeader tag;
+  union_MaybeResult_FileHeader value;
+} MaybeResult_FileHeader;
+
+typedef struct {
+  enum_Status status;
+} Failure_BitmapHeader;
+
+typedef struct {
+  BitmapHeader result;
+} Result_BitmapHeader;
+
+typedef union {
+  Failure_BitmapHeader Failure_BitmapHeader_v;
+  Result_BitmapHeader Result_BitmapHeader_v;
+} union_MaybeResult_BitmapHeader;
+
+typedef struct {
+  enum_MaybeResult_BitmapHeader tag;
+  union_MaybeResult_BitmapHeader value;
+} MaybeResult_BitmapHeader;
+
+typedef struct {
+  enum_Status status;
+} Failure_Tuple_Tuple_int32_int32_int32;
+
+typedef struct {
+  int32_t _1;
+  int32_t _2;
+} Tuple_int32_int32;
+
+typedef struct {
+  Tuple_int32_int32 _1;
+  int32_t _2;
+} Tuple_Tuple_int32_int32_int32;
+
+typedef struct {
+  Tuple_Tuple_int32_int32_int32 result;
+} Result_Tuple_Tuple_int32_int32_int32;
+
+typedef union {
+  Failure_Tuple_Tuple_int32_int32_int32 Failure_Tuple_Tuple_int32_int32_int32_v;
+  Result_Tuple_Tuple_int32_int32_int32 Result_Tuple_Tuple_int32_int32_int32_v;
+} union_MaybeResult_Tuple_Tuple_int32_int32_int32;
+
+typedef struct {
+  enum_MaybeResult_Tuple_Tuple_int32_int32_int32 tag;
+  union_MaybeResult_Tuple_Tuple_int32_int32_int32 value;
+} MaybeResult_Tuple_Tuple_int32_int32_int32;
+
+typedef struct {
+  enum_Status status;
+} Failure_Tuple_int32_int32;
+
+typedef struct {
+  Tuple_int32_int32 result;
+} Result_Tuple_int32_int32;
+
+typedef union {
+  Failure_Tuple_int32_int32 Failure_Tuple_int32_int32_v;
+  Result_Tuple_int32_int32 Result_Tuple_int32_int32_v;
+} union_MaybeResult_Tuple_int32_int32;
+
+typedef struct {
+  enum_MaybeResult_Tuple_int32_int32 tag;
+  union_MaybeResult_Tuple_int32_int32 value;
+} MaybeResult_Tuple_int32_int32;
+
+typedef struct {
+  enum_Status status;
+} Failure_int32;
+
+typedef struct {
+  int32_t result;
+} Result_int32;
+
+typedef union {
+  Failure_int32 Failure_int32_v;
+  Result_int32 Result_int32_v;
+} union_MaybeResult_int32;
+
+typedef struct {
+  enum_MaybeResult_int32 tag;
+  union_MaybeResult_int32 value;
+} MaybeResult_int32;
+
+typedef struct {
+  enum_Status status;
+} Failure_Tuple_Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  int32_t _1;
+  int32_t _2;
+  int32_t _3;
+} Tuple_int32_int32_int32;
+
+typedef struct {
+  Tuple_int32_int32_int32 _1;
+  int32_t _2;
+} Tuple_Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  Tuple_Tuple_int32_int32_int32_int32 result;
+} Result_Tuple_Tuple_int32_int32_int32_int32;
+
+typedef union {
+  Failure_Tuple_Tuple_int32_int32_int32_int32 Failure_Tuple_Tuple_int32_int32_int32_int32_v;
+  Result_Tuple_Tuple_int32_int32_int32_int32 Result_Tuple_Tuple_int32_int32_int32_int32_v;
+} union_MaybeResult_Tuple_Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  enum_MaybeResult_Tuple_Tuple_int32_int32_int32_int32 tag;
+  union_MaybeResult_Tuple_Tuple_int32_int32_int32_int32 value;
+} MaybeResult_Tuple_Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  enum_Status status;
+} Failure_Tuple_int32_int32_int32;
+
+typedef struct {
+  Tuple_int32_int32_int32 result;
+} Result_Tuple_int32_int32_int32;
+
+typedef union {
+  Failure_Tuple_int32_int32_int32 Failure_Tuple_int32_int32_int32_v;
+  Result_Tuple_int32_int32_int32 Result_Tuple_int32_int32_int32_v;
+} union_MaybeResult_Tuple_int32_int32_int32;
+
+typedef struct {
+  enum_MaybeResult_Tuple_int32_int32_int32 tag;
+  union_MaybeResult_Tuple_int32_int32_int32 value;
+} MaybeResult_Tuple_int32_int32_int32;
+
+typedef struct {
+  enum_Status status;
+} Failure_Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  int32_t _1;
+  int32_t _2;
+  int32_t _3;
+  int32_t _4;
+} Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  Tuple_int32_int32_int32_int32 result;
+} Result_Tuple_int32_int32_int32_int32;
+
+typedef union {
+  Failure_Tuple_int32_int32_int32_int32 Failure_Tuple_int32_int32_int32_int32_v;
+  Result_Tuple_int32_int32_int32_int32 Result_Tuple_int32_int32_int32_int32_v;
+} union_MaybeResult_Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  enum_MaybeResult_Tuple_int32_int32_int32_int32 tag;
+  union_MaybeResult_Tuple_int32_int32_int32_int32 value;
+} MaybeResult_Tuple_int32_int32_int32_int32;
+
+typedef struct {
+  int8_t _1;
+  int8_t _2;
+} Tuple_int8_int8;
+
+typedef struct {
+  int8_t extra;
+} None_int8;
+
+typedef struct {
+  int8_t v;
+} Some_int8;
+
+typedef union {
+  None_int8 None_int8_v;
+  Some_int8 Some_int8_v;
+} union_Option_int8;
+
+typedef struct {
+  enum_Option_int8 tag;
+  union_Option_int8 value;
+} Option_int8;
+
+
+
+/* ---------------------- function declarations ----- */
+
+static void apply(Kernel* thiss, Image* src, Image* dest);
+static STAINLESS_FUNC_PURE int8_t apply_1(Kernel* thiss, array_int8 channel, int32_t width, int32_t height, int32_t index);
+static STAINLESS_FUNC_PURE int32_t at(Kernel* thiss, array_int8 channel, int32_t* width, int32_t* height, int32_t* index, int32_t col, int32_t row);
+static STAINLESS_FUNC_PURE int32_t buildInt(FileInputStream* fis, State* state, int8_t b1, int8_t b2, int8_t b3, int8_t b4);
+static STAINLESS_FUNC_PURE int32_t buildInt_1(FileInputStream* fis, State* state, int8_t b1, int8_t b2, int8_t b3, int8_t b4);
+static STAINLESS_FUNC_PURE void check(bool prop);
+static STAINLESS_FUNC_PURE int32_t clamp(int32_t x, int32_t down, int32_t up);
+static 
+bool close(FILE* this);
+static 
+bool close_1(FILE* this, void* unused);
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_FileHeader_BitmapHeader combine_FileHeader_BitmapHeader(MaybeResult_FileHeader a, MaybeResult_BitmapHeader b);
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_Tuple_int32_int32_int32 combine_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32 a, MaybeResult_int32 b);
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_Tuple_int32_int32_int32_int32 combine_Tuple_int32_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 a, MaybeResult_int32 b);
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_int32_int32 combine_int32_int32(MaybeResult_int32 a, MaybeResult_int32 b);
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_int32_int32_int32 combine_int32_int32_int32(MaybeResult_int32 a, MaybeResult_int32 b, MaybeResult_int32 c);
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_int32_int32_int32_int32 combine_int32_int32_int32_int32(MaybeResult_int32 a, MaybeResult_int32 b, MaybeResult_int32 c, MaybeResult_int32 d);
+static STAINLESS_FUNC_PURE int32_t constructWord(int8_t byte1, int8_t byte2);
+static STAINLESS_FUNC_PURE Tuple_int8_int8 destructWord(int32_t word);
+static STAINLESS_FUNC_PURE int32_t fix(Kernel* thiss, array_int8 channel, int32_t* width, int32_t* height, int32_t* index, int32_t x, int32_t side);
+static STAINLESS_FUNC_PURE BitmapHeader getResult_BitmapHeader(MaybeResult_BitmapHeader thiss);
+static STAINLESS_FUNC_PURE FileHeader getResult_FileHeader(MaybeResult_FileHeader thiss);
+static STAINLESS_FUNC_PURE Tuple_int32_int32 getResult_Tuple_int32_int32(MaybeResult_Tuple_int32_int32 thiss);
+static STAINLESS_FUNC_PURE Tuple_int32_int32_int32 getResult_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 thiss);
+static STAINLESS_FUNC_PURE int32_t getResult_int32(MaybeResult_int32 thiss);
+static STAINLESS_FUNC_PURE enum_Status getStatus_BitmapHeader(MaybeResult_BitmapHeader thiss);
+static STAINLESS_FUNC_PURE enum_Status getStatus_FileHeader(MaybeResult_FileHeader thiss);
+static STAINLESS_FUNC_PURE enum_Status getStatus_Tuple_int32_int32(MaybeResult_Tuple_int32_int32 thiss);
+static STAINLESS_FUNC_PURE enum_Status getStatus_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 thiss);
+static STAINLESS_FUNC_PURE enum_Status getStatus_int32(MaybeResult_int32 thiss);
+static STAINLESS_FUNC_PURE int8_t get_int8(Option_int8 thiss);
+static 
+int8_t impl(FILE** this, void** unused, bool* valid);
+static STAINLESS_FUNC_PURE bool inRange(int32_t x, int32_t min_1, int32_t max_1);
+static STAINLESS_FUNC_PURE bool isDefined_BitmapHeader(MaybeResult_BitmapHeader thiss);
+static STAINLESS_FUNC_PURE bool isDefined_FileHeader(MaybeResult_FileHeader thiss);
+static STAINLESS_FUNC_PURE bool isDefined_Tuple_int32_int32(MaybeResult_Tuple_int32_int32 thiss);
+static STAINLESS_FUNC_PURE bool isDefined_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 thiss);
+static STAINLESS_FUNC_PURE bool isDefined_int32(MaybeResult_int32 thiss);
+static STAINLESS_FUNC_PURE bool isDefined_int8(Option_int8 thiss);
+static STAINLESS_FUNC_PURE bool isEmpty_int8(Option_int8 thiss);
+static 
+bool isOpen(FILE* this);
+static 
+bool isOpen_1(FILE* this);
+static STAINLESS_FUNC_PURE bool isSuccess(enum_Status thiss);
+static enum_Status loadImageData(FileInputStream fis, Image* image, State state);
+static void log(char* msg, int32_t x);
+static void log_1(FileHeader h);
+static void log_2(BitmapHeader h);
+static STAINLESS_FUNC_PURE int32_t max(int32_t x, int32_t y);
+static MaybeResult_BitmapHeader maybeReadBitmapHeader(FileInputStream fis, State state);
+static MaybeResult_int32 maybeReadDword(FileInputStream fis, State state);
+static MaybeResult_FileHeader maybeReadFileHeader(FileInputStream fis, State state);
+static MaybeResult_int32 maybeReadLong(FileInputStream fis, State state);
+static MaybeResult_int32 maybeReadWord(FileInputStream fis, State state);
+static STAINLESS_FUNC_PURE int32_t min(int32_t x, int32_t y);
+static void* newState(void);
+static 
+FILE* open(char* filename, void* unused);
+static 
+FILE* open_1(char* filename);
+static 
+void print(char* s);
+static 
+void print_1(int32_t x);
+static 
+void print_2(char c);
+static void println(int32_t x);
+static void println_1(void);
+static void println_2(char* s);
+static enum_Status process(FileInputStream fis, FileOutputStream fos, State state);
+static enum_Status processImage(FileInputStream* fis, FileOutputStream* fos, State* state, Kernel* kernel, Image* src);
+static enum_Status saveImage(FileOutputStream fos, Image* image);
+static bool skipBytes(FileInputStream fis, int32_t count, State state);
+static int32_t statusCode(enum_Status s);
+static Option_int8 tryReadByte(FileInputStream thiss, State state);
+static 
+bool write(FILE* this, int8_t x);
+static bool writeBitmapHeader(FileOutputStream* fos, Image* image);
+static bool writeBytes(FileOutputStream fos, int8_t byte, int32_t count);
+static bool writeDword(FileOutputStream fos, int32_t dword);
+static bool writeFileHeader(FileOutputStream* fos, Image* image);
+static bool writeImage(FileOutputStream* fos, Image* image);
+static bool writeLong(FileOutputStream fos, int32_t long_1);
+static bool writeWord(FileOutputStream fos, int32_t word);
+
+
+/* ----------------------- function definitions ----- */
+
+static void apply(Kernel* thiss, Image* src, Image* dest) {
+    int32_t size = src->w * src->h;
+    int32_t i = 0;
+    while (i < size) {
+        int32_t norm_1 = i;
+        int8_t norm_0 = apply_1(thiss, (array_int8) { .data = src->r, .length = 262144 }, src->w, src->h, i);
+        int8_t norm_2 = norm_0;
+        dest->r[norm_1] = norm_2;
+        int32_t norm_4 = i;
+        int8_t norm_3 = apply_1(thiss, (array_int8) { .data = src->g, .length = 262144 }, src->w, src->h, i);
+        int8_t norm_5 = norm_3;
+        dest->g[norm_4] = norm_5;
+        int32_t norm_7 = i;
+        int8_t norm_6 = apply_1(thiss, (array_int8) { .data = src->b, .length = 262144 }, src->w, src->h, i);
+        int8_t norm_8 = norm_6;
+        dest->b[norm_7] = norm_8;
+        i = i + 1;
+    }
+}
+
+static STAINLESS_FUNC_PURE int8_t apply_1(Kernel* thiss, array_int8 channel, int32_t width, int32_t height, int32_t index) {
+    int32_t mid = thiss->size / 2;
+    int32_t i = index % width;
+    int32_t j = index / width;
+    int32_t res = 0;
+    int32_t p = -mid;
+    while (p <= mid) {
+        int32_t q = -mid;
+        int32_t oldP = p;
+        while (q <= mid) {
+            int32_t kcol = p + mid;
+            int32_t krow = q + mid;
+            int32_t kidx = krow * thiss->size + kcol;
+            res = res + at(thiss, channel, &width, &height, &index, i + p, j + q) * thiss->kernel.data[kidx];
+            q = q + 1;
+            check(inRange(q, -mid, mid + 1));
+        }
+        p = p + 1;
+        check(inRange(p, -mid, mid + 1));
+    }
+    res = clamp(res / thiss->scale, 0, 255);
+    return (int8_t)res;
+}
+
+static STAINLESS_FUNC_PURE int32_t at(Kernel* thiss, array_int8 channel, int32_t* width, int32_t* height, int32_t* index, int32_t col, int32_t row) {
+    int32_t c = fix(thiss, channel, width, height, index, col, *width);
+    int32_t r = fix(thiss, channel, width, height, index, row, *height);
+    int8_t component = channel.data[r * (*width) + c];
+    if (((int32_t)component) < 0) {
+        return ((int32_t)component) + 255;
+    } else {
+        return (int32_t)component;
+    }
+}
+
+static STAINLESS_FUNC_PURE int32_t buildInt(FileInputStream* fis, State* state, int8_t b1, int8_t b2, int8_t b3, int8_t b4) {
+    return ((((int32_t)(((uint32_t)((int32_t)b4)) << 24)) | ((int32_t)(((uint32_t)(((int32_t)b3) & 255)) << 16))) | ((int32_t)(((uint32_t)(((int32_t)b2) & 255)) << 8))) | (((int32_t)b1) & 255);
+}
+
+static STAINLESS_FUNC_PURE int32_t buildInt_1(FileInputStream* fis, State* state, int8_t b1, int8_t b2, int8_t b3, int8_t b4) {
+    return ((((int32_t)(((uint32_t)((int32_t)b4)) << 24)) | ((int32_t)(((uint32_t)(((int32_t)b3) & 255)) << 16))) | ((int32_t)(((uint32_t)(((int32_t)b2) & 255)) << 8))) | (((int32_t)b1) & 255);
+}
+
+static STAINLESS_FUNC_PURE void check(bool prop) {
+    
+}
+
+static STAINLESS_FUNC_PURE int32_t clamp(int32_t x, int32_t down, int32_t up) {
+    return max(down, min(x, up));
+}
+
+
+bool close(FILE* this) {
+  if (this != NULL)
+    return fclose(this) == 0;
+  else
+    return true;
+}
+    
+
+
+bool close_1(FILE* this, void* unused) {
+  if (this != NULL)
+    return fclose(this) == 0;
+  else
+    return true;
+}
+      
+
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_FileHeader_BitmapHeader combine_FileHeader_BitmapHeader(MaybeResult_FileHeader a, MaybeResult_BitmapHeader b) {
+    if (isDefined_FileHeader(a)) {
+        if (isDefined_BitmapHeader(b)) {
+            return (MaybeResult_Tuple_FileHeader_BitmapHeader) { .tag = tag_Result_Tuple_FileHeader_BitmapHeader, .value = (union_MaybeResult_Tuple_FileHeader_BitmapHeader) { .Result_Tuple_FileHeader_BitmapHeader_v = (Result_Tuple_FileHeader_BitmapHeader) { .result = (Tuple_FileHeader_BitmapHeader) { ._1 = getResult_FileHeader(a), ._2 = getResult_BitmapHeader(b) } } } };
+        } else {
+            return (MaybeResult_Tuple_FileHeader_BitmapHeader) { .tag = tag_Failure_Tuple_FileHeader_BitmapHeader, .value = (union_MaybeResult_Tuple_FileHeader_BitmapHeader) { .Failure_Tuple_FileHeader_BitmapHeader_v = (Failure_Tuple_FileHeader_BitmapHeader) { .status = getStatus_BitmapHeader(b) } } };
+        }
+    } else {
+        return (MaybeResult_Tuple_FileHeader_BitmapHeader) { .tag = tag_Failure_Tuple_FileHeader_BitmapHeader, .value = (union_MaybeResult_Tuple_FileHeader_BitmapHeader) { .Failure_Tuple_FileHeader_BitmapHeader_v = (Failure_Tuple_FileHeader_BitmapHeader) { .status = getStatus_FileHeader(a) } } };
+    }
+}
+
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_Tuple_int32_int32_int32 combine_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32 a, MaybeResult_int32 b) {
+    if (isDefined_Tuple_int32_int32(a)) {
+        if (isDefined_int32(b)) {
+            return (MaybeResult_Tuple_Tuple_int32_int32_int32) { .tag = tag_Result_Tuple_Tuple_int32_int32_int32, .value = (union_MaybeResult_Tuple_Tuple_int32_int32_int32) { .Result_Tuple_Tuple_int32_int32_int32_v = (Result_Tuple_Tuple_int32_int32_int32) { .result = (Tuple_Tuple_int32_int32_int32) { ._1 = getResult_Tuple_int32_int32(a), ._2 = getResult_int32(b) } } } };
+        } else {
+            return (MaybeResult_Tuple_Tuple_int32_int32_int32) { .tag = tag_Failure_Tuple_Tuple_int32_int32_int32, .value = (union_MaybeResult_Tuple_Tuple_int32_int32_int32) { .Failure_Tuple_Tuple_int32_int32_int32_v = (Failure_Tuple_Tuple_int32_int32_int32) { .status = getStatus_int32(b) } } };
+        }
+    } else {
+        return (MaybeResult_Tuple_Tuple_int32_int32_int32) { .tag = tag_Failure_Tuple_Tuple_int32_int32_int32, .value = (union_MaybeResult_Tuple_Tuple_int32_int32_int32) { .Failure_Tuple_Tuple_int32_int32_int32_v = (Failure_Tuple_Tuple_int32_int32_int32) { .status = getStatus_Tuple_int32_int32(a) } } };
+    }
+}
+
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_Tuple_int32_int32_int32_int32 combine_Tuple_int32_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 a, MaybeResult_int32 b) {
+    if (isDefined_Tuple_int32_int32_int32(a)) {
+        if (isDefined_int32(b)) {
+            return (MaybeResult_Tuple_Tuple_int32_int32_int32_int32) { .tag = tag_Result_Tuple_Tuple_int32_int32_int32_int32, .value = (union_MaybeResult_Tuple_Tuple_int32_int32_int32_int32) { .Result_Tuple_Tuple_int32_int32_int32_int32_v = (Result_Tuple_Tuple_int32_int32_int32_int32) { .result = (Tuple_Tuple_int32_int32_int32_int32) { ._1 = getResult_Tuple_int32_int32_int32(a), ._2 = getResult_int32(b) } } } };
+        } else {
+            return (MaybeResult_Tuple_Tuple_int32_int32_int32_int32) { .tag = tag_Failure_Tuple_Tuple_int32_int32_int32_int32, .value = (union_MaybeResult_Tuple_Tuple_int32_int32_int32_int32) { .Failure_Tuple_Tuple_int32_int32_int32_int32_v = (Failure_Tuple_Tuple_int32_int32_int32_int32) { .status = getStatus_int32(b) } } };
+        }
+    } else {
+        return (MaybeResult_Tuple_Tuple_int32_int32_int32_int32) { .tag = tag_Failure_Tuple_Tuple_int32_int32_int32_int32, .value = (union_MaybeResult_Tuple_Tuple_int32_int32_int32_int32) { .Failure_Tuple_Tuple_int32_int32_int32_int32_v = (Failure_Tuple_Tuple_int32_int32_int32_int32) { .status = getStatus_Tuple_int32_int32_int32(a) } } };
+    }
+}
+
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_int32_int32 combine_int32_int32(MaybeResult_int32 a, MaybeResult_int32 b) {
+    if (isDefined_int32(a)) {
+        if (isDefined_int32(b)) {
+            return (MaybeResult_Tuple_int32_int32) { .tag = tag_Result_Tuple_int32_int32, .value = (union_MaybeResult_Tuple_int32_int32) { .Result_Tuple_int32_int32_v = (Result_Tuple_int32_int32) { .result = (Tuple_int32_int32) { ._1 = getResult_int32(a), ._2 = getResult_int32(b) } } } };
+        } else {
+            return (MaybeResult_Tuple_int32_int32) { .tag = tag_Failure_Tuple_int32_int32, .value = (union_MaybeResult_Tuple_int32_int32) { .Failure_Tuple_int32_int32_v = (Failure_Tuple_int32_int32) { .status = getStatus_int32(b) } } };
+        }
+    } else {
+        return (MaybeResult_Tuple_int32_int32) { .tag = tag_Failure_Tuple_int32_int32, .value = (union_MaybeResult_Tuple_int32_int32) { .Failure_Tuple_int32_int32_v = (Failure_Tuple_int32_int32) { .status = getStatus_int32(a) } } };
+    }
+}
+
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_int32_int32_int32 combine_int32_int32_int32(MaybeResult_int32 a, MaybeResult_int32 b, MaybeResult_int32 c) {
+    MaybeResult_Tuple_Tuple_int32_int32_int32 tmp = combine_Tuple_int32_int32_int32(combine_int32_int32(a, b), c);
+    if (tmp.tag == tag_Result_Tuple_Tuple_int32_int32_int32) {
+        return (MaybeResult_Tuple_int32_int32_int32) { .tag = tag_Result_Tuple_int32_int32_int32, .value = (union_MaybeResult_Tuple_int32_int32_int32) { .Result_Tuple_int32_int32_int32_v = (Result_Tuple_int32_int32_int32) { .result = (Tuple_int32_int32_int32) { ._1 = tmp.value.Result_Tuple_Tuple_int32_int32_int32_v.result._1._1, ._2 = tmp.value.Result_Tuple_Tuple_int32_int32_int32_v.result._1._2, ._3 = tmp.value.Result_Tuple_Tuple_int32_int32_int32_v.result._2 } } } };
+    } else if (tmp.tag == tag_Failure_Tuple_Tuple_int32_int32_int32) {
+        return (MaybeResult_Tuple_int32_int32_int32) { .tag = tag_Failure_Tuple_int32_int32_int32, .value = (union_MaybeResult_Tuple_int32_int32_int32) { .Failure_Tuple_int32_int32_int32_v = (Failure_Tuple_int32_int32_int32) { .status = tmp.value.Failure_Tuple_Tuple_int32_int32_int32_v.status } } };
+    }
+}
+
+static STAINLESS_FUNC_PURE MaybeResult_Tuple_int32_int32_int32_int32 combine_int32_int32_int32_int32(MaybeResult_int32 a, MaybeResult_int32 b, MaybeResult_int32 c, MaybeResult_int32 d) {
+    MaybeResult_Tuple_Tuple_int32_int32_int32_int32 tmp = combine_Tuple_int32_int32_int32_int32(combine_int32_int32_int32(a, b, c), d);
+    if (tmp.tag == tag_Result_Tuple_Tuple_int32_int32_int32_int32) {
+        return (MaybeResult_Tuple_int32_int32_int32_int32) { .tag = tag_Result_Tuple_int32_int32_int32_int32, .value = (union_MaybeResult_Tuple_int32_int32_int32_int32) { .Result_Tuple_int32_int32_int32_int32_v = (Result_Tuple_int32_int32_int32_int32) { .result = (Tuple_int32_int32_int32_int32) { ._1 = tmp.value.Result_Tuple_Tuple_int32_int32_int32_int32_v.result._1._1, ._2 = tmp.value.Result_Tuple_Tuple_int32_int32_int32_int32_v.result._1._2, ._3 = tmp.value.Result_Tuple_Tuple_int32_int32_int32_int32_v.result._1._3, ._4 = tmp.value.Result_Tuple_Tuple_int32_int32_int32_int32_v.result._2 } } } };
+    } else if (tmp.tag == tag_Failure_Tuple_Tuple_int32_int32_int32_int32) {
+        return (MaybeResult_Tuple_int32_int32_int32_int32) { .tag = tag_Failure_Tuple_int32_int32_int32_int32, .value = (union_MaybeResult_Tuple_int32_int32_int32_int32) { .Failure_Tuple_int32_int32_int32_int32_v = (Failure_Tuple_int32_int32_int32_int32) { .status = tmp.value.Failure_Tuple_Tuple_int32_int32_int32_int32_v.status } } };
+    }
+}
+
+static STAINLESS_FUNC_PURE int32_t constructWord(int8_t byte1, int8_t byte2) {
+    int32_t signed_1 = ((int32_t)(((uint32_t)((int32_t)byte1)) << 8)) | (((int32_t)byte2) & 255);
+    int32_t unsigned_1;
+    if (signed_1 < 0) {
+        unsigned_1 = signed_1 + 2 * 32768;
+    } else {
+        unsigned_1 = signed_1;
+    }
+    return unsigned_1;
+}
+
+static STAINLESS_FUNC_PURE Tuple_int8_int8 destructWord(int32_t word) {
+    int32_t signed_1;
+    if (word >= 32768) {
+        signed_1 = word - 2 * 32768;
+    } else {
+        signed_1 = word;
+    }
+    int8_t b1 = (int8_t)((int32_t)(((uint32_t)signed_1) >> 8));
+    int8_t b2 = (int8_t)signed_1;
+    return (Tuple_int8_int8) { ._1 = b1, ._2 = b2 };
+}
+
+static STAINLESS_FUNC_PURE int32_t fix(Kernel* thiss, array_int8 channel, int32_t* width, int32_t* height, int32_t* index, int32_t x, int32_t side) {
+    return clamp(x, 0, side - 1);
+}
+
+static STAINLESS_FUNC_PURE BitmapHeader getResult_BitmapHeader(MaybeResult_BitmapHeader thiss) {
+    return thiss.value.Result_BitmapHeader_v.result;
+}
+
+static STAINLESS_FUNC_PURE FileHeader getResult_FileHeader(MaybeResult_FileHeader thiss) {
+    return thiss.value.Result_FileHeader_v.result;
+}
+
+static STAINLESS_FUNC_PURE Tuple_int32_int32 getResult_Tuple_int32_int32(MaybeResult_Tuple_int32_int32 thiss) {
+    return thiss.value.Result_Tuple_int32_int32_v.result;
+}
+
+static STAINLESS_FUNC_PURE Tuple_int32_int32_int32 getResult_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 thiss) {
+    return thiss.value.Result_Tuple_int32_int32_int32_v.result;
+}
+
+static STAINLESS_FUNC_PURE int32_t getResult_int32(MaybeResult_int32 thiss) {
+    return thiss.value.Result_int32_v.result;
+}
+
+static STAINLESS_FUNC_PURE enum_Status getStatus_BitmapHeader(MaybeResult_BitmapHeader thiss) {
+    return thiss.value.Failure_BitmapHeader_v.status;
+}
+
+static STAINLESS_FUNC_PURE enum_Status getStatus_FileHeader(MaybeResult_FileHeader thiss) {
+    return thiss.value.Failure_FileHeader_v.status;
+}
+
+static STAINLESS_FUNC_PURE enum_Status getStatus_Tuple_int32_int32(MaybeResult_Tuple_int32_int32 thiss) {
+    return thiss.value.Failure_Tuple_int32_int32_v.status;
+}
+
+static STAINLESS_FUNC_PURE enum_Status getStatus_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 thiss) {
+    return thiss.value.Failure_Tuple_int32_int32_int32_v.status;
+}
+
+static STAINLESS_FUNC_PURE enum_Status getStatus_int32(MaybeResult_int32 thiss) {
+    return thiss.value.Failure_int32_v.status;
+}
+
+static STAINLESS_FUNC_PURE int8_t get_int8(Option_int8 thiss) {
+    if (thiss.tag == tag_Some_int8) {
+        return thiss.value.Some_int8_v.v;
+    }
+}
+
+
+int8_t impl(FILE** this, void** unused, bool* valid) {
+  int8_t x;
+  *valid = fscanf(*this, "%c", &x) == 1;
+  return x;
+}
+      
+
+static STAINLESS_FUNC_PURE bool inRange(int32_t x, int32_t min_1, int32_t max_1) {
+    return min_1 <= x && x <= max_1;
+}
+
+static STAINLESS_FUNC_PURE bool isDefined_BitmapHeader(MaybeResult_BitmapHeader thiss) {
+    if (thiss.tag == tag_Result_BitmapHeader) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static STAINLESS_FUNC_PURE bool isDefined_FileHeader(MaybeResult_FileHeader thiss) {
+    if (thiss.tag == tag_Result_FileHeader) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static STAINLESS_FUNC_PURE bool isDefined_Tuple_int32_int32(MaybeResult_Tuple_int32_int32 thiss) {
+    if (thiss.tag == tag_Result_Tuple_int32_int32) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static STAINLESS_FUNC_PURE bool isDefined_Tuple_int32_int32_int32(MaybeResult_Tuple_int32_int32_int32 thiss) {
+    if (thiss.tag == tag_Result_Tuple_int32_int32_int32) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static STAINLESS_FUNC_PURE bool isDefined_int32(MaybeResult_int32 thiss) {
+    if (thiss.tag == tag_Result_int32) {
+        return true;
+    } else {
+        return false;
+    }
+}
+
+static STAINLESS_FUNC_PURE bool isDefined_int8(Option_int8 thiss) {
+    return !isEmpty_int8(thiss);
+}
+
+static STAINLESS_FUNC_PURE bool isEmpty_int8(Option_int8 thiss) {
+    if (thiss.tag == tag_Some_int8) {
+        return false;
+    } else if (thiss.tag == tag_None_int8) {
+        return true;
+    }
+}
+
+
+bool isOpen(FILE* this) {
+  return this != NULL;
+}
+      
+
+
+bool isOpen_1(FILE* this) {
+  return this != NULL;
+}
+    
+
+static STAINLESS_FUNC_PURE bool isSuccess(enum_Status thiss) {
+    return thiss == tag_Success;
+}
+
+static enum_Status loadImageData(FileInputStream fis, Image* image, State state) {
+    int32_t size = image->w * image->h;
+    int32_t i = 0;
+    enum_Status status = tag_Success;
+    while (isSuccess(status) && i < size) {
+        Option_int8 rOpt = tryReadByte(fis, state);
+        Option_int8 gOpt = tryReadByte(fis, state);
+        Option_int8 bOpt = tryReadByte(fis, state);
+        if ((isEmpty_int8(rOpt) || isEmpty_int8(gOpt)) || isEmpty_int8(bOpt)) {
+            status = tag_ReadError;
+            log("stopped reading data abruptly after", i);
+        } else {
+            int32_t norm_10 = i;
+            int8_t norm_9 = get_int8(rOpt);
+            int8_t norm_11 = norm_9;
+            image->r[norm_10] = norm_11;
+            int32_t norm_13 = i;
+            int8_t norm_12 = get_int8(gOpt);
+            int8_t norm_14 = norm_12;
+            image->g[norm_13] = norm_14;
+            int32_t norm_16 = i;
+            int8_t norm_15 = get_int8(bOpt);
+            int8_t norm_17 = norm_15;
+            image->b[norm_16] = norm_17;
+        }
+        i = i + 1;
+    }
+    return status;
+}
+
+static void log(char* msg, int32_t x) {
+    print(msg);
+    print(": ");
+    println(x);
+}
+
+static void log_1(FileHeader h) {
+    log("size", h.size);
+    log("offset", h.offset);
+}
+
+static void log_2(BitmapHeader h) {
+    log("width", h.width);
+    log("height", h.height);
+}
+
+int32_t main(void) {
+    State state = newState();
+    FileInputStream input = open("input.bmp", state);
+    FileOutputStream output = open_1("output.bmp");
+    enum_Status status;
+    if (isOpen(input) && isOpen_1(output)) {
+        status = process(input, output, state);
+    } else {
+        status = tag_OpenError;
+    }
+    close(output);
+    close_1(input, state);
+    return statusCode(status);
+}
+
+static STAINLESS_FUNC_PURE int32_t max(int32_t x, int32_t y) {
+    if (x < y) {
+        return y;
+    } else {
+        return x;
+    }
+}
+
+static MaybeResult_BitmapHeader maybeReadBitmapHeader(FileInputStream fis, State state) {
+    bool skipSuccess = skipBytes(fis, 4, state);
+    MaybeResult_int32 widthRes = maybeReadLong(fis, state);
+    MaybeResult_int32 heightRes = maybeReadLong(fis, state);
+    if (skipSuccess) {
+        skipSuccess = skipBytes(fis, 2, state);
+    }
+    MaybeResult_int32 bppRes = maybeReadWord(fis, state);
+    MaybeResult_int32 compressionRes = maybeReadWord(fis, state);
+    MaybeResult_Tuple_int32_int32_int32_int32 tmp = combine_int32_int32_int32_int32(widthRes, heightRes, bppRes, compressionRes);
+    if (!skipSuccess) {
+        return (MaybeResult_BitmapHeader) { .tag = tag_Failure_BitmapHeader, .value = (union_MaybeResult_BitmapHeader) { .Failure_BitmapHeader_v = (Failure_BitmapHeader) { .status = tag_ReadError } } };
+    } else if (tmp.tag == tag_Failure_Tuple_int32_int32_int32_int32) {
+        return (MaybeResult_BitmapHeader) { .tag = tag_Failure_BitmapHeader, .value = (union_MaybeResult_BitmapHeader) { .Failure_BitmapHeader_v = (Failure_BitmapHeader) { .status = tmp.value.Failure_Tuple_int32_int32_int32_int32_v.status } } };
+    } else if (tmp.tag == tag_Result_Tuple_int32_int32_int32_int32) {
+        if (((tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._1 < 0 || tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._2 < 0) || tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._3 != 24) || tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._4 != 0) {
+            log("width", tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._1);
+            log("height", tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._2);
+            log("bpp", tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._3);
+            log("compression", tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._4);
+            return (MaybeResult_BitmapHeader) { .tag = tag_Failure_BitmapHeader, .value = (union_MaybeResult_BitmapHeader) { .Failure_BitmapHeader_v = (Failure_BitmapHeader) { .status = tag_InvalidBitmapHeaderError } } };
+        } else {
+            return (MaybeResult_BitmapHeader) { .tag = tag_Result_BitmapHeader, .value = (union_MaybeResult_BitmapHeader) { .Result_BitmapHeader_v = (Result_BitmapHeader) { .result = (BitmapHeader) { .width = tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._1, .height = tmp.value.Result_Tuple_int32_int32_int32_int32_v.result._2 } } } };
+        }
+    }
+}
+
+static MaybeResult_int32 maybeReadDword(FileInputStream fis, State state) {
+    Option_int8 byte1 = tryReadByte(fis, state);
+    Option_int8 byte2 = tryReadByte(fis, state);
+    Option_int8 byte3 = tryReadByte(fis, state);
+    Option_int8 byte4 = tryReadByte(fis, state);
+    if (((isDefined_int8(byte1) && isDefined_int8(byte2)) && isDefined_int8(byte3)) && isDefined_int8(byte4)) {
+        if (((int32_t)get_int8(byte4)) >= 0) {
+            int32_t dword = buildInt(&fis, &state, get_int8(byte1), get_int8(byte2), get_int8(byte3), get_int8(byte4));
+            return (MaybeResult_int32) { .tag = tag_Result_int32, .value = (union_MaybeResult_int32) { .Result_int32_v = (Result_int32) { .result = dword } } };
+        } else {
+            return (MaybeResult_int32) { .tag = tag_Failure_int32, .value = (union_MaybeResult_int32) { .Failure_int32_v = (Failure_int32) { .status = tag_DomainError } } };
+        }
+    } else {
+        return (MaybeResult_int32) { .tag = tag_Failure_int32, .value = (union_MaybeResult_int32) { .Failure_int32_v = (Failure_int32) { .status = tag_ReadError } } };
+    }
+}
+
+static MaybeResult_FileHeader maybeReadFileHeader(FileInputStream fis, State state) {
+    bool skipSuccess = skipBytes(fis, 2, state);
+    MaybeResult_int32 sizeRes = maybeReadDword(fis, state);
+    if (skipSuccess) {
+        skipSuccess = skipBytes(fis, 2 * 2, state);
+    }
+    MaybeResult_int32 offsetRes = maybeReadDword(fis, state);
+    MaybeResult_Tuple_int32_int32 tmp = combine_int32_int32(sizeRes, offsetRes);
+    if (!skipSuccess) {
+        return (MaybeResult_FileHeader) { .tag = tag_Failure_FileHeader, .value = (union_MaybeResult_FileHeader) { .Failure_FileHeader_v = (Failure_FileHeader) { .status = tag_ReadError } } };
+    } else if (tmp.tag == tag_Failure_Tuple_int32_int32) {
+        return (MaybeResult_FileHeader) { .tag = tag_Failure_FileHeader, .value = (union_MaybeResult_FileHeader) { .Failure_FileHeader_v = (Failure_FileHeader) { .status = tmp.value.Failure_Tuple_int32_int32_v.status } } };
+    } else if (tmp.tag == tag_Result_Tuple_int32_int32) {
+        if ((14 <= tmp.value.Result_Tuple_int32_int32_v.result._1 && 14 + 40 <= tmp.value.Result_Tuple_int32_int32_v.result._2) && tmp.value.Result_Tuple_int32_int32_v.result._2 <= tmp.value.Result_Tuple_int32_int32_v.result._1) {
+            return (MaybeResult_FileHeader) { .tag = tag_Result_FileHeader, .value = (union_MaybeResult_FileHeader) { .Result_FileHeader_v = (Result_FileHeader) { .result = (FileHeader) { .size = tmp.value.Result_Tuple_int32_int32_v.result._1, .offset = tmp.value.Result_Tuple_int32_int32_v.result._2 } } } };
+        } else {
+            return (MaybeResult_FileHeader) { .tag = tag_Failure_FileHeader, .value = (union_MaybeResult_FileHeader) { .Failure_FileHeader_v = (Failure_FileHeader) { .status = tag_InvalidFileHeaderError } } };
+        }
+    }
+}
+
+static MaybeResult_int32 maybeReadLong(FileInputStream fis, State state) {
+    Option_int8 byte1 = tryReadByte(fis, state);
+    Option_int8 byte2 = tryReadByte(fis, state);
+    Option_int8 byte3 = tryReadByte(fis, state);
+    Option_int8 byte4 = tryReadByte(fis, state);
+    if (((isDefined_int8(byte1) && isDefined_int8(byte2)) && isDefined_int8(byte3)) && isDefined_int8(byte4)) {
+        int32_t long_1 = buildInt_1(&fis, &state, get_int8(byte1), get_int8(byte2), get_int8(byte3), get_int8(byte4));
+        return (MaybeResult_int32) { .tag = tag_Result_int32, .value = (union_MaybeResult_int32) { .Result_int32_v = (Result_int32) { .result = long_1 } } };
+    } else {
+        return (MaybeResult_int32) { .tag = tag_Failure_int32, .value = (union_MaybeResult_int32) { .Failure_int32_v = (Failure_int32) { .status = tag_ReadError } } };
+    }
+}
+
+static MaybeResult_int32 maybeReadWord(FileInputStream fis, State state) {
+    Option_int8 byte2 = tryReadByte(fis, state);
+    Option_int8 byte1 = tryReadByte(fis, state);
+    if (isDefined_int8(byte1) && isDefined_int8(byte2)) {
+        return (MaybeResult_int32) { .tag = tag_Result_int32, .value = (union_MaybeResult_int32) { .Result_int32_v = (Result_int32) { .result = constructWord(get_int8(byte1), get_int8(byte2)) } } };
+    } else {
+        return (MaybeResult_int32) { .tag = tag_Failure_int32, .value = (union_MaybeResult_int32) { .Failure_int32_v = (Failure_int32) { .status = tag_ReadError } } };
+    }
+}
+
+static STAINLESS_FUNC_PURE int32_t min(int32_t x, int32_t y) {
+    if (x <= y) {
+        return x;
+    } else {
+        return y;
+    }
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+FILE* open(char* filename, void* unused) {
+  FILE* this = fopen(filename, "r");
+  /* this == NULL on failure */
+  return this;
+}
+    
+
+
+FILE* open_1(char* filename) {
+  FILE* this = fopen(filename, "w");
+  /* this == NULL on failure */
+  return this;
+}
+    
+
+
+void print(char* s) {
+  printf("%s", s);
+}
+      
+
+
+void print_1(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_2(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print_1(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_2('\n');
+}
+
+static void println_2(char* s) {
+    print(s);
+    println_1();
+}
+
+static enum_Status process(FileInputStream fis, FileOutputStream fos, State state) {
+    int32_t stainless_buffer_4[25] = { 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1, 1 };
+    array_int32 norm_18 = (array_int32) { .data = stainless_buffer_4, .length = 25 };
+    array_int32 norm_19 = norm_18;
+    Kernel kernel = (Kernel) { .size = 5, .scale = 25, .kernel = norm_19 };
+    MaybeResult_FileHeader fileHeaderRes = maybeReadFileHeader(fis, state);
+    MaybeResult_BitmapHeader bitmapHeaderRes = maybeReadBitmapHeader(fis, state);
+    enum_Status status;
+    MaybeResult_Tuple_FileHeader_BitmapHeader tmp = combine_FileHeader_BitmapHeader(fileHeaderRes, bitmapHeaderRes);
+    if (tmp.tag == tag_Failure_Tuple_FileHeader_BitmapHeader) {
+        status = tmp.value.Failure_Tuple_FileHeader_BitmapHeader_v.status;
+    } else if (tmp.tag == tag_Result_Tuple_FileHeader_BitmapHeader && tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._1.size <= 14 + 40) {
+        status = tag_CorruptedDataError;
+    } else if (tmp.tag == tag_Result_Tuple_FileHeader_BitmapHeader) {
+        log_1(tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._1);
+        log_2(tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._2);
+        int32_t toSkip = tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._1.offset - (14 + 18);
+        bool success = skipBytes(fis, toSkip, state);
+        if (!success) {
+            status = tag_CorruptedDataError;
+        } else if (tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._2.width > 512 || tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._2.height > 512) {
+            status = tag_ImageTooBigError;
+        } else if (tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._2.width * tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._2.height > 512 * 512) {
+            status = tag_ImageTooBigError;
+        } else {
+            Image image = (Image) { .r = { 0 }, .g = { 0 }, .b = { 0 }, .w = tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._2.width, .h = tmp.value.Result_Tuple_FileHeader_BitmapHeader_v.result._2.height };
+            enum_Status status_1 = loadImageData(fis, &image, state);
+            if (isSuccess(status_1)) {
+                status = processImage(&fis, &fos, &state, &kernel, &image);
+            } else {
+                status = status_1;
+            }
+        }
+    }
+    return status;
+}
+
+static enum_Status processImage(FileInputStream* fis, FileOutputStream* fos, State* state, Kernel* kernel, Image* src) {
+    Image dest = (Image) { .r = { 0 }, .g = { 0 }, .b = { 0 }, .w = src->w, .h = src->h };
+    apply(kernel, src, &dest);
+    return saveImage(*fos, &dest);
+}
+
+static enum_Status saveImage(FileOutputStream fos, Image* image) {
+    bool ok1 = writeFileHeader(&fos, image);
+    if (!ok1) {
+        return tag_WriteError;
+    }
+    bool ok2 = writeBitmapHeader(&fos, image);
+    if (!ok2) {
+        return tag_WriteError;
+    }
+    bool ok3 = writeImage(&fos, image);
+    if (ok3) {
+        return tag_Success;
+    } else {
+        return tag_WriteError;
+    }
+}
+
+static bool skipBytes(FileInputStream fis, int32_t count, State state) {
+    int32_t i = 0;
+    bool success = true;
+    while (success && i < count) {
+        Option_int8 opt = tryReadByte(fis, state);
+        success = isDefined_int8(opt);
+        i = i + 1;
+    }
+    return success;
+}
+
+static int32_t statusCode(enum_Status s) {
+    if (s == tag_Success) {
+        println_2("success");
+        return 0;
+    } else if (s == tag_OpenError) {
+        println_2("couldn't open file");
+        return 1;
+    } else if (s == tag_ReadError) {
+        println_2("couldn't read some expected data");
+        return 2;
+    } else if (s == tag_DomainError) {
+        println_2("integer out of range");
+        return 3;
+    } else if (s == tag_InvalidFileHeaderError) {
+        println_2("file format unsupported");
+        return 4;
+    } else if (s == tag_InvalidBitmapHeaderError) {
+        println_2("bitmap format unsupported");
+        return 5;
+    } else if (s == tag_CorruptedDataError) {
+        println_2("the file appears to be corrupted");
+        return 6;
+    } else if (s == tag_ImageTooBigError) {
+        println_2("the image is too big");
+        return 7;
+    } else if (s == tag_WriteError) {
+        println_2("couldn't write image");
+        return 8;
+    } else if (s == tag_NotImplementedError) {
+        println_2("not yet implemented");
+        return 99;
+    }
+}
+
+static Option_int8 tryReadByte(FileInputStream thiss, State state) {
+    bool valid = true;
+    int8_t res = impl(&thiss, &state, &valid);
+    if (valid) {
+        return (Option_int8) { .tag = tag_Some_int8, .value = (union_Option_int8) { .Some_int8_v = (Some_int8) { .v = res } } };
+    } else {
+        return (Option_int8) { .tag = tag_None_int8, .value = (union_Option_int8) { .None_int8_v = (None_int8) { .extra = 0 } } };
+    }
+}
+
+
+bool write(FILE* this, int8_t x) {
+  return fprintf(this, "%c", x) >= 0;
+}
+    
+
+static bool writeBitmapHeader(FileOutputStream* fos, Image* image) {
+    int32_t size = 40;
+    int32_t w = image->w;
+    int32_t h = image->h;
+    int32_t planes = 1;
+    int32_t bpp = 24;
+    int32_t comp = 0;
+    bool ok1 = writeDword(*fos, size);
+    if (!ok1) {
+        return false;
+    }
+    bool ok2 = writeLong(*fos, w);
+    if (!ok2) {
+        return false;
+    }
+    bool ok3 = writeLong(*fos, h);
+    if (!ok3) {
+        return false;
+    }
+    bool ok4 = writeWord(*fos, planes);
+    if (!ok4) {
+        return false;
+    }
+    bool ok5 = writeWord(*fos, bpp);
+    if (!ok5) {
+        return false;
+    }
+    bool ok6 = writeWord(*fos, comp);
+    if (!ok6) {
+        return false;
+    }
+    return writeBytes(*fos, 0, 22);
+}
+
+static bool writeBytes(FileOutputStream fos, int8_t byte, int32_t count) {
+    FileOutputStream fos_0 = fos;
+    int8_t byte_0 = byte;
+    int32_t count_0 = count;
+    while (true) {
+        label_0: ;
+            if (count_0 == 0) {
+                return true;
+            } else {
+                bool ok1 = write(fos_0, byte_0);
+                if (ok1) {
+                    FileOutputStream fos_0_0 = fos_0;
+                    int8_t byte_0_0 = byte_0;
+                    int32_t count_0_0 = count_0 - 1;
+                    fos_0 = fos_0_0;
+                    byte_0 = byte_0_0;
+                    count_0 = count_0_0;
+                    goto label_0;
+                } else {
+                    return false;
+                }
+            };
+    }
+}
+
+static bool writeDword(FileOutputStream fos, int32_t dword) {
+    int8_t b4 = (int8_t)((int32_t)(((uint32_t)dword) >> 24));
+    int8_t b3 = (int8_t)((int32_t)(((uint32_t)dword) >> 16));
+    int8_t b2 = (int8_t)((int32_t)(((uint32_t)dword) >> 8));
+    int8_t b1 = (int8_t)dword;
+    bool ok1 = write(fos, b1);
+    if (!ok1) {
+        return false;
+    }
+    bool ok2 = write(fos, b2);
+    if (!ok2) {
+        return false;
+    }
+    bool ok3 = write(fos, b3);
+    if (!ok3) {
+        return false;
+    }
+    return write(fos, b4);
+}
+
+static bool writeFileHeader(FileOutputStream* fos, Image* image) {
+    int32_t size = (14 + 40) + (image->w * image->h) * 3;
+    int32_t reserved = 0;
+    int32_t offset = 14 + 40;
+    bool ok1 = write(*fos, (int8_t)66);
+    if (!ok1) {
+        return false;
+    }
+    bool ok2 = write(*fos, (int8_t)77);
+    if (!ok2) {
+        return false;
+    }
+    bool ok3 = writeDword(*fos, size);
+    if (!ok3) {
+        return false;
+    }
+    bool ok4 = writeWord(*fos, reserved);
+    if (!ok4) {
+        return false;
+    }
+    bool ok5 = writeWord(*fos, reserved);
+    if (!ok5) {
+        return false;
+    }
+    return writeDword(*fos, offset);
+}
+
+static bool writeImage(FileOutputStream* fos, Image* image) {
+    int32_t count = image->w * image->h;
+    int32_t i = 0;
+    bool success = true;
+    while (success && i < count) {
+        bool ok1 = write(*fos, image->r[i]);
+        bool ok2;
+        if (ok1) {
+            ok2 = write(*fos, image->g[i]);
+        } else {
+            ok2 = false;
+        }
+        bool ok3;
+        if (ok2) {
+            ok3 = write(*fos, image->b[i]);
+        } else {
+            ok3 = false;
+        }
+        success = ok3;
+        i = i + 1;
+    }
+    return success;
+}
+
+static bool writeLong(FileOutputStream fos, int32_t long_1) {
+    int8_t b4 = (int8_t)((int32_t)(((uint32_t)long_1) >> 24));
+    int8_t b3 = (int8_t)((int32_t)(((uint32_t)long_1) >> 16));
+    int8_t b2 = (int8_t)((int32_t)(((uint32_t)long_1) >> 8));
+    int8_t b1 = (int8_t)long_1;
+    bool ok1 = write(fos, b1);
+    if (!ok1) {
+        return false;
+    }
+    bool ok2 = write(fos, b2);
+    if (!ok2) {
+        return false;
+    }
+    bool ok3 = write(fos, b3);
+    if (!ok3) {
+        return false;
+    }
+    return write(fos, b4);
+}
+
+static bool writeWord(FileOutputStream fos, int32_t word) {
+    Tuple_int8_int8 tmp = destructWord(word);
+    Tuple_int8_int8 _2_ = tmp;
+    int8_t b1 = _2_._1;
+    int8_t b2 = _2_._2;
+    bool ok1 = write(fos, b2);
+    if (!ok1) {
+        return false;
+    }
+    return write(fos, b1);
+}

--- a/frontends/benchmarks/genc/valid/ImageProcessing.expected.h
+++ b/frontends/benchmarks/genc/valid/ImageProcessing.expected.h
@@ -1,5 +1,5 @@
-#ifndef __FIXEDARRAY_H__
-#define __FIXEDARRAY_H__
+#ifndef __IMAGEPROCESSING_H__
+#define __IMAGEPROCESSING_H__
 
 /* --------------------------- preprocessor macros ----- */
 
@@ -31,25 +31,10 @@
 
 
 
-/* ---------------------- data type definitions ----- */
-
-typedef struct {
-  int32_t x;
-  int32_t a[5];
-  int32_t y;
-} W;
-
-typedef struct {
-  int32_t* data;
-  int32_t length;
-} array_int32;
-
 
 
 /* ---------------------- function declarations ----- */
 
-int32_t f(W* w);
-void g(array_int32 a);
-void main(void);
+int32_t main(void);
 
 #endif

--- a/frontends/benchmarks/genc/valid/InPlaceRefFnCall1.expected.c
+++ b/frontends/benchmarks/genc/valid/InPlaceRefFnCall1.expected.c
@@ -1,0 +1,48 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "InPlaceRefFnCall1.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE void placeholder(int32_t* r);
+
+
+/* ----------------------- function definitions ----- */
+
+STAINLESS_FUNC_PURE void f(int32_t v) {
+    int32_t tmp_1 = v + 10;
+    int32_t* norm_0 = &tmp_1;
+    int32_t tmp = *norm_0;
+    int32_t* norm_1 = &tmp;
+    placeholder(norm_1);
+}
+
+STAINLESS_FUNC_PURE void main(void) {
+    
+}
+
+static STAINLESS_FUNC_PURE void placeholder(int32_t* r) {
+    
+}

--- a/frontends/benchmarks/genc/valid/InPlaceRefFnCall1.expected.h
+++ b/frontends/benchmarks/genc/valid/InPlaceRefFnCall1.expected.h
@@ -1,0 +1,39 @@
+#ifndef __INPLACEREFFNCALL1_H__
+#define __INPLACEREFFNCALL1_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+STAINLESS_FUNC_PURE void f(int32_t v);
+STAINLESS_FUNC_PURE void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/InPlaceRefFnCall2.expected.c
+++ b/frontends/benchmarks/genc/valid/InPlaceRefFnCall2.expected.c
@@ -1,0 +1,55 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "InPlaceRefFnCall2.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+/* ---------------------- data type definitions ----- */
+
+typedef struct {
+  int32_t _1;
+  int32_t _2;
+} Tuple_int32_Ref_int32;
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE void placeholder(Tuple_int32_Ref_int32* r);
+
+
+/* ----------------------- function definitions ----- */
+
+STAINLESS_FUNC_PURE void f(int32_t v) {
+    int32_t tmp_1 = v + 10;
+    int32_t* norm_0 = &tmp_1;
+    Tuple_int32_Ref_int32 tmp = (Tuple_int32_Ref_int32) { ._1 = 456, ._2 = (*norm_0) };
+    Tuple_int32_Ref_int32* norm_1 = &tmp;
+    placeholder(norm_1);
+}
+
+STAINLESS_FUNC_PURE void main(void) {
+    
+}
+
+static STAINLESS_FUNC_PURE void placeholder(Tuple_int32_Ref_int32* r) {
+    
+}

--- a/frontends/benchmarks/genc/valid/InPlaceRefFnCall2.expected.h
+++ b/frontends/benchmarks/genc/valid/InPlaceRefFnCall2.expected.h
@@ -1,0 +1,39 @@
+#ifndef __INPLACEREFFNCALL2_H__
+#define __INPLACEREFFNCALL2_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+STAINLESS_FUNC_PURE void f(int32_t v);
+STAINLESS_FUNC_PURE void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/Nested.expected.c
+++ b/frontends/benchmarks/genc/valid/Nested.expected.c
@@ -1,0 +1,74 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "Nested.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static int32_t f(int32_t x);
+static STAINLESS_FUNC_PURE int32_t gg(int32_t* x, int32_t y);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static int32_t f(int32_t x) {
+    int32_t res = gg(&x, 15);
+    println(res);
+    return res;
+}
+
+static STAINLESS_FUNC_PURE int32_t gg(int32_t* x, int32_t y) {
+    return (*x) + y;
+}
+
+int32_t main(void) {
+    return f(100);
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/Nested.expected.h
+++ b/frontends/benchmarks/genc/valid/Nested.expected.h
@@ -1,0 +1,40 @@
+#ifndef __NESTED_H__
+#define __NESTED_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+int32_t main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/Normalisation.expected.c
+++ b/frontends/benchmarks/genc/valid/Normalisation.expected.c
@@ -1,0 +1,87 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "Normalisation.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+/* ---------------------- data type definitions ----- */
+
+typedef struct {
+  int32_t x;
+  uint16_t y;
+  int64_t z;
+} A;
+
+typedef struct {
+  A a1;
+  uint8_t i;
+  uint32_t j;
+  A a2;
+} B;
+
+
+
+/* ---------------------- function declarations ----- */
+
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+static STAINLESS_FUNC_PURE int32_t sum(A thiss);
+
+
+/* ----------------------- function definitions ----- */
+
+void main(void) {
+    A a = (A) { .x = 100, .y = 9, .z = 200 };
+    int32_t x = sum(a) + sum(a);
+    int32_t y = x + sum(a);
+    println(y);
+    B b = (B) { .a1 = a, .i = 76, .j = 14, .a2 = a };
+    println(((sum(b.a1) + ((int32_t)((uint32_t)b.i))) + ((int32_t)b.j)) + sum(b.a2));
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}
+
+static STAINLESS_FUNC_PURE int32_t sum(A thiss) {
+    return (thiss.x + ((int32_t)((uint32_t)thiss.y))) + ((int32_t)thiss.z);
+}

--- a/frontends/benchmarks/genc/valid/Normalisation.expected.h
+++ b/frontends/benchmarks/genc/valid/Normalisation.expected.h
@@ -1,0 +1,40 @@
+#ifndef __NORMALISATION_H__
+#define __NORMALISATION_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/Pointer.expected.c
+++ b/frontends/benchmarks/genc/valid/Pointer.expected.c
@@ -1,0 +1,72 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "Pointer.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static void f(int32_t* r, int32_t* r2);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static void f(int32_t* r, int32_t* r2) {
+    *r = 150;
+    *r2 = 250;
+}
+
+void main(void) {
+    int32_t r = 100;
+    int32_t r2 = 100;
+    f(&r, &r2);
+    println(r);
+    println(r2);
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/Pointer.expected.h
+++ b/frontends/benchmarks/genc/valid/Pointer.expected.h
@@ -1,0 +1,40 @@
+#ifndef __POINTER_H__
+#define __POINTER_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/Pointer2.expected.c
+++ b/frontends/benchmarks/genc/valid/Pointer2.expected.c
@@ -40,8 +40,8 @@ static void println_1(void);
 
 static STAINLESS_FUNC_PURE int32_t f(int32_t v) {
     int32_t tmp = v + 42;
-    int32_t* norm_1 = &tmp;
-    return inc(norm_1);
+    int32_t* norm_0 = &tmp;
+    return inc(norm_0);
 }
 
 static int32_t inc(int32_t* p) {
@@ -51,8 +51,8 @@ static int32_t inc(int32_t* p) {
 
 void main(void) {
     int32_t tmp = 123;
-    int32_t* norm_0 = &tmp;
-    int32_t res1 = inc(norm_0);
+    int32_t* norm_1 = &tmp;
+    int32_t res1 = inc(norm_1);
     int32_t res2 = f(400);
     println(res1);
     println(res2);

--- a/frontends/benchmarks/genc/valid/Pointer2.expected.c
+++ b/frontends/benchmarks/genc/valid/Pointer2.expected.c
@@ -1,0 +1,80 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "Pointer2.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t f(int32_t v);
+static int32_t inc(int32_t* p);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t f(int32_t v) {
+    int32_t tmp = v + 42;
+    int32_t* norm_1 = &tmp;
+    return inc(norm_1);
+}
+
+static int32_t inc(int32_t* p) {
+    *p = (*p) + 1;
+    return *p;
+}
+
+void main(void) {
+    int32_t tmp = 123;
+    int32_t* norm_0 = &tmp;
+    int32_t res1 = inc(norm_0);
+    int32_t res2 = f(400);
+    println(res1);
+    println(res2);
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/Pointer2.expected.h
+++ b/frontends/benchmarks/genc/valid/Pointer2.expected.h
@@ -1,0 +1,40 @@
+#ifndef __POINTER2_H__
+#define __POINTER2_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/RefInCtor.expected.c
+++ b/frontends/benchmarks/genc/valid/RefInCtor.expected.c
@@ -1,0 +1,45 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "RefInCtor.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+
+/* ----------------------- function definitions ----- */
+
+STAINLESS_FUNC_PURE void main(void) {
+    
+}
+
+STAINLESS_FUNC_PURE void test1(int32_t v) {
+    int32_t tmp = v;
+    int32_t* norm_0 = &tmp;
+    int32_t cont = *norm_0;
+}
+
+STAINLESS_FUNC_PURE void test2(int32_t v) {
+    int32_t tmp_1 = v;
+    int32_t* tmp = &tmp_1;
+    int32_t* norm_1 = tmp;
+    int32_t cont = *norm_1;
+}

--- a/frontends/benchmarks/genc/valid/RefInCtor.expected.h
+++ b/frontends/benchmarks/genc/valid/RefInCtor.expected.h
@@ -1,5 +1,5 @@
-#ifndef __FIXEDARRAY_H__
-#define __FIXEDARRAY_H__
+#ifndef __REFINCTOR_H__
+#define __REFINCTOR_H__
 
 /* --------------------------- preprocessor macros ----- */
 
@@ -21,35 +21,20 @@
 /* ----------------------------------- includes ----- */
 
 #include <assert.h>
-#include <inttypes.h>
 #include <stdbool.h>
 #include <stddef.h>
 #include <stdint.h>
-#include <stdio.h>
 #include <string.h>
 
 
 
 
-/* ---------------------- data type definitions ----- */
-
-typedef struct {
-  int32_t x;
-  int32_t a[5];
-  int32_t y;
-} W;
-
-typedef struct {
-  int32_t* data;
-  int32_t length;
-} array_int32;
-
 
 
 /* ---------------------- function declarations ----- */
 
-int32_t f(W* w);
-void g(array_int32 a);
-void main(void);
+STAINLESS_FUNC_PURE void main(void);
+STAINLESS_FUNC_PURE void test1(int32_t v);
+STAINLESS_FUNC_PURE void test2(int32_t v);
 
 #endif

--- a/frontends/benchmarks/genc/valid/Return.expected.c
+++ b/frontends/benchmarks/genc/valid/Return.expected.c
@@ -1,0 +1,119 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "Return.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+/* ---------------------- data type definitions ----- */
+
+typedef struct {
+  int32_t* data;
+  int32_t length;
+} array_int32;
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t findIndex_int32(array_int32 a, int32_t t);
+static 
+void print(char* s);
+static 
+void print_1(char c);
+static void println(char* s);
+static void println_1(void);
+static STAINLESS_FUNC_PURE int32_t return10(void);
+static void verify(bool b);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t findIndex_int32(array_int32 a, int32_t t) {
+    int32_t i = 0;
+    while (i < a.length) {
+        if (a.data[i] == t) {
+            return i;
+        }
+        i = i + 1;
+    }
+    return 0;
+}
+
+void main(void) {
+    verify(return10() == 10);
+    int32_t stainless_buffer_0[4] = { 0, 100, 200, 250 };
+    array_int32 norm_0 = (array_int32) { .data = stainless_buffer_0, .length = 4 };
+    array_int32 norm_1 = norm_0;
+    int32_t norm_2 = findIndex_int32(norm_1, 0);
+    bool norm_3 = norm_2 == 0;
+    verify(norm_3);
+    int32_t stainless_buffer_1[4] = { 0, 100, 200, 250 };
+    array_int32 norm_4 = (array_int32) { .data = stainless_buffer_1, .length = 4 };
+    array_int32 norm_5 = norm_4;
+    int32_t norm_6 = findIndex_int32(norm_5, 100);
+    bool norm_7 = norm_6 == 1;
+    verify(norm_7);
+    int32_t stainless_buffer_2[4] = { 0, 100, 200, 250 };
+    array_int32 norm_8 = (array_int32) { .data = stainless_buffer_2, .length = 4 };
+    array_int32 norm_9 = norm_8;
+    int32_t norm_10 = findIndex_int32(norm_9, 200);
+    bool norm_11 = norm_10 == 2;
+    verify(norm_11);
+    int32_t stainless_buffer_3[4] = { 0, 100, 200, 250 };
+    array_int32 norm_12 = (array_int32) { .data = stainless_buffer_3, .length = 4 };
+    array_int32 norm_13 = norm_12;
+    int32_t norm_14 = findIndex_int32(norm_13, 250);
+    bool norm_15 = norm_14 == 3;
+    verify(norm_15);
+}
+
+
+void print(char* s) {
+  printf("%s", s);
+}
+      
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(char* s) {
+    print(s);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}
+
+static STAINLESS_FUNC_PURE int32_t return10(void) {
+    return 10;
+}
+
+static void verify(bool b) {
+    if (b) {
+        println("OK");
+    } else {
+        println("ERROR");
+    }
+}

--- a/frontends/benchmarks/genc/valid/Return.expected.h
+++ b/frontends/benchmarks/genc/valid/Return.expected.h
@@ -1,0 +1,39 @@
+#ifndef __RETURN_H__
+#define __RETURN_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/StateTest.expected.c
+++ b/frontends/benchmarks/genc/valid/StateTest.expected.c
@@ -1,0 +1,50 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "StateTest.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t f(State state);
+static void* newState(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t f(State state) {
+    return 0;
+}
+
+int32_t main(void) {
+    State state = newState();
+    return f(state);
+}
+
+void* newState(void) {
+  return NULL;
+}

--- a/frontends/benchmarks/genc/valid/StateTest.expected.h
+++ b/frontends/benchmarks/genc/valid/StateTest.expected.h
@@ -1,0 +1,38 @@
+#ifndef __STATETEST_H__
+#define __STATETEST_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+int32_t main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecAliasedArgs.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecAliasedArgs.expected.c
@@ -46,20 +46,18 @@ static STAINLESS_FUNC_PURE int32_t aliased(int32_t n, int32_t a, int32_t b) {
     int32_t n_0 = n;
     int32_t a_0 = a;
     int32_t b_0 = b;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return a_0;
-            } else {
-                int32_t n_0_0 = n_0 - 1;
-                int32_t a_0_0 = b_0;
-                int32_t b_0_0 = a_0 + b_0;
-                n_0 = n_0_0;
-                a_0 = a_0_0;
-                b_0 = b_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return a_0;
+        } else {
+            int32_t n_0_0 = n_0 - 1;
+            int32_t a_0_0 = b_0;
+            int32_t b_0_0 = a_0 + b_0;
+            n_0 = n_0_0;
+            a_0 = a_0_0;
+            b_0 = b_0_0;
+            goto label_0;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecAliasedArgs.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecAliasedArgs.expected.c
@@ -1,0 +1,93 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecAliasedArgs.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t aliased(int32_t n, int32_t a, int32_t b);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t aliased(int32_t n, int32_t a, int32_t b) {
+    int32_t n_0 = n;
+    int32_t a_0 = a;
+    int32_t b_0 = b;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return a_0;
+            } else {
+                int32_t n_0_0 = n_0 - 1;
+                int32_t a_0_0 = b_0;
+                int32_t b_0_0 = a_0 + b_0;
+                n_0 = n_0_0;
+                a_0 = a_0_0;
+                b_0 = b_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    println(aliased(5, 0, 1));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecAliasedArgs.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecAliasedArgs.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECALIASEDARGS_H__
+#define __TAILRECALIASEDARGS_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecComplexArgs.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecComplexArgs.expected.c
@@ -44,16 +44,14 @@ static void println_1(void);
 
 static STAINLESS_FUNC_PURE int32_t complexArgs(int32_t n) {
     int32_t n_0 = n;
-    while (true) {
-        label_0: ;
-            if (n_0 <= 0) {
-                return 1;
-            } else {
-                int32_t n_0_0 = (n_0 - 1 * 2) + 1;
-                n_0 = n_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 <= 0) {
+            return 1;
+        } else {
+            int32_t n_0_0 = (n_0 - 1 * 2) + 1;
+            n_0 = n_0_0;
+            goto label_0;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecComplexArgs.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecComplexArgs.expected.c
@@ -1,0 +1,87 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecComplexArgs.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t complexArgs(int32_t n);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t complexArgs(int32_t n) {
+    int32_t n_0 = n;
+    while (true) {
+        label_0: ;
+            if (n_0 <= 0) {
+                return 1;
+            } else {
+                int32_t n_0_0 = (n_0 - 1 * 2) + 1;
+                n_0 = n_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    println(complexArgs(5));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecComplexArgs.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecComplexArgs.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECCOMPLEXARGS_H__
+#define __TAILRECCOMPLEXARGS_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecCountDown.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecCountDown.expected.c
@@ -1,0 +1,87 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecCountDown.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t countDown(int32_t n);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t countDown(int32_t n) {
+    int32_t n_0 = n;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return 0;
+            } else {
+                int32_t n_0_0 = n_0 - 1;
+                n_0 = n_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    println(countDown(1000000));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecCountDown.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecCountDown.expected.c
@@ -44,16 +44,14 @@ static void println_1(void);
 
 static STAINLESS_FUNC_PURE int32_t countDown(int32_t n) {
     int32_t n_0 = n;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return 0;
-            } else {
-                int32_t n_0_0 = n_0 - 1;
-                n_0 = n_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return 0;
+        } else {
+            int32_t n_0_0 = n_0 - 1;
+            n_0 = n_0_0;
+            goto label_0;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecCountDown.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecCountDown.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECCOUNTDOWN_H__
+#define __TAILRECCOUNTDOWN_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecEarlyReturn.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecEarlyReturn.expected.c
@@ -1,0 +1,92 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecEarlyReturn.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t earlyReturn(int32_t n, int32_t acc);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t earlyReturn(int32_t n, int32_t acc) {
+    int32_t n_0 = n;
+    int32_t acc_0 = acc;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return acc_0;
+            } else if (n_0 == 3) {
+                return acc_0 * 2;
+            } else {
+                int32_t n_0_0 = n_0 - 1;
+                int32_t acc_0_0 = acc_0 + 1;
+                n_0 = n_0_0;
+                acc_0 = acc_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    println(earlyReturn(5, 0));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecEarlyReturn.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecEarlyReturn.expected.c
@@ -45,20 +45,18 @@ static void println_1(void);
 static STAINLESS_FUNC_PURE int32_t earlyReturn(int32_t n, int32_t acc) {
     int32_t n_0 = n;
     int32_t acc_0 = acc;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return acc_0;
-            } else if (n_0 == 3) {
-                return acc_0 * 2;
-            } else {
-                int32_t n_0_0 = n_0 - 1;
-                int32_t acc_0_0 = acc_0 + 1;
-                n_0 = n_0_0;
-                acc_0 = acc_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return acc_0;
+        } else if (n_0 == 3) {
+            return acc_0 * 2;
+        } else {
+            int32_t n_0_0 = n_0 - 1;
+            int32_t acc_0_0 = acc_0 + 1;
+            n_0 = n_0_0;
+            acc_0 = acc_0_0;
+            goto label_0;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecEarlyReturn.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecEarlyReturn.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECEARLYRETURN_H__
+#define __TAILRECEARLYRETURN_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecFib.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecFib.expected.c
@@ -1,0 +1,103 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecFib.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t fib(int32_t n, int32_t i, int32_t j);
+static STAINLESS_FUNC_PURE int32_t fib_default_2(void);
+static STAINLESS_FUNC_PURE int32_t fib_default_3(void);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t fib(int32_t n, int32_t i, int32_t j) {
+    int32_t n_0 = n;
+    int32_t i_0 = i;
+    int32_t j_0 = j;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return i_0;
+            } else {
+                int32_t n_0_0 = n_0 - 1;
+                int32_t i_0_0 = j_0;
+                int32_t j_0_0 = i_0 + j_0;
+                n_0 = n_0_0;
+                i_0 = i_0_0;
+                j_0 = j_0_0;
+                goto label_0;
+            };
+    }
+}
+
+static STAINLESS_FUNC_PURE int32_t fib_default_2(void) {
+    return 0;
+}
+
+static STAINLESS_FUNC_PURE int32_t fib_default_3(void) {
+    return 1;
+}
+
+void main(void) {
+    State state = newState();
+    println(fib(10, fib_default_2(), fib_default_3()));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecFib.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecFib.expected.c
@@ -48,20 +48,18 @@ static STAINLESS_FUNC_PURE int32_t fib(int32_t n, int32_t i, int32_t j) {
     int32_t n_0 = n;
     int32_t i_0 = i;
     int32_t j_0 = j;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return i_0;
-            } else {
-                int32_t n_0_0 = n_0 - 1;
-                int32_t i_0_0 = j_0;
-                int32_t j_0_0 = i_0 + j_0;
-                n_0 = n_0_0;
-                i_0 = i_0_0;
-                j_0 = j_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return i_0;
+        } else {
+            int32_t n_0_0 = n_0 - 1;
+            int32_t i_0_0 = j_0;
+            int32_t j_0_0 = i_0 + j_0;
+            n_0 = n_0_0;
+            i_0 = i_0_0;
+            j_0 = j_0_0;
+            goto label_0;
+        };
 }
 
 static STAINLESS_FUNC_PURE int32_t fib_default_2(void) {

--- a/frontends/benchmarks/genc/valid/TailRecFib.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecFib.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECFIB_H__
+#define __TAILRECFIB_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecFibAliased.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecFibAliased.expected.c
@@ -48,20 +48,18 @@ static STAINLESS_FUNC_PURE int32_t fib(int32_t n, int32_t i, int32_t j) {
     int32_t n_0 = n;
     int32_t i_0 = i;
     int32_t j_0 = j;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return i_0;
-            } else {
-                int32_t n_0_0 = n_0 - 1;
-                int32_t i_0_0 = j_0;
-                int32_t j_0_0 = i_0 + j_0;
-                n_0 = n_0_0;
-                i_0 = i_0_0;
-                j_0 = j_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return i_0;
+        } else {
+            int32_t n_0_0 = n_0 - 1;
+            int32_t i_0_0 = j_0;
+            int32_t j_0_0 = i_0 + j_0;
+            n_0 = n_0_0;
+            i_0 = i_0_0;
+            j_0 = j_0_0;
+            goto label_0;
+        };
 }
 
 static STAINLESS_FUNC_PURE int32_t fib_default_2(void) {

--- a/frontends/benchmarks/genc/valid/TailRecFibAliased.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecFibAliased.expected.c
@@ -1,0 +1,103 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecFibAliased.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t fib(int32_t n, int32_t i, int32_t j);
+static STAINLESS_FUNC_PURE int32_t fib_default_2(void);
+static STAINLESS_FUNC_PURE int32_t fib_default_3(void);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t fib(int32_t n, int32_t i, int32_t j) {
+    int32_t n_0 = n;
+    int32_t i_0 = i;
+    int32_t j_0 = j;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return i_0;
+            } else {
+                int32_t n_0_0 = n_0 - 1;
+                int32_t i_0_0 = j_0;
+                int32_t j_0_0 = i_0 + j_0;
+                n_0 = n_0_0;
+                i_0 = i_0_0;
+                j_0 = j_0_0;
+                goto label_0;
+            };
+    }
+}
+
+static STAINLESS_FUNC_PURE int32_t fib_default_2(void) {
+    return 0;
+}
+
+static STAINLESS_FUNC_PURE int32_t fib_default_3(void) {
+    return 1;
+}
+
+void main(void) {
+    State state = newState();
+    println(fib(10, fib_default_2(), fib_default_3()));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecFibAliased.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecFibAliased.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECFIBALIASED_H__
+#define __TAILRECFIBALIASED_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecMultipleCalls.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecMultipleCalls.expected.c
@@ -1,0 +1,98 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecMultipleCalls.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t multipleCalls(int32_t n, int32_t acc);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+void main(void) {
+    State state = newState();
+    println(multipleCalls(10, 0));
+}
+
+static STAINLESS_FUNC_PURE int32_t multipleCalls(int32_t n, int32_t acc) {
+    int32_t n_0 = n;
+    int32_t acc_0 = acc;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return acc_0;
+            } else if (n_0 == 1) {
+                return acc_0 + 2;
+            } else if (n_0 % 2 == 0) {
+                int32_t n_0_0 = n_0 - 1;
+                int32_t acc_0_0 = acc_0 + 1;
+                n_0 = n_0_0;
+                acc_0 = acc_0_0;
+                goto label_0;
+            } else {
+                int32_t n_0_1 = n_0 - 2;
+                int32_t acc_0_1 = acc_0 + 2;
+                n_0 = n_0_1;
+                acc_0 = acc_0_1;
+                goto label_0;
+            };
+    }
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecMultipleCalls.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecMultipleCalls.expected.c
@@ -50,26 +50,24 @@ void main(void) {
 static STAINLESS_FUNC_PURE int32_t multipleCalls(int32_t n, int32_t acc) {
     int32_t n_0 = n;
     int32_t acc_0 = acc;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return acc_0;
-            } else if (n_0 == 1) {
-                return acc_0 + 2;
-            } else if (n_0 % 2 == 0) {
-                int32_t n_0_0 = n_0 - 1;
-                int32_t acc_0_0 = acc_0 + 1;
-                n_0 = n_0_0;
-                acc_0 = acc_0_0;
-                goto label_0;
-            } else {
-                int32_t n_0_1 = n_0 - 2;
-                int32_t acc_0_1 = acc_0 + 2;
-                n_0 = n_0_1;
-                acc_0 = acc_0_1;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return acc_0;
+        } else if (n_0 == 1) {
+            return acc_0 + 2;
+        } else if (n_0 % 2 == 0) {
+            int32_t n_0_0 = n_0 - 1;
+            int32_t acc_0_0 = acc_0 + 1;
+            n_0 = n_0_0;
+            acc_0 = acc_0_0;
+            goto label_0;
+        } else {
+            int32_t n_0_1 = n_0 - 2;
+            int32_t acc_0_1 = acc_0 + 2;
+            n_0 = n_0_1;
+            acc_0 = acc_0_1;
+            goto label_0;
+        };
 }
 
 void* newState(void) {

--- a/frontends/benchmarks/genc/valid/TailRecMultipleCalls.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecMultipleCalls.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECMULTIPLECALLS_H__
+#define __TAILRECMULTIPLECALLS_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecNested.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecNested.expected.c
@@ -1,0 +1,92 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecNested.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t inner(int32_t* n, int32_t x);
+static void* newState(void);
+static STAINLESS_FUNC_PURE int32_t outer(int32_t n);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t inner(int32_t* n, int32_t x) {
+    int32_t x_0 = x;
+    while (true) {
+        label_0: ;
+            if (x_0 == 0) {
+                return 0;
+            } else {
+                int32_t x_0_0 = x_0 - 1;
+                x_0 = x_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    println(outer(5));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+static STAINLESS_FUNC_PURE int32_t outer(int32_t n) {
+    return inner(&n, n);
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecNested.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecNested.expected.c
@@ -45,16 +45,14 @@ static void println_1(void);
 
 static STAINLESS_FUNC_PURE int32_t inner(int32_t* n, int32_t x) {
     int32_t x_0 = x;
-    while (true) {
-        label_0: ;
-            if (x_0 == 0) {
-                return 0;
-            } else {
-                int32_t x_0_0 = x_0 - 1;
-                x_0 = x_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (x_0 == 0) {
+            return 0;
+        } else {
+            int32_t x_0_0 = x_0 - 1;
+            x_0 = x_0_0;
+            goto label_0;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecNested.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecNested.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECNESTED_H__
+#define __TAILRECNESTED_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecPatternMatching.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecPatternMatching.expected.c
@@ -1,0 +1,129 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecPatternMatching.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+/* -------------------------------------- enums ----- */
+
+typedef enum {
+  tag_None_int32,
+  tag_Some_int32
+} enum_Option_int32;
+
+
+/* ---------------------- data type definitions ----- */
+
+typedef struct {
+  int8_t extra;
+} None_int32;
+
+typedef struct {
+  int32_t v;
+} Some_int32;
+
+typedef union {
+  None_int32 None_int32_v;
+  Some_int32 Some_int32_v;
+} union_Option_int32;
+
+typedef struct {
+  enum_Option_int32 tag;
+  union_Option_int32 value;
+} Option_int32;
+
+
+
+/* ---------------------- function declarations ----- */
+
+static void* newState(void);
+static STAINLESS_FUNC_PURE int32_t patternMatch(Option_int32 x, int32_t acc);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+void main(void) {
+    State state = newState();
+    println(patternMatch((Option_int32) { .tag = tag_Some_int32, .value = (union_Option_int32) { .Some_int32_v = (Some_int32) { .v = 5 } } }, 0));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+static STAINLESS_FUNC_PURE int32_t patternMatch(Option_int32 x, int32_t acc) {
+    Option_int32 x_0 = x;
+    int32_t acc_0 = acc;
+    while (true) {
+        label_0: ;
+            int32_t measure;
+            if (x_0.tag == tag_None_int32) {
+                measure = 0;
+            } else if (x_0.tag == tag_Some_int32) {
+                measure = x_0.value.Some_int32_v.v;
+            }
+            if (x_0.tag == tag_None_int32) {
+                return acc_0;
+            } else if (x_0.tag == tag_Some_int32 && x_0.value.Some_int32_v.v == 1) {
+                Option_int32 x_0_0 = (Option_int32) { .tag = tag_None_int32, .value = (union_Option_int32) { .None_int32_v = (None_int32) { .extra = 0 } } };
+                int32_t acc_0_0 = acc_0 + 1;
+                x_0 = x_0_0;
+                acc_0 = acc_0_0;
+                goto label_0;
+            } else if (x_0.tag == tag_Some_int32) {
+                Option_int32 x_0_1 = (Option_int32) { .tag = tag_Some_int32, .value = (union_Option_int32) { .Some_int32_v = (Some_int32) { .v = (x_0.value.Some_int32_v.v - 1) } } };
+                int32_t acc_0_1 = acc_0 + 1;
+                x_0 = x_0_1;
+                acc_0 = acc_0_1;
+                goto label_0;
+            };
+    }
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecPatternMatching.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecPatternMatching.expected.c
@@ -81,30 +81,28 @@ void* newState(void) {
 static STAINLESS_FUNC_PURE int32_t patternMatch(Option_int32 x, int32_t acc) {
     Option_int32 x_0 = x;
     int32_t acc_0 = acc;
-    while (true) {
-        label_0: ;
-            int32_t measure;
-            if (x_0.tag == tag_None_int32) {
-                measure = 0;
-            } else if (x_0.tag == tag_Some_int32) {
-                measure = x_0.value.Some_int32_v.v;
-            }
-            if (x_0.tag == tag_None_int32) {
-                return acc_0;
-            } else if (x_0.tag == tag_Some_int32 && x_0.value.Some_int32_v.v == 1) {
-                Option_int32 x_0_0 = (Option_int32) { .tag = tag_None_int32, .value = (union_Option_int32) { .None_int32_v = (None_int32) { .extra = 0 } } };
-                int32_t acc_0_0 = acc_0 + 1;
-                x_0 = x_0_0;
-                acc_0 = acc_0_0;
-                goto label_0;
-            } else if (x_0.tag == tag_Some_int32) {
-                Option_int32 x_0_1 = (Option_int32) { .tag = tag_Some_int32, .value = (union_Option_int32) { .Some_int32_v = (Some_int32) { .v = (x_0.value.Some_int32_v.v - 1) } } };
-                int32_t acc_0_1 = acc_0 + 1;
-                x_0 = x_0_1;
-                acc_0 = acc_0_1;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        int32_t measure;
+        if (x_0.tag == tag_None_int32) {
+            measure = 0;
+        } else if (x_0.tag == tag_Some_int32) {
+            measure = x_0.value.Some_int32_v.v;
+        }
+        if (x_0.tag == tag_None_int32) {
+            return acc_0;
+        } else if (x_0.tag == tag_Some_int32 && x_0.value.Some_int32_v.v == 1) {
+            Option_int32 x_0_0 = (Option_int32) { .tag = tag_None_int32, .value = (union_Option_int32) { .None_int32_v = (None_int32) { .extra = 0 } } };
+            int32_t acc_0_0 = acc_0 + 1;
+            x_0 = x_0_0;
+            acc_0 = acc_0_0;
+            goto label_0;
+        } else if (x_0.tag == tag_Some_int32) {
+            Option_int32 x_0_1 = (Option_int32) { .tag = tag_Some_int32, .value = (union_Option_int32) { .Some_int32_v = (Some_int32) { .v = (x_0.value.Some_int32_v.v - 1) } } };
+            int32_t acc_0_1 = acc_0 + 1;
+            x_0 = x_0_1;
+            acc_0 = acc_0_1;
+            goto label_0;
+        };
 }
 
 

--- a/frontends/benchmarks/genc/valid/TailRecPatternMatching.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecPatternMatching.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECPATTERNMATCHING_H__
+#define __TAILRECPATTERNMATCHING_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecStackOverflow.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecStackOverflow.expected.c
@@ -44,18 +44,16 @@ static void println_1(void);
 
 static STAINLESS_FUNC_PURE int32_t even(int32_t n) {
     int32_t n_0 = n;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return 1;
-            } else if (n_0 == 1) {
-                return 0;
-            } else {
-                int32_t n_0_0 = n_0 - 2;
-                n_0 = n_0_0;
-                goto label_0;
-            };
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return 1;
+        } else if (n_0 == 1) {
+            return 0;
+        } else {
+            int32_t n_0_0 = n_0 - 2;
+            n_0 = n_0_0;
+            goto label_0;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecStackOverflow.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecStackOverflow.expected.c
@@ -1,0 +1,89 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecStackOverflow.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE int32_t even(int32_t n);
+static void* newState(void);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE int32_t even(int32_t n) {
+    int32_t n_0 = n;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return 1;
+            } else if (n_0 == 1) {
+                return 0;
+            } else {
+                int32_t n_0_0 = n_0 - 2;
+                n_0 = n_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    println(even(1000000));
+}
+
+void* newState(void) {
+  return NULL;
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}

--- a/frontends/benchmarks/genc/valid/TailRecStackOverflow.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecStackOverflow.expected.h
@@ -1,0 +1,40 @@
+#ifndef __TAILRECSTACKOVERFLOW_H__
+#define __TAILRECSTACKOVERFLOW_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecUnit.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnit.expected.c
@@ -44,8 +44,7 @@ static STAINLESS_FUNC_PURE void countDown(int32_t n) {
         }
         int32_t n_0_0 = n_0 - 1;
         n_0 = n_0_0;
-        goto label_0;
-        return;;
+        goto label_0;;
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecUnit.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnit.expected.c
@@ -38,16 +38,14 @@ static void* newState(void);
 
 static STAINLESS_FUNC_PURE void countDown(int32_t n) {
     int32_t n_0 = n;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return;
-            }
-            int32_t n_0_0 = n_0 - 1;
-            n_0 = n_0_0;
-            goto label_0;
-            return;;
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return;
+        }
+        int32_t n_0_0 = n_0 - 1;
+        n_0 = n_0_0;
+        goto label_0;
+        return;;
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecUnit.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnit.expected.c
@@ -1,0 +1,60 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecUnit.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE void countDown(int32_t n);
+static void* newState(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE void countDown(int32_t n) {
+    int32_t n_0 = n;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return;
+            }
+            int32_t n_0_0 = n_0 - 1;
+            n_0 = n_0_0;
+            goto label_0;
+            return;;
+    }
+}
+
+void main(void) {
+    State state = newState();
+    countDown(1000000);
+}
+
+void* newState(void) {
+  return NULL;
+}

--- a/frontends/benchmarks/genc/valid/TailRecUnit.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecUnit.expected.h
@@ -1,0 +1,38 @@
+#ifndef __TAILRECUNIT_H__
+#define __TAILRECUNIT_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
@@ -46,7 +46,8 @@ static STAINLESS_FUNC_PURE void countDown(int32_t n) {
                 int32_t n_0_0 = n_0 - 1;
                 n_0 = n_0_0;
                 goto label_0;
-            };
+            }
+            return;;
     }
 }
 

--- a/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
@@ -1,0 +1,60 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecUnitIf.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE void countDown(int32_t n);
+static void* newState(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE void countDown(int32_t n) {
+    int32_t n_0 = n;
+    while (true) {
+        label_0: ;
+            if (n_0 == 0) {
+                return;
+            } else {
+                int32_t n_0_0 = n_0 - 1;
+                n_0 = n_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    countDown(1000000);
+}
+
+void* newState(void) {
+  return NULL;
+}

--- a/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
@@ -38,17 +38,15 @@ static void* newState(void);
 
 static STAINLESS_FUNC_PURE void countDown(int32_t n) {
     int32_t n_0 = n;
-    while (true) {
-        label_0: ;
-            if (n_0 == 0) {
-                return;
-            } else {
-                int32_t n_0_0 = n_0 - 1;
-                n_0 = n_0_0;
-                goto label_0;
-            }
-            return;;
-    }
+    label_0: ;
+        if (n_0 == 0) {
+            return;
+        } else {
+            int32_t n_0_0 = n_0 - 1;
+            n_0 = n_0_0;
+            goto label_0;
+        }
+        return;;
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.c
@@ -45,8 +45,7 @@ static STAINLESS_FUNC_PURE void countDown(int32_t n) {
             int32_t n_0_0 = n_0 - 1;
             n_0 = n_0_0;
             goto label_0;
-        }
-        return;;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecUnitIf.expected.h
@@ -1,0 +1,38 @@
+#ifndef __TAILRECUNITIF_H__
+#define __TAILRECUNITIF_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
@@ -1,0 +1,58 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TailRecUnitNoExplicitEnd.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+/* ------------------------------- type aliases ----- */
+
+typedef void* State;
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE void countDown(int32_t n);
+static void* newState(void);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE void countDown(int32_t n) {
+    int32_t n_0 = n;
+    while (true) {
+        label_0: ;
+            if (n_0 > 0) {
+                int32_t n_0_0 = n_0 - 1;
+                n_0 = n_0_0;
+                goto label_0;
+            };
+    }
+}
+
+void main(void) {
+    State state = newState();
+    countDown(1000000);
+}
+
+void* newState(void) {
+  return NULL;
+}

--- a/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
@@ -38,15 +38,13 @@ static void* newState(void);
 
 static STAINLESS_FUNC_PURE void countDown(int32_t n) {
     int32_t n_0 = n;
-    while (true) {
-        label_0: ;
-            if (n_0 > 0) {
-                int32_t n_0_0 = n_0 - 1;
-                n_0 = n_0_0;
-                goto label_0;
-            }
-            return;;
-    }
+    label_0: ;
+        if (n_0 > 0) {
+            int32_t n_0_0 = n_0 - 1;
+            n_0 = n_0_0;
+            goto label_0;
+        }
+        return;;
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
@@ -43,8 +43,7 @@ static STAINLESS_FUNC_PURE void countDown(int32_t n) {
             int32_t n_0_0 = n_0 - 1;
             n_0 = n_0_0;
             goto label_0;
-        }
-        return;;
+        };
 }
 
 void main(void) {

--- a/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
+++ b/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.c
@@ -44,7 +44,8 @@ static STAINLESS_FUNC_PURE void countDown(int32_t n) {
                 int32_t n_0_0 = n_0 - 1;
                 n_0 = n_0_0;
                 goto label_0;
-            };
+            }
+            return;;
     }
 }
 

--- a/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.h
+++ b/frontends/benchmarks/genc/valid/TailRecUnitNoExplicitEnd.expected.h
@@ -1,0 +1,38 @@
+#ifndef __TAILRECUNITNOEXPLICITEND_H__
+#define __TAILRECUNITNOEXPLICITEND_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/TwoOptions.expected.c
+++ b/frontends/benchmarks/genc/valid/TwoOptions.expected.c
@@ -1,0 +1,110 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "TwoOptions.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+/* -------------------------------------- enums ----- */
+
+typedef enum {
+  tag_None_int32,
+  tag_Some_int32
+} enum_Option_int32;
+
+typedef enum {
+  tag_None_int64,
+  tag_Some_int64
+} enum_Option_int64;
+
+
+/* ---------------------- data type definitions ----- */
+
+typedef struct {
+  int8_t extra;
+} None_int64;
+
+typedef struct {
+  int64_t v;
+} Some_int64;
+
+typedef union {
+  None_int64 None_int64_v;
+  Some_int64 Some_int64_v;
+} union_Option_int64;
+
+typedef struct {
+  enum_Option_int64 tag;
+  union_Option_int64 value;
+} Option_int64;
+
+typedef struct {
+  int8_t extra;
+} None_int32;
+
+typedef struct {
+  int32_t v;
+} Some_int32;
+
+typedef union {
+  None_int32 None_int32_v;
+  Some_int32 Some_int32_v;
+} union_Option_int32;
+
+typedef struct {
+  enum_Option_int32 tag;
+  union_Option_int32 value;
+} Option_int32;
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE bool isEmpty_int32(Option_int32 thiss);
+static STAINLESS_FUNC_PURE bool isEmpty_int64(Option_int64 thiss);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE bool isEmpty_int32(Option_int32 thiss) {
+    if (thiss.tag == tag_Some_int32) {
+        return false;
+    } else if (thiss.tag == tag_None_int32) {
+        return true;
+    }
+}
+
+static STAINLESS_FUNC_PURE bool isEmpty_int64(Option_int64 thiss) {
+    if (thiss.tag == tag_Some_int64) {
+        return false;
+    } else if (thiss.tag == tag_None_int64) {
+        return true;
+    }
+}
+
+STAINLESS_FUNC_PURE void main(void) {
+    
+}
+
+STAINLESS_FUNC_PURE void twoOptions(void) {
+    Option_int64 opt1 = (Option_int64) { .tag = tag_None_int64, .value = (union_Option_int64) { .None_int64_v = (None_int64) { .extra = 0 } } };
+    Option_int32 opt2 = (Option_int32) { .tag = tag_None_int32, .value = (union_Option_int32) { .None_int32_v = (None_int32) { .extra = 0 } } };
+    isEmpty_int64(opt1);
+    isEmpty_int32(opt2);
+}

--- a/frontends/benchmarks/genc/valid/TwoOptions.expected.c
+++ b/frontends/benchmarks/genc/valid/TwoOptions.expected.c
@@ -38,24 +38,6 @@ typedef enum {
 
 typedef struct {
   int8_t extra;
-} None_int64;
-
-typedef struct {
-  int64_t v;
-} Some_int64;
-
-typedef union {
-  None_int64 None_int64_v;
-  Some_int64 Some_int64_v;
-} union_Option_int64;
-
-typedef struct {
-  enum_Option_int64 tag;
-  union_Option_int64 value;
-} Option_int64;
-
-typedef struct {
-  int8_t extra;
 } None_int32;
 
 typedef struct {
@@ -71,6 +53,24 @@ typedef struct {
   enum_Option_int32 tag;
   union_Option_int32 value;
 } Option_int32;
+
+typedef struct {
+  int8_t extra;
+} None_int64;
+
+typedef struct {
+  int64_t v;
+} Some_int64;
+
+typedef union {
+  None_int64 None_int64_v;
+  Some_int64 Some_int64_v;
+} union_Option_int64;
+
+typedef struct {
+  enum_Option_int64 tag;
+  union_Option_int64 value;
+} Option_int64;
 
 
 

--- a/frontends/benchmarks/genc/valid/TwoOptions.expected.h
+++ b/frontends/benchmarks/genc/valid/TwoOptions.expected.h
@@ -1,0 +1,39 @@
+#ifndef __TWOOPTIONS_H__
+#define __TWOOPTIONS_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+STAINLESS_FUNC_PURE void main(void);
+STAINLESS_FUNC_PURE void twoOptions(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/Unsigned.expected.c
+++ b/frontends/benchmarks/genc/valid/Unsigned.expected.c
@@ -1,0 +1,131 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "Unsigned.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE uint64_t fa(uint64_t x, uint64_t y);
+static STAINLESS_FUNC_PURE uint32_t fb(uint32_t x, uint32_t y);
+static STAINLESS_FUNC_PURE uint16_t fc(uint16_t x, uint16_t y);
+static STAINLESS_FUNC_PURE uint8_t fd(uint8_t x, uint8_t y);
+static 
+void print(char c);
+static 
+void printU16(uint16_t x);
+static 
+void printU32(uint32_t x);
+static 
+void printU64(uint64_t x);
+static 
+void printU8(uint8_t x);
+static void println(void);
+static void printlnU16(uint16_t x);
+static void printlnU32(uint32_t x);
+static void printlnU64(uint64_t x);
+static void printlnU8(uint8_t x);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE uint64_t fa(uint64_t x, uint64_t y) {
+    return x + y;
+}
+
+static STAINLESS_FUNC_PURE uint32_t fb(uint32_t x, uint32_t y) {
+    return x - y;
+}
+
+static STAINLESS_FUNC_PURE uint16_t fc(uint16_t x, uint16_t y) {
+    return x * y;
+}
+
+static STAINLESS_FUNC_PURE uint8_t fd(uint8_t x, uint8_t y) {
+    return x / y;
+}
+
+void main(void) {
+    uint64_t a = fa(16, 84);
+    uint32_t b = fb(84, 14);
+    uint16_t c = fc(5, 7);
+    uint8_t d = fd(126, 3);
+    printlnU64(a);
+    printlnU32(b);
+    printlnU16(c);
+    printlnU8(d);
+}
+
+
+void print(char c) {
+  printf("%c", c);
+}
+      
+
+
+void printU16(uint16_t x) {
+  printf("%"PRIu16, x);
+}
+     
+
+
+void printU32(uint32_t x) {
+  printf("%"PRIu32, x);
+}
+     
+
+
+void printU64(uint64_t x) {
+  printf("%"PRIu64, x);
+}
+     
+
+
+void printU8(uint8_t x) {
+  printf("%"PRIu8, x);
+}
+     
+
+static void println(void) {
+    print('\n');
+}
+
+static void printlnU16(uint16_t x) {
+    printU16(x);
+    println();
+}
+
+static void printlnU32(uint32_t x) {
+    printU32(x);
+    println();
+}
+
+static void printlnU64(uint64_t x) {
+    printU64(x);
+    println();
+}
+
+static void printlnU8(uint8_t x) {
+    printU8(x);
+    println();
+}

--- a/frontends/benchmarks/genc/valid/Unsigned.expected.h
+++ b/frontends/benchmarks/genc/valid/Unsigned.expected.h
@@ -1,0 +1,40 @@
+#ifndef __UNSIGNED_H__
+#define __UNSIGNED_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+
+#endif

--- a/frontends/benchmarks/genc/valid/WhileInLet.expected.c
+++ b/frontends/benchmarks/genc/valid/WhileInLet.expected.c
@@ -1,0 +1,34 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "WhileInLet.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+
+/* ----------------------- function definitions ----- */
+
+STAINLESS_FUNC_PURE void main(void) {
+    while (false) {
+        
+    }
+}

--- a/frontends/benchmarks/genc/valid/WhileInLet.expected.h
+++ b/frontends/benchmarks/genc/valid/WhileInLet.expected.h
@@ -1,0 +1,38 @@
+#ifndef __WHILEINLET_H__
+#define __WHILEINLET_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+STAINLESS_FUNC_PURE void main(void);
+
+#endif

--- a/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
+++ b/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
@@ -21,12 +21,6 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
   val updateExpected: Boolean =
     sys.env.get("STAINLESS_GENC_UPDATE_EXPECTED").exists(v => v == "1" || v.equalsIgnoreCase("true"))
 
-  // Benchmarks whose *generated binary* currently does not terminate, so we cannot run it
-  // to compare its output. Their C is still generated, compiled and snapshotted; only the
-  // execution/output check is ignored. See the GenC tail-recursion infinite-loop issue
-  // (the generated while(true) loop lacks a terminating return for a non-Block Unit body).
-  val nonTerminatingBenchmarks = Set("TailRecUnitNoExplicitEnd.scala")
-
   val validFiles = resourceFiles("genc/valid", _.endsWith(".scala"), false).map(_.getPath)
   val invalidFiles = resourceFiles("genc/invalid", _.endsWith(".scala"), false).map(_.getPath)
   val tailrecFiles = validFiles.filter(_.toLowerCase.contains("tailrec".toLowerCase)).map { path =>
@@ -106,17 +100,9 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
   for (case (file, checkFile) <- tailrecFiles) {
     val name = file.split("/").last
     val checkValue = Files.readAllLines(Paths.get(checkFile)).toArray.mkString
-    val testName = s"Checking that $name outputs $checkValue"
-    // Run the compiled binary and check its output, unless the binary is known not to
-    // terminate (see genc-tailrec-unit-infinite-loop.md), in which case we `ignore` the
-    // test so the suite does not hang.
-    if (nonTerminatingBenchmarks.contains(name)) {
-      ignore(testName) {}
-    } else {
-      test(testName) {
-        val output = runCHelper(file)
-        assert(output == checkValue, s"Output '$output' should be $checkValue")
-      }
+    test(s"Checking that $name outputs $checkValue") {
+      val output = runCHelper(file)
+      assert(output == checkValue, s"Output '$output' should be $checkValue")
     }
   }
 

--- a/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
+++ b/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
@@ -8,12 +8,30 @@ import org.scalatest.funsuite.AnyFunSuite
 import org.scalatest.matchers.should.Matchers
 
 import java.nio.file.{Paths, Files}
+import java.nio.charset.StandardCharsets
 import java.io.File
 import java.io.PrintWriter
 
 import Utils._
 
 class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with Matchers {
+  // When STAINLESS_GENC_UPDATE_EXPECTED is set to "1" or "true", the golden `.expected.c`
+  // and `.expected.h` files are (re)generated from the current output instead of being
+  // compared against. Use this to bootstrap or intentionally update the snapshots.
+  val updateExpected: Boolean =
+    sys.env.get("STAINLESS_GENC_UPDATE_EXPECTED").exists(v => v == "1" || v.equalsIgnoreCase("true"))
+
+  // Benchmarks whose *generated binary* currently does not terminate, so we cannot run it
+  // to compare its output. Their C is still generated, compiled and snapshotted; only the
+  // execution/output check is ignored. See the GenC tail-recursion infinite-loop issue
+  // (the generated while(true) loop lacks a terminating return for a non-Block Unit body).
+  val nonTerminatingBenchmarks = Set("TailRecUnitNoExplicitEnd.scala")
+
+  // Benchmarks whose generated C is not deterministic across runs (Set-derived enum/union
+  // ordering, and fresh-variable numbering), so a golden snapshot would be flaky. Their C is
+  // still generated, compiled and executed; only the golden comparison is skipped.
+  val nonDeterministicBenchmarks = Set("RefInCtor.scala", "ImageProcessing.scala")
+
   val validFiles = resourceFiles("genc/valid", _.endsWith(".scala"), false).map(_.getPath)
   val invalidFiles = resourceFiles("genc/invalid", _.endsWith(".scala"), false).map(_.getPath)
   val tailrecFiles = validFiles.filter(_.toLowerCase.contains("tailrec".toLowerCase)).map { path =>
@@ -43,10 +61,20 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
 
   for (file <- validFiles) {
     val cFile = file.replace(".scala", ".c")
+    val hFile = file.replace(".scala", ".h")
     val outFile = file.replace(".scala", ".out")
     test(s"stainless --genc --genc-output=$cFile $file") {
       runMainWithArgs(Array(file) :+ "--genc" :+ s"--genc-output=$cFile")
       assert(Files.exists(Paths.get(cFile)))
+      assert(Files.exists(Paths.get(hFile)))
+      // Snapshot the generated C and header against golden files so that unintended
+      // changes to the emitted code (not just compilation/behaviour) are caught. The
+      // golden files live in the source tree (not the copied test resources) so they
+      // can be committed. Skipped for benchmarks with non-deterministic output.
+      if (!nonDeterministicBenchmarks.contains(file.split("/").last)) {
+        checkGolden(cFile, sourceGoldenPath(file, ".expected.c"))
+        checkGolden(hFile, sourceGoldenPath(file, ".expected.h"))
+      }
       val gccCompile = s"gcc $cFile -o $outFile"
       ctx.reporter.info(s"Running: $gccCompile")
       val (std, exitCode) = runCommand(gccCompile)
@@ -83,10 +111,66 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
   }
 
   for (case (file, checkFile) <- tailrecFiles) {
-    test(s"Checking that ${file.split("/").last} outputs ${Files.readAllLines(Paths.get(checkFile)).toArray.mkString}") {
-      val output = runCHelper(file)
-      val checkValue = Files.readAllLines(Paths.get(checkFile)).toArray.mkString
-      assert(output == checkValue, s"Output '$output' should be $checkValue")
+    val name = file.split("/").last
+    val checkValue = Files.readAllLines(Paths.get(checkFile)).toArray.mkString
+    val testName = s"Checking that $name outputs $checkValue"
+    // Run the compiled binary and check its output, unless the binary is known not to
+    // terminate (see genc-tailrec-unit-infinite-loop.md), in which case we `ignore` the
+    // test so the suite does not hang.
+    if (nonTerminatingBenchmarks.contains(name)) {
+      ignore(testName) {}
+    } else {
+      test(testName) {
+        val output = runCHelper(file)
+        assert(output == checkValue, s"Output '$output' should be $checkValue")
+      }
+    }
+  }
+
+  /** Map a benchmark resource path to the corresponding golden file in the source tree.
+    *
+    * The genc benchmarks are copied into the test class output directory, so `resourceFiles`
+    * returns paths such as `<root>/frontends/dotty/target/.../it-classes/genc/valid/X.scala`.
+    * Golden files must instead live under `<root>/frontends/benchmarks/genc/valid/` so they
+    * are part of the repository and can be committed.
+    */
+  def sourceGoldenPath(scalaResourcePath: String, ext: String): String = {
+    val marker = "/it-classes/"
+    val i = scalaResourcePath.indexOf(marker)
+    require(i >= 0, s"Unexpected benchmark resource path (no '$marker'): $scalaResourcePath")
+    val root = scalaResourcePath.substring(0, scalaResourcePath.indexOf("/frontends/"))
+    val rel = scalaResourcePath.substring(i + marker.length) // e.g. genc/valid/X.scala
+    s"$root/frontends/benchmarks/${rel.stripSuffix(".scala") + ext}"
+  }
+
+  /** Compare the contents of `generatedFile` against the golden `expectedFile`.
+    *
+    * In update mode (STAINLESS_GENC_UPDATE_EXPECTED), the golden file is (over)written
+    * with the freshly generated contents. Otherwise the generated contents must match the
+    * golden file exactly, and a missing golden file is a failure pointing at the update flag.
+    */
+  def checkGolden(generatedFile: String, expectedFile: String): Unit = {
+    val generated = new String(Files.readAllBytes(Paths.get(generatedFile)), StandardCharsets.UTF_8)
+    val expectedPath = Paths.get(expectedFile)
+    if (updateExpected) {
+      Files.write(expectedPath, generated.getBytes(StandardCharsets.UTF_8))
+      ctx.reporter.info(s"Updated golden file: $expectedFile")
+    } else {
+      assert(
+        Files.exists(expectedPath),
+        s"Golden file $expectedFile is missing. Re-run with STAINLESS_GENC_UPDATE_EXPECTED=1 to create it."
+      )
+      val expected = new String(Files.readAllBytes(expectedPath), StandardCharsets.UTF_8)
+      if (generated != expected) {
+        // Include a unified diff (expected vs generated) in the failure message so the
+        // mismatch is actionable from CI logs alone, without local reproduction.
+        val (diffOut, _) = runCommand(s"diff -u $expectedFile $generatedFile")
+        fail(
+          s"Generated output for $generatedFile does not match golden file $expectedFile. " +
+            s"If this change is intended, re-run with STAINLESS_GENC_UPDATE_EXPECTED=1 to update it.\n" +
+            s"--- diff (expected vs generated) ---\n" + diffOut.mkString("\n")
+        )
+      }
     }
   }
 

--- a/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
+++ b/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
@@ -27,11 +27,6 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
   // (the generated while(true) loop lacks a terminating return for a non-Block Unit body).
   val nonTerminatingBenchmarks = Set("TailRecUnitNoExplicitEnd.scala")
 
-  // Benchmarks whose generated C is not deterministic across runs (Set-derived enum/union
-  // ordering, and fresh-variable numbering), so a golden snapshot would be flaky. Their C is
-  // still generated, compiled and executed; only the golden comparison is skipped.
-  val nonDeterministicBenchmarks = Set("RefInCtor.scala", "ImageProcessing.scala")
-
   val validFiles = resourceFiles("genc/valid", _.endsWith(".scala"), false).map(_.getPath)
   val invalidFiles = resourceFiles("genc/invalid", _.endsWith(".scala"), false).map(_.getPath)
   val tailrecFiles = validFiles.filter(_.toLowerCase.contains("tailrec".toLowerCase)).map { path =>
@@ -70,11 +65,9 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
       // Snapshot the generated C and header against golden files so that unintended
       // changes to the emitted code (not just compilation/behaviour) are caught. The
       // golden files live in the source tree (not the copied test resources) so they
-      // can be committed. Skipped for benchmarks with non-deterministic output.
-      if (!nonDeterministicBenchmarks.contains(file.split("/").last)) {
-        checkGolden(cFile, sourceGoldenPath(file, ".expected.c"))
-        checkGolden(hFile, sourceGoldenPath(file, ".expected.h"))
-      }
+      // can be committed.
+      checkGolden(cFile, sourceGoldenPath(file, ".expected.c"))
+      checkGolden(hFile, sourceGoldenPath(file, ".expected.h"))
       val gccCompile = s"gcc $cFile -o $outFile"
       ctx.reporter.info(s"Running: $gccCompile")
       val (std, exitCode) = runCommand(gccCompile)

--- a/frontends/dotty/src/it/scala/stainless/TailRecGenCSuite.scala
+++ b/frontends/dotty/src/it/scala/stainless/TailRecGenCSuite.scala
@@ -14,10 +14,6 @@ import java.io.PrintWriter
 import Utils._
 
 class TailRecGenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with Matchers {
-  // Benchmarks whose generated binary currently does not terminate; their output check is
-  // ignored so the suite does not hang. See the GenC tail-recursion infinite-loop issue.
-  val nonTerminatingBenchmarks = Set("TailRecUnitNoExplicitEnd.scala")
-
   val validFiles = resourceFiles("genc/valid", _.endsWith(".scala"), false).map(_.getPath)
   val tailrecFiles = validFiles.filter(_.toLowerCase.contains("tailrec".toLowerCase)).map { path =>
     val checkFile = path.replace(".scala", ".check")
@@ -60,14 +56,9 @@ class TailRecGenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUti
   for (case (file, checkFile) <- tailrecFiles) {
     val name = file.split("/").last
     val checkValue = Files.readAllLines(Paths.get(checkFile)).toArray.mkString
-    val testName = s"Checking that $name outputs $checkValue"
-    if (nonTerminatingBenchmarks.contains(name)) {
-      ignore(testName) {}
-    } else {
-      test(testName) {
-        val output = runCHelper(file)
-        assert(output == checkValue, s"Output '$output' should be $checkValue")
-      }
+    test(s"Checking that $name outputs $checkValue") {
+      val output = runCHelper(file)
+      assert(output == checkValue, s"Output '$output' should be $checkValue")
     }
   }
 

--- a/frontends/dotty/src/it/scala/stainless/TailRecGenCSuite.scala
+++ b/frontends/dotty/src/it/scala/stainless/TailRecGenCSuite.scala
@@ -14,6 +14,10 @@ import java.io.PrintWriter
 import Utils._
 
 class TailRecGenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with Matchers {
+  // Benchmarks whose generated binary currently does not terminate; their output check is
+  // ignored so the suite does not hang. See the GenC tail-recursion infinite-loop issue.
+  val nonTerminatingBenchmarks = Set("TailRecUnitNoExplicitEnd.scala")
+
   val validFiles = resourceFiles("genc/valid", _.endsWith(".scala"), false).map(_.getPath)
   val tailrecFiles = validFiles.filter(_.toLowerCase.contains("tailrec".toLowerCase)).map { path =>
     val checkFile = path.replace(".scala", ".check")
@@ -54,10 +58,16 @@ class TailRecGenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUti
   }
 
   for (case (file, checkFile) <- tailrecFiles) {
-    test(s"Checking that ${file.split("/").last} outputs ${Files.readAllLines(Paths.get(checkFile)).toArray.mkString}") {
-      val output = runCHelper(file)
-      val checkValue = Files.readAllLines(Paths.get(checkFile)).toArray.mkString
-      assert(output == checkValue, s"Output '$output' should be $checkValue")
+    val name = file.split("/").last
+    val checkValue = Files.readAllLines(Paths.get(checkFile)).toArray.mkString
+    val testName = s"Checking that $name outputs $checkValue"
+    if (nonTerminatingBenchmarks.contains(name)) {
+      ignore(testName) {}
+    } else {
+      test(testName) {
+        val output = runCHelper(file)
+        assert(output == checkValue, s"Output '$output' should be $checkValue")
+      }
     }
   }
 


### PR DESCRIPTION
Compare each genc/valid benchmark's generated .c and .h against committed .expected.c/.expected.h golden files, so unintended changes to the emitted code (not just compilation/behaviour) are caught. Set STAINLESS_GENC_UPDATE_EXPECTED=1 to (re)generate the goldens; on mismatch the test prints a unified diff for CI.

The golden files use an .expected.c/.expected.h suffix (kept out of the *.c/*.h gitignore via negation) so they are tracked and get C syntax highlighting.

Two GenC bugs surfaced:
- ~TailRecUnitNoExplicitEnd generates a non-terminating while(true) loop, so its execution test is ignored (nonTerminatingBenchmarks) to avoid hanging the suite.~
  Fixed in 94fd50b.
- ~RefInCtor and ImageProcessing have non-deterministic C output (Set-derived enum/union ordering and fresh-variable numbering), so they are excluded from the golden comparison (nonDeterministicBenchmarks).~
  Fixed in a2be173.