### PR TITLE
Fix extraction of opaque type aliases used outside their defining scope

### DIFF
--- a/frontends/benchmarks/dotty-specific/invalid/OpaqueTypes2Invalid.scala
+++ b/frontends/benchmarks/dotty-specific/invalid/OpaqueTypes2Invalid.scala
@@ -1,0 +1,19 @@
+object OpaqueTypes2Invalid {
+  opaque type Positive <: BigInt = BigInt
+  object Positive {
+    def apply(b: BigInt): Positive = {
+      require(b >= 0)
+      b
+    }
+  }
+}
+
+// Guards against the precondition VC silently disappearing: when the bounded
+// opaque type is extracted as an abstract type instead of an alias, the type
+// encoding boxes `apply`'s body and swallows its `require`, making this call
+// verify vacuously. Extracting the alias keeps the precondition, so this
+// violating call must be reported as invalid.
+object OpaqueTypes2InvalidUse {
+  import OpaqueTypes2Invalid.*
+  def bad: BigInt = Positive(BigInt(-1))
+}

--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypes2.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypes2.scala
@@ -1,0 +1,21 @@
+object OpaqueTypes2 {
+  opaque type Positive <: BigInt = BigInt
+  object Positive {
+    def apply(b: BigInt): Positive = {
+      require(b >= 0)
+      b
+    }
+  }
+}
+
+// Unlike OpaqueTypes1, the opaque type is used outside its defining scope:
+// `+` is available through the declared bound `<: BigInt`, but the receiver's
+// type is the opaque alias, which extraction must resolve to dispatch the call.
+object OpaqueTypes2Use {
+  import OpaqueTypes2.*
+  def test(p: Positive, q: Positive): BigInt = {
+    p + q
+  }
+
+  def test2: BigInt = Positive(BigInt(1)) + Positive(BigInt(2))
+}

--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypes3.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypes3.scala
@@ -1,0 +1,20 @@
+object OpaqueTypes3 {
+  opaque type Tagged[T] <: BigInt = BigInt
+  object Tagged {
+    def apply[T](b: BigInt): Tagged[T] = {
+      require(b >= 0)
+      b
+    }
+  }
+}
+
+// Like OpaqueTypes2, but with an applied (parameterized) opaque type
+// constructor used outside its defining scope.
+object OpaqueTypes3Use {
+  import OpaqueTypes3.*
+  def test(p: Tagged[Int], q: Tagged[Int]): BigInt = {
+    p + q
+  }
+
+  def test2: BigInt = Tagged[Int](BigInt(1)) + Tagged[Int](BigInt(2))
+}

--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypesRefinements.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypesRefinements.scala
@@ -1,0 +1,21 @@
+object OpaqueTypesRefinements {
+  opaque type UInt32 = {v: BigInt with v >= 0 && v <= BigInt(0xFFFFFFFFL)}
+  object UInt32 {
+    def apply(v: BigInt with v >= 0 && v <= BigInt(0xFFFFFFFFL)): UInt32 = v
+  }
+  extension (v: UInt32)
+    def foo(other: UInt32 with v + other <= BigInt(0xFFFFFFFFL)): UInt32 = v + other
+}
+
+// Regression test for the "Unsupported call to + on v$N" extraction error:
+// at the call site below, the qualifier of `foo`'s parameter is instantiated
+// outside the defining scope of the opaque type, where `+` is dispatched on a
+// receiver whose type is the opaque alias. Extraction must resolve the alias
+// to its translucent super type for the dispatch to succeed.
+object OpaqueTypesRefinementsUse {
+  import OpaqueTypesRefinements.*
+  def test(): Unit = {
+    UInt32(BigInt(123)).foo(UInt32(BigInt(123)))
+    ()
+  }
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -458,20 +458,25 @@ class CodeExtraction(inoxCtx: inox.Context,
         val typeParamsSymbols = typeParamSymbols(tparams)
         val typeParams = extractTypeParams(typeParamsSymbols)
         val tpCtx = dctx.withNewTypeParams(typeParamsSymbols zip typeParams)
-        val typeBody = extractType(body)(using tpCtx)
+        val typeBody = body match {
+          // Bounded opaque type constructor: extract the alias, as below.
+          case TypeBoundsTree(_, _, alias) if !alias.isEmpty => extractType(alias)(using tpCtx)
+          case _ => extractType(body)(using tpCtx)
+        }
         (typeParams, typeBody, false)
+
+      // A TypeBoundsTree with a non-empty alias is a bounded opaque type
+      // (e.g. `opaque type Positive <: BigInt = BigInt`): extract it as an
+      // alias to its right-hand side rather than as an abstract type, like
+      // we do for unbounded opaque types.
+      case TypeBoundsTree(_, _, alias) if !alias.isEmpty =>
+        (Seq.empty, extractType(alias), false)
 
       case TypeBoundsTree(lo, hi, _) =>
         val (loType, hiType) = (extractType(lo), extractType(hi))
         (Seq.empty, xt.TypeBounds(loType, hiType, Seq.empty), true)
 
       case tpt =>
-        val tpe =
-          if (tpt.symbol `is` Opaque)
-            tpt.symbol.typeRef.translucentSuperType
-          else
-            tpt.tpe
-
         (Seq.empty, extractType(tpt), false)
     }
 
@@ -2708,12 +2713,25 @@ class CodeExtraction(inoxCtx: inox.Context,
           case None => xt.ClassType(id, args map extractType)
         }
 
+      // This case must come before the two below: isAbstractOrAliasType is also true for
+      // opaque aliases, but widenDealiasKeepRefiningAnnots does not unfold them outside
+      // their defining scope, so they would be extracted symbolically instead of resolved.
+      case tr: TypeRef if dctx.resolveTypes && tr.symbol.isOpaqueAlias =>
+        extractType(tr.translucentSuperType)
+
       case tr: TypeRef if dctx.resolveTypes && tr.symbol.isAbstractOrAliasType =>
         extractType(tr.widenDealiasKeepRefiningAnnots)(using dctx.setResolveTypes(tr != tr.widenDealiasKeepRefiningAnnots), pos)
 
       case tr @ TypeRef(prefix, _) if tr.symbol.isAbstractOrAliasType || tr.symbol.isOpaqueAlias =>
         val selector = extractPrefix(prefix)
         xt.TypeApply(xt.TypeSelect(selector, getIdentifier(tr.symbol)), Seq.empty)
+
+      // As for the unapplied opaque alias case above: opaque aliases must be
+      // resolved via their translucent super type (beta-reduced with the type
+      // arguments), which widenDealiasKeepRefiningAnnots does not reveal
+      // outside their defining scope.
+      case at @ AppliedType(tr: TypeRef, _) if dctx.resolveTypes && tr.symbol.isOpaqueAlias =>
+        extractType(at.translucentSuperType)
 
       case at@AppliedType(tr @ TypeRef(prefix, _), args) if dctx.resolveTypes && tr.symbol.isAbstractOrAliasType =>
         extractType(at.derivedAppliedType(tr.widenDealiasKeepRefiningAnnots, args))(using dctx.setResolveTypes(tr != tr.widenDealiasKeepRefiningAnnots), pos)
@@ -2739,9 +2757,6 @@ class CodeExtraction(inoxCtx: inox.Context,
         val vd = dctx.depParams(ref.paramName).setPos(pos)
         val selector = getIdentifier(tr.symbol)
         xt.TypeApply(xt.TypeSelect(Some(vd.toVariable), selector).setPos(pos), Seq.empty)
-
-      case tr: TypeRef if tr.symbol.isOpaqueAlias && dctx.resolveTypes =>
-        extractType(tr.translucentSuperType)
 
       case tt @ TypeRef(prefix: TermRef, name) if prefix.underlying.classSymbol.typeParams.exists(_.name == name) =>
         extractType(TypeRef(prefix.widenTermRefExpr, name))


### PR DESCRIPTION
Extraction failed with `Unsupported call to + on v$4` on primitive calls whose receiver has an opaque type seen from outside its defining scope. This was previously unobservable (such calls don't typecheck in plain Scala) but qualified types make it reachable: a dependent qualifier typed inside the scope (e.g. `other: UInt32 with v + other <= max`) is instantiated at call sites outside it.

## Changes

- `extractType`: move the opaque-alias resolution case (`translucentSuperType`) above the `isAbstractOrAliasType` cases that shadowed it; `isAbstractOrAliasType` is also true for opaque aliases, but `widenDealiasKeepRefiningAnnots` does not unfold them outside their scope, so they were extracted symbolically and primitive dispatch fell through. Remove the now-redundant unreachable copy of that case.
- `extractType`: add the analogous case for *applied* (parameterized) opaque aliases, beta-reducing via `AppliedType.translucentSuperType`.
- `extractTypeDef`: extract bounded opaque types (`TypeBoundsTree` with a non-empty `alias`, incl. under `LambdaTypeTree`) as aliases instead of abstract types, and drop the dead `translucentSuperType` computation.
- New benchmarks: `OpaqueTypesRefinements` (escaping qualifier), `OpaqueTypes2` / `OpaqueTypes3` (bounded / parameterized opaque cross-scope), and `OpaqueTypes2Invalid`, which guards the soundness fix (a `valid` test would pass vacuously if the precondition VC disappears again).

## History

- The resolve-through-`translucentSuperType` behavior was introduced in b409ab5f4 ("Dealias opaque types to their translucent super type") and extended to type definitions in 7675362bf ("Fix handling of opaque type aliases").
- Both were silently disabled by the Scala 3 frontend port (4f748fb63): the type-member case became unreachable and the `extractTypeDef` handling became dead code.
