### PR TITLE
genc: Add option to compile `BigInt` to `uint32_t`

### DIFF
--- a/core/src/main/scala/stainless/MainHelpers.scala
+++ b/core/src/main/scala/stainless/MainHelpers.scala
@@ -67,6 +67,9 @@ trait MainHelpers extends inox.MainHelpers { self =>
     optJson -> Description(General, "Output verification and termination reports to a JSON file"),
     genc.optOutputFile -> Description(General, "File name for GenC output"),
     genc.optIncludes -> Description(General, "Add includes in GenC output"),
+    genc.optBigIntAs -> Description(General, "Compile BigInt to the given C type (only uint32 is supported).\n" +
+      "Requires verifying with the same option: it adds VCs checking that every\n" +
+      "BigInt value stays within [0, 2^32-1]"),
     optWatch -> Description(General, "Re-run stainless upon file changes"),
     optCompact -> Description(General, "Print only invalid elements of summaries"),
     optExtendedSummary -> Description(General, "Print an extended summary of all Stainless phases"),

--- a/core/src/main/scala/stainless/extraction/package.scala
+++ b/core/src/main/scala/stainless/extraction/package.scala
@@ -64,6 +64,7 @@ package object extraction {
     "ComputeDependencies"       -> "(GenC) Compute the dependencies of a given definition",
     "ComputeFunCtx"             -> "(GenC) Compute the context of each given function definition",
     "GhostElimination"          -> "(GenC) Remove ghost code",
+    "BigIntLowering"            -> "(GenC) Lower BigInt (IntegerType) to uint32_t (with --genc-bigint-as=uint32)",
     "Scala2IR"                  -> "(GenC) Convert the Stainless AST into GenC's IR",
     "StructInlining"            -> "(GenC) Inline structs which have just one member",
     "Normalisation"             -> "(GenC) Normalise IR to match the C execution model",

--- a/core/src/main/scala/stainless/genc/GenerateC.scala
+++ b/core/src/main/scala/stainless/genc/GenerateC.scala
@@ -14,6 +14,7 @@ object GenerateC {
     val arrayLengthsMap = ArraysLengthsExtraction.get(symbols)
 
     NamedLeonPhase("GhostElimination", new GhostEliminationPhase) `andThen`
+    NamedLeonPhase("BigIntLowering", new BigIntLoweringPhase) `andThen`
     NamedLeonPhase("TrimSymbols", new TrimSymbols) `andThen`
     NamedLeonPhase("ComputeFunCtx", LeonPipeline.both(NoopPhase[Symbols], new ComputeFunCtxPhase)) `andThen`
     NamedLeonPhase("Scala2IR", Scala2IRPhase(arrayLengthsMap)) `andThen`

--- a/core/src/main/scala/stainless/genc/package.scala
+++ b/core/src/main/scala/stainless/genc/package.scala
@@ -12,12 +12,30 @@ package object genc {
     val parser = inox.OptionParsers.stringParser
   }
 
+  // How GenC compiles BigInt (IntegerType). Empty (the default) means BigInt is rejected.
+  // The same option must be passed to verification, where it injects VCs checking that
+  // every BigInt operation's mathematical result fits in the chosen representation.
+  object optBigIntAs extends inox.OptionDef[String] {
+    val name = "genc-bigint-as"
+    val default = ""
+    val usageRhs = "uint32"
+    val parser = inox.OptionParsers.stringParser
+  }
+
   object optIncludes extends inox.OptionDef[Seq[String]] {
     val name = "genc-includes"
     val default = Seq()
     val usageRhs = "file1.h,file2.h,..."
     val parser = inox.OptionParsers.seqParser(inox.OptionParsers.stringParser)
   }
+
+  def bigIntToUInt32(ctx: inox.Context): Boolean =
+    ctx.options.findOptionOrDefault(optBigIntAs) match {
+      case "" => false
+      case "uint32" => true
+      case other =>
+        ctx.reporter.fatalError(s"Unsupported --genc-bigint-as value: $other (supported: uint32)")
+    }
 
   // FIXME: see leon definition
   def pathFromRoot(df: Definition)(using Symbols): List[Definition] = List(df)

--- a/core/src/main/scala/stainless/genc/phases/BigIntLoweringPhase.scala
+++ b/core/src/main/scala/stainless/genc/phases/BigIntLoweringPhase.scala
@@ -1,0 +1,194 @@
+/* Copyright 2009-2021 EPFL, Lausanne */
+
+package stainless
+package genc
+package phases
+
+import extraction._
+import extraction.throwing.{ trees => tt }
+
+/**
+ * Lower `BigInt` (IntegerType) to 32-bit unsigned bitvectors, so that downstream phases
+ * compile it to C `uint32_t` (enabled by `--genc-bigint-as=uint32`).
+ *
+ * This mapping is only sound for programs verified with the same option: verification
+ * then proves that every BigInt value stays within [0, 2^32-1] (see
+ * [[stainless.verification.AssertionInjector]]), so by induction every runtime uint32
+ * value equals the BigInt value of the source semantics. On non-negative operands, C's
+ * `/` and `%` coincide with the BigInt Division/Remainder semantics, and `mod` coincides
+ * with `%`, so `mod` is lowered to `%`.
+ *
+ * Preconditions of exported functions are compiled to *runtime* checks against
+ * unverified C callers, so no VC can bound arithmetic inside them; BigInt arithmetic is
+ * therefore rejected there (comparisons between already-computed values are exact and
+ * remain allowed). This phase runs after [[GhostEliminationPhase]], so ghost BigInt code
+ * is already gone and preconditions of exported functions have been folded into
+ * `Assert(cond, Some("Dynamic precondition check"), _)`.
+ */
+class BigIntLowering(override val s: tt.type,
+                     override val t: throwing.Trees)
+                    (val symbols: tt.Symbols,
+                     val context: inox.Context) extends inox.transformers.Transformer {
+
+  case class Env()
+
+  private val uint32Max = BigInt(2).pow(32) - 1
+
+  private def uint32 = t.BVType(false, 32)
+
+  override def transform(tpe: s.Type, env: Env): t.Type = tpe match {
+    case s.IntegerType() => t.BVType(false, 32).copiedFrom(tpe)
+    case _ => super.transform(tpe, env)
+  }
+
+  override def transform(expr: s.Expr, env: Env): t.Expr = expr match {
+    case s.IntegerLiteral(v) =>
+      if (v < 0 || v > uint32Max)
+        context.reporter.fatalError(expr.getPos,
+          s"BigInt literal $v does not fit in uint32_t (required by --genc-bigint-as=uint32)")
+      t.BVLiteral(false, v, 32).copiedFrom(expr)
+
+    // BV -> BigInt conversions; exact thanks to the [0, 2^32-1] VCs injected by
+    // verification under --genc-bigint-as=uint32 (unsigned sources up to 32 bits
+    // are in range by construction).
+    case s.BVToInt(e) => e.getType(using symbols) match {
+      case s.BVType(false, 32) =>
+        transform(e, env)
+      case s.BVType(false, size) if size < 32 =>
+        t.BVWideningCast(transform(e, env), uint32.copiedFrom(expr)).copiedFrom(expr)
+      case s.BVType(false, 64) =>
+        t.BVNarrowingCast(transform(e, env), uint32.copiedFrom(expr)).copiedFrom(expr)
+      case s.BVType(true, 32) =>
+        t.BVSignedToUnsigned(transform(e, env)).copiedFrom(expr)
+      case s.BVType(true, size) if size < 32 =>
+        t.BVSignedToUnsigned(
+          t.BVWideningCast(transform(e, env), t.BVType(true, 32).copiedFrom(expr)).copiedFrom(expr)
+        ).copiedFrom(expr)
+      case s.BVType(true, 64) =>
+        // value in [0, 2^32-1]: go through uint64 (a direct narrowing to int32 could not
+        // represent values above 2^31 - 1)
+        t.BVNarrowingCast(
+          t.BVSignedToUnsigned(transform(e, env)).copiedFrom(expr),
+          uint32.copiedFrom(expr)
+        ).copiedFrom(expr)
+      case tpe =>
+        context.reporter.fatalError(expr.getPos, s"Unexpected BigInt conversion from type ${tpe.asString(using s.PrinterOptions.fromContext(context))}")
+    }
+
+    // BigInt -> BV conversions; exact thanks to the target-range VCs injected by
+    // verification under --genc-bigint-as=uint32.
+    case s.IntToBV(size, signed, e) =>
+      val e32 = transform(e, env)
+      (signed, size) match {
+        case (false, 32) => e32
+        case (false, sz) if sz < 32 =>
+          t.BVNarrowingCast(e32, t.BVType(false, sz).copiedFrom(expr)).copiedFrom(expr)
+        case (false, 64) =>
+          t.BVWideningCast(e32, t.BVType(false, 64).copiedFrom(expr)).copiedFrom(expr)
+        case (true, 32) =>
+          t.BVUnsignedToSigned(e32).copiedFrom(expr)
+        case (true, sz) if sz < 32 =>
+          t.BVUnsignedToSigned(
+            t.BVNarrowingCast(e32, t.BVType(false, sz).copiedFrom(expr)).copiedFrom(expr)
+          ).copiedFrom(expr)
+        case (true, 64) =>
+          t.BVUnsignedToSigned(
+            t.BVWideningCast(e32, t.BVType(false, 64).copiedFrom(expr)).copiedFrom(expr)
+          ).copiedFrom(expr)
+        case _ =>
+          context.reporter.fatalError(expr.getPos, s"Unsupported BigInt conversion to a $size-bit bitvector")
+      }
+
+    // On non-negative operands, mod coincides with % (both operands are in
+    // [0, 2^32-1] by the verified invariant).
+    case s.Modulo(a, b) if expr.getType(using symbols) == s.IntegerType() =>
+      t.Remainder(transform(a, env), transform(b, env)).copiedFrom(expr)
+
+    case s.StringLength(_) | s.SubString(_, _, _) =>
+      context.reporter.fatalError(expr.getPos,
+        "String operations returning or taking BigInt are not supported with --genc-bigint-as=uint32")
+
+    // Preconditions of exported functions run as unverified C-side checks: no VC can
+    // bound their arithmetic, so only arithmetic-free conditions are allowed.
+    case s.Assert(cond, Some("Dynamic precondition check"), _) =>
+      checkExportedPreconditionArithmeticFree(cond)
+      super.transform(expr, env)
+
+    case _ => super.transform(expr, env)
+  }
+
+  private def checkExportedPreconditionArithmeticFree(cond: s.Expr): Unit = {
+    import s._
+    exprOps.preTraversal {
+      case e @ (Plus(_, _) | Minus(_, _) | Times(_, _) | UMinus(_) | Division(_, _) | Remainder(_, _) | Modulo(_, _))
+          if e.getType(using symbols) == IntegerType() =>
+        context.reporter.fatalError(e.getPos,
+          "BigInt arithmetic is not allowed in preconditions of exported functions with " +
+          "--genc-bigint-as=uint32: the check runs at runtime on unverified C inputs, where " +
+          "the arithmetic itself could overflow. Only comparisons are allowed here.")
+      case _ => ()
+    }(cond)
+  }
+
+  def transform(cd: s.ClassDef, env: Env): t.ClassDef = {
+    new t.ClassDef(
+      cd.id,
+      cd.tparams.map(transform(_, env)),
+      cd.parents.map(transform(_, env)).map(_.asInstanceOf[t.ClassType]),
+      cd.fields.map(transform(_, env)),
+      cd.flags.map(transform(_, env))
+    ).setPos(cd)
+  }
+
+  def transform(cons: s.ADTConstructor, env: Env): t.ADTConstructor = {
+    new t.ADTConstructor(
+      cons.id,
+      cons.sort,
+      cons.fields.map(transform(_, env))
+    ).setPos(cons)
+  }
+
+  def transform(sort: s.ADTSort, env: Env): t.ADTSort = {
+    new t.ADTSort(
+      sort.id,
+      sort.tparams.map(transform(_, env)),
+      sort.constructors.map(transform(_, env)),
+      sort.flags.map(transform(_, env))
+    ).setPos(sort)
+  }
+
+  def transform(fd: s.FunDef, env: Env): t.FunDef = {
+    new t.FunDef(
+      fd.id,
+      fd.tparams.map(transform(_, env)),
+      fd.params.map(transform(_, env)),
+      transform(fd.returnType, env),
+      transform(fd.fullBody, env),
+      fd.flags.map(transform(_, env))
+    ).setPos(fd)
+  }
+
+  def transform(symbols: s.Symbols): t.Symbols = {
+    val emptyEnv = Env()
+    t.NoSymbols
+      .withFunctions(symbols.functions.values.toSeq.map(transform(_, emptyEnv)))
+      .withSorts(symbols.sorts.values.toSeq.map(transform(_, emptyEnv)))
+      .withClasses(symbols.classes.values.toSeq.map(transform(_, emptyEnv)))
+  }
+
+}
+
+class BigIntLoweringPhase(using override val context: inox.Context) extends LeonPipeline[tt.Symbols, tt.Symbols](context) {
+  val name = "BigInt Lowering"
+
+  given givenDebugSection: DebugSectionGenC.type = DebugSectionGenC
+
+  def run(syms: tt.Symbols): tt.Symbols = {
+    if (!bigIntToUInt32(context)) syms // when disabled, BigInt is rejected later by Scala2IRPhase
+    else {
+      class Impl(override val s: tt.type, override val t: tt.type)
+        extends BigIntLowering(s, t)(syms, context)
+      new Impl(tt, tt).transform(syms)
+    }
+  }
+}

--- a/core/src/main/scala/stainless/verification/AssertionInjector.scala
+++ b/core/src/main/scala/stainless/verification/AssertionInjector.scala
@@ -10,7 +10,8 @@ import smtlib.theories.FloatingPoint.FPLit
  * casts are legal, no division by zero occur and, when using the [[strictArithmetic]] mode,
  * that the program is exempt of integer overflow and unexpected behaviour.
  */
-class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees, val strictArithmetic: Boolean)
+class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees,
+                        val strictArithmetic: Boolean, val bigIntToUInt32: Boolean = false)
                        (using val symbols: s.Symbols)
   extends transformers.ConcreteTreeTransformer(s, t) {
 
@@ -24,6 +25,35 @@ class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees, va
     inWrappingMode = old
     res
   }
+
+  // BigInt bounds checks (--genc-bigint-as=uint32) do not apply inside specs and ghost code:
+  // GenC never compiles those, and proofs legitimately use unbounded arithmetic there.
+  // Unlike checkOverflow, wrapping mode does not disable these checks, as "wrapping BigInt"
+  // would silently change the mathematical semantics of the compiled program.
+  private var inSpecOrGhost: Boolean = false
+  private def bigIntCheck: Boolean = bigIntToUInt32 && !inSpecOrGhost
+
+  def specOrGhost[A](enabled: Boolean)(a: => A): A = {
+    val old = inSpecOrGhost
+    inSpecOrGhost = enabled
+    val res = a
+    inSpecOrGhost = old
+    res
+  }
+
+  private def inSpec[A](a: => A): A = specOrGhost(true)(a)
+
+  private val uint32Max = BigInt(2).pow(32) - 1
+
+  private def assertInUInt32Range(res: t.Expr, what: String, e: s.Expr): t.Expr =
+    t.Assert(
+      t.And(
+        t.LessEquals(t.IntegerLiteral(BigInt(0)).copiedFrom(e), res).copiedFrom(e),
+        t.LessEquals(res, t.IntegerLiteral(uint32Max).copiedFrom(e)).copiedFrom(e)
+      ).copiedFrom(e),
+      Some(what),
+      res
+    ).copiedFrom(e)
 
   private def indexUpTo(i: t.Expr, e: t.Expr) = t.And(
     t.GreaterEquals(i, t.Int32Literal(0).copiedFrom(i)).copiedFrom(i),
@@ -51,8 +81,13 @@ class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees, va
   }
 
   override def transform(e: s.Expr): t.Expr = e match {
-    case s.Annotated(body, flags) if flags contains s.Wrapping =>
-      t.Annotated(wrapping(true)(transform(body)), flags map transform).copiedFrom(e)
+    case s.Annotated(body, flags) if (flags contains s.Wrapping) || (flags contains s.Ghost) =>
+      val inner = wrapping(inWrappingMode || (flags contains s.Wrapping)) {
+        specOrGhost(inSpecOrGhost || (flags contains s.Ghost)) {
+          transform(body)
+        }
+      }
+      t.Annotated(inner, flags map transform).copiedFrom(e)
 
     case s.ArraySelect(a, i) =>
       bindIfCannotDuplicate(a, "a") { ax =>
@@ -191,6 +226,46 @@ class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees, va
         ).copiedFrom(e)
       }}
 
+    // BigInt arithmetic compiled to uint32_t (--genc-bigint-as=uint32): the operations are
+    // exact on BigInt, so a plain range check on the mathematical result is both necessary
+    // and sufficient for the compiled C operation to be exact. Division and remainder need
+    // no check: with both operands in [0, 2^32-1] (and the divisor nonzero, checked
+    // unconditionally below), their results are always in range.
+    case IntTyped(e0 @ s.Plus(lhs0, rhs0)) if bigIntCheck =>
+      bindIfCannotDuplicate(lhs0, "lhs") { lhsx =>
+      bindIfCannotDuplicate(rhs0, "rhs") { rhsx =>
+        assertInUInt32Range(t.Plus(lhsx, rhsx).copiedFrom(e), "Addition out of uint32 range", e)
+      }}
+
+    case IntTyped(e0 @ s.Minus(lhs0, rhs0)) if bigIntCheck =>
+      bindIfCannotDuplicate(lhs0, "lhs") { lhsx =>
+      bindIfCannotDuplicate(rhs0, "rhs") { rhsx =>
+        assertInUInt32Range(t.Minus(lhsx, rhsx).copiedFrom(e), "Subtraction out of uint32 range", e)
+      }}
+
+    case IntTyped(e0 @ s.Times(lhs0, rhs0)) if bigIntCheck =>
+      bindIfCannotDuplicate(lhs0, "lhs") { lhsx =>
+      bindIfCannotDuplicate(rhs0, "rhs") { rhsx =>
+        assertInUInt32Range(t.Times(lhsx, rhsx).copiedFrom(e), "Multiplication out of uint32 range", e)
+      }}
+
+    case IntTyped(e0 @ s.UMinus(n0)) if bigIntCheck =>
+      bindIfCannotDuplicate(n0, "inner") { innerx =>
+        assertInUInt32Range(t.UMinus(innerx).copiedFrom(e), "Negation out of uint32 range", e)
+      }
+
+    // Bitvector to BigInt conversions must produce a value in [0, 2^32-1]; this holds by
+    // construction for unsigned sources up to 32 bits, and needs a VC otherwise (signed
+    // sources can be negative, 64-bit sources can exceed the range).
+    case s.BVToInt(bv0) if bigIntCheck =>
+      bv0.getType match {
+        case s.BVType(false, size) if size <= 32 => super.transform(e)
+        case _ =>
+          bindIfCannotDuplicate(bv0, "bv") { x =>
+            assertInUInt32Range(t.BVToInt(x).copiedFrom(e), "Bitvector to BigInt conversion out of uint32 range", e)
+          }
+      }
+
     case s.Division(n, d) =>
       // Check division by zero, and if requested/meaningful, check for overflow
       bindIfCannotDuplicate(n, "n") { nx =>
@@ -300,7 +375,9 @@ class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees, va
         }
       }
 
-    case s.IntToBV(size, signed, value) if checkOverflow =>
+    // Also injected in bigIntCheck mode: when BigInt is compiled to uint32_t, these bounds
+    // are what makes the lowered narrowing cast exact, even with --strict-arithmetic=false.
+    case s.IntToBV(size, signed, value) if checkOverflow || bigIntCheck =>
       bindIfCannotDuplicate(value, "i") { x =>      // x : IntegerType
         val (lo, hi) =
           if (signed) (-BigInt(2).pow(size - 1), BigInt(2).pow(size - 1) - 1)
@@ -354,12 +431,41 @@ class AssertionInjector(override val s: ast.Trees, override val t: ast.Trees, va
     case s.FPLessThan(e1, e2) if checkOverflow => checkNaNBinop(e)(t.FPLessThan.apply, e1, e2)
     case s.FPEquals(e1, e2) if checkOverflow => checkNaNBinop(e)(t.FPEquals.apply, e1, e2)
 
+    // In bigIntCheck mode, spec conditions and ghost bindings are transformed with BigInt
+    // bounds checks disabled: GenC never compiles them (all Assert/Assume/spec conditions
+    // are discarded except exported preconditions, which the GenC lowering restricts to
+    // arithmetic-free conditions). Other injected checks still apply within them.
+    case s.Require(pre, body) if bigIntToUInt32 =>
+      t.Require(inSpec(transform(pre)), transform(body)).copiedFrom(e)
+
+    case s.Ensuring(body, pred) if bigIntToUInt32 =>
+      t.Ensuring(transform(body), inSpec(transform(pred).asInstanceOf[t.Lambda])).copiedFrom(e)
+
+    case s.Decreases(measure, body) if bigIntToUInt32 =>
+      t.Decreases(inSpec(transform(measure)), transform(body)).copiedFrom(e)
+
+    case s.Assert(cond, err, body) if bigIntToUInt32 =>
+      t.Assert(inSpec(transform(cond)), err, transform(body)).copiedFrom(e)
+
+    case s.Assume(cond, body) if bigIntToUInt32 =>
+      t.Assume(inSpec(transform(cond)), transform(body)).copiedFrom(e)
+
+    case s.Let(vd, value, body) if bigIntToUInt32 && (vd.flags contains s.Ghost) =>
+      t.Let(transform(vd), inSpec(transform(value)), transform(body)).copiedFrom(e)
+
     case _ => super.transform(e)
   }
 
   private object BVTyped {
     def unapply(e: s.Expr): Option[(Boolean, Int, s.Expr)] = e.getType match {
       case s.BVType(signed, size) => Some((signed, size, e))
+      case _ => None
+    }
+  }
+
+  private object IntTyped {
+    def unapply(e: s.Expr): Option[s.Expr] = e.getType match {
+      case s.IntegerType() => Some(e)
       case _ => None
     }
   }
@@ -410,7 +516,9 @@ object AssertionInjector {
     class InjectorImpl(override val s: p.trees.type,
                        override val t: p.trees.type)
                       (using override val symbols: p.symbols.type)
-      extends AssertionInjector(s, t, ctx.options.findOptionOrDefault(optStrictArithmetic))
+      extends AssertionInjector(s, t,
+        ctx.options.findOptionOrDefault(optStrictArithmetic),
+        genc.bigIntToUInt32(ctx))
     val injector = new InjectorImpl(p.trees, p.trees)(using p.symbols)
 
     class TransformerImpl(override val s: p.trees.type, override val t: p.trees.type)
@@ -421,6 +529,7 @@ object AssertionInjector {
         NoSymbols
           .withFunctions(syms.functions.values.toSeq.map { fd =>
             injector.wrapping(fd.flags.contains(s.Wrapping)) {
+            injector.specOrGhost(fd.flags.contains(s.Ghost)) {
               new FunDef(
                 fd.id,
                 fd.tparams map injector.transform,
@@ -429,7 +538,7 @@ object AssertionInjector {
                 injector.transform(fd.fullBody),
                 fd.flags map injector.transform
               ).copiedFrom(fd)
-            }
+            }}
           })
           .withSorts(syms.sorts.values.toSeq.map(injector.transform))
       }

--- a/core/src/sphinx/genc.rst
+++ b/core/src/sphinx/genc.rst
@@ -99,6 +99,33 @@ Additionally, GenC has partial support for character and string literals made
 of ASCII characters only but it has no API to manipulate strings at the moment:
 ``Char`` is mapped to ``char`` and ``String`` is mapped to ``char*``.
 
+BigInt
+^^^^^^
+
+By default, ``BigInt`` is rejected: it is unbounded and has no C counterpart.
+With the ``--genc-bigint-as=uint32`` option, GenC compiles ``BigInt`` to
+``uint32_t``. This mapping is only sound for verified programs: the *same*
+option must also be passed to verification, where it generates verification
+conditions checking that every ``BigInt`` value stays within
+``[0, 2^32 - 1]`` (one VC per addition, subtraction, multiplication and
+negation — division and remainder are always in range on non-negative
+operands — plus one per conversion from a signed or 64-bit integer type).
+Once these VCs are proven, every runtime ``uint32_t`` value equals the
+corresponding mathematical ``BigInt`` value. On non-negative operands, C's
+``/`` and ``%`` coincide with the ``BigInt`` semantics, and ``mod`` coincides
+with ``%``, so all three are supported. Ghost code and specifications are
+exempt from these VCs, so proofs can still use unbounded (and negative)
+arithmetic.
+
+Restrictions under ``--genc-bigint-as=uint32``:
+
+ - Every compiled ``BigInt`` value must provably stay within
+   ``[0, 2^32 - 1]``; in particular ``a - b`` requires ``b <= a``.
+ - Preconditions of exported functions may only use *comparisons* on
+   ``BigInt``, not arithmetic: they are compiled to runtime checks on
+   unverified C inputs, where the arithmetic itself could overflow.
+ - ``BigInt`` literals must fit in ``uint32_t``.
+
 Tuples
 ^^^^^^
 

--- a/frontends/benchmarks/genc/invalid/BigIntNegativeLiteral.flags
+++ b/frontends/benchmarks/genc/invalid/BigIntNegativeLiteral.flags
@@ -1,0 +1,1 @@
+--genc-bigint-as=uint32

--- a/frontends/benchmarks/genc/invalid/BigIntNegativeLiteral.scala
+++ b/frontends/benchmarks/genc/invalid/BigIntNegativeLiteral.scala
@@ -1,0 +1,11 @@
+import stainless._
+import stainless.annotation._
+
+object BigIntNegativeLiteral {
+  // uint32_t cannot represent negative values, so with --genc-bigint-as=uint32
+  // GenC rejects BigInt literals outside [0, 2^32-1] at compile time.
+  @cCode.`export`
+  def test(): BigInt = {
+    BigInt(-5)
+  }
+}

--- a/frontends/benchmarks/genc/invalid/BigIntPreconditionArith.flags
+++ b/frontends/benchmarks/genc/invalid/BigIntPreconditionArith.flags
@@ -1,0 +1,1 @@
+--genc-bigint-as=uint32

--- a/frontends/benchmarks/genc/invalid/BigIntPreconditionArith.scala
+++ b/frontends/benchmarks/genc/invalid/BigIntPreconditionArith.scala
@@ -1,0 +1,14 @@
+import stainless._
+import stainless.annotation._
+
+object BigIntPreconditionArith {
+  // Preconditions of exported functions are compiled to runtime checks against
+  // unverified C callers, so with --genc-bigint-as=uint32 no VC can bound their
+  // arithmetic: `x * x` itself could overflow inside the check. GenC rejects this;
+  // only comparisons on BigInt are allowed in exported preconditions.
+  @cCode.`export`
+  def test(x: BigInt): BigInt = {
+    require(x * x <= 100)
+    x + 1
+  }
+}

--- a/frontends/benchmarks/genc/invalid/BigIntUnsupported.scala
+++ b/frontends/benchmarks/genc/invalid/BigIntUnsupported.scala
@@ -1,0 +1,11 @@
+import stainless._
+import stainless.annotation._
+
+object BigIntUnsupported {
+  // BigInt is unbounded and has no C counterpart, so GenC must reject it.
+  @cCode.`export`
+  def test(x: Int): Int = {
+    val big: BigInt = BigInt(x) + BigInt(1)
+    if (big > BigInt(0)) x else -x
+  }
+}

--- a/frontends/benchmarks/genc/unverified/BigIntOverflow.flags
+++ b/frontends/benchmarks/genc/unverified/BigIntOverflow.flags
@@ -1,0 +1,1 @@
+--genc-bigint-as=uint32

--- a/frontends/benchmarks/genc/unverified/BigIntOverflow.scala
+++ b/frontends/benchmarks/genc/unverified/BigIntOverflow.scala
@@ -1,0 +1,13 @@
+import stainless._
+import stainless.annotation._
+
+object BigIntOverflow {
+  // With --genc-bigint-as=uint32, verification injects a VC that x + x stays within
+  // [0, 2^32-1]. With no upper bound on x, that VC is invalid
+  // ("Addition out of uint32 range").
+  @cCode.`export`
+  def double(x: BigInt): BigInt = {
+    require(0 <= x)
+    x + x
+  }
+}

--- a/frontends/benchmarks/genc/valid/BigIntArith.expected.c
+++ b/frontends/benchmarks/genc/valid/BigIntArith.expected.c
@@ -1,0 +1,88 @@
+/* --------------------------- GenC requirements ----- */
+
+#include <limits.h>
+#if (__STDC_VERSION__ < 199901L) || (CHAR_BIT != 8)
+#error "Your compiler does not meet the minimum requirements of GenC. Please see"
+#error "https://epfl-lara.github.io/stainless/genc.html#requirements for more details."
+#endif
+
+/* ---------------------------- include header ------- */
+
+#include "BigIntArith.h"
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <string.h>
+
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+static STAINLESS_FUNC_PURE uint32_t compute(uint32_t a, uint32_t b);
+static STAINLESS_FUNC_PURE uint32_t diff(uint32_t a, uint32_t b);
+static 
+void print(int32_t x);
+static 
+void print_1(char c);
+static void println(int32_t x);
+static void println_1(void);
+static STAINLESS_FUNC_PURE uint32_t sumTo(uint32_t n);
+
+
+/* ----------------------- function definitions ----- */
+
+static STAINLESS_FUNC_PURE uint32_t compute(uint32_t a, uint32_t b) {
+    return (((a + b) * 3 + a / 2) + b % 1000) + b % 7;
+}
+
+static STAINLESS_FUNC_PURE uint32_t diff(uint32_t a, uint32_t b) {
+    return a - b;
+}
+
+void main(void) {
+    print((int32_t)compute(1000, 500));
+    print((int32_t)diff(1000, 400));
+    println((int32_t)sumTo(100));
+}
+
+
+void print(int32_t x) {
+  printf("%"PRIi32, x);
+}
+     
+
+
+void print_1(char c) {
+  printf("%c", c);
+}
+      
+
+static void println(int32_t x) {
+    print(x);
+    println_1();
+}
+
+static void println_1(void) {
+    print_1('\n');
+}
+
+STAINLESS_FUNC_PURE uint32_t scaleClamped(uint32_t x) {
+    assert((0 <= x && x <= 1000000));
+    return x * 3;
+}
+
+static STAINLESS_FUNC_PURE uint32_t sumTo(uint32_t n) {
+    if (n <= 0) {
+        return 0;
+    } else {
+        return n + sumTo(n - 1);
+    }
+}

--- a/frontends/benchmarks/genc/valid/BigIntArith.expected.h
+++ b/frontends/benchmarks/genc/valid/BigIntArith.expected.h
@@ -1,0 +1,41 @@
+#ifndef __BIGINTARITH_H__
+#define __BIGINTARITH_H__
+
+/* --------------------------- preprocessor macros ----- */
+
+#define STAINLESS_FUNC_PURE
+#if defined(__cplusplus)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE _Pragma("FUNC_IS_PURE;")
+#elif __GNUC__>=3
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#elif defined(__has_attribute)
+#if __has_attribute(pure)
+#undef STAINLESS_FUNC_PURE
+#define STAINLESS_FUNC_PURE __attribute__((__pure__))
+#endif
+#endif
+
+
+/* ----------------------------------- includes ----- */
+
+#include <assert.h>
+#include <inttypes.h>
+#include <stdbool.h>
+#include <stddef.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+
+
+
+
+
+/* ---------------------- function declarations ----- */
+
+void main(void);
+STAINLESS_FUNC_PURE uint32_t scaleClamped(uint32_t x);
+
+#endif

--- a/frontends/benchmarks/genc/valid/BigIntArith.flags
+++ b/frontends/benchmarks/genc/valid/BigIntArith.flags
@@ -1,0 +1,1 @@
+--genc-bigint-as=uint32

--- a/frontends/benchmarks/genc/valid/BigIntArith.scala
+++ b/frontends/benchmarks/genc/valid/BigIntArith.scala
@@ -1,0 +1,43 @@
+import stainless._
+import stainless.lang._
+import stainless.annotation._
+import stainless.io._
+
+object BigIntArith {
+
+  def compute(a: BigInt, b: BigInt): BigInt = {
+    require(0 <= a && a <= 1000000 && 0 <= b && b <= 1000000)
+    // On non-negative values, mod coincides with % and both are supported.
+    (a + b) * 3 + a / 2 + b % 1000 + (b mod 7)
+  }.ensuring(res => 0 <= res && res <= 7000000)
+
+  def diff(a: BigInt, b: BigInt): BigInt = {
+    require(0 <= b && b <= a && a <= 1000000)
+    a - b // needs b <= a: uint32 subtraction must not go below zero
+  }.ensuring(res => 0 <= res && res <= 1000000)
+
+  def sumTo(n: BigInt): BigInt = {
+    require(0 <= n && n <= 1000)
+    decreases(n)
+    if (n <= 0) BigInt(0)
+    else n + sumTo(n - 1)
+  }.ensuring(res => 0 <= res && res <= 1000 * n)
+
+  // BigInt parameters and results of exported functions become uint32_t in C.
+  // Note that preconditions of exported functions may only use comparisons on BigInt
+  // (no arithmetic), as they are compiled to runtime checks on unverified C inputs.
+  @cCode.`export`
+  def scaleClamped(x: BigInt): BigInt = {
+    require(0 <= x && x <= 1000000)
+    x * 3
+  }
+
+  @cCode.`export`
+  def main(): Unit = {
+    @ghost implicit val state: State = newState
+    StdOut.print(compute(BigInt(1000), BigInt(500)).toInt)
+    StdOut.print(diff(BigInt(1000), BigInt(400)).toInt)
+    StdOut.println(sumTo(BigInt(100)).toInt)
+  }
+
+}

--- a/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
+++ b/frontends/dotty/src/it/scala/stainless/GenCSuite.scala
@@ -23,6 +23,10 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
 
   val validFiles = resourceFiles("genc/valid", _.endsWith(".scala"), false).map(_.getPath)
   val invalidFiles = resourceFiles("genc/invalid", _.endsWith(".scala"), false).map(_.getPath)
+  // Benchmarks whose *verification* must report invalid VCs (with the benchmark's flags),
+  // e.g. missing BigInt bounds under --genc-bigint-as=int64. Distinct from `invalid`, whose
+  // files must make the genc run itself fail with a fatal error.
+  val unverifiedFiles = resourceFiles("genc/unverified", _.endsWith(".scala"), false).map(_.getPath)
   val tailrecFiles = validFiles.filter(_.toLowerCase.contains("tailrec".toLowerCase)).map { path =>
     val checkFile = path.replace(".scala", ".check")
     path -> checkFile
@@ -34,12 +38,12 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
     val cFile = file.replace(".scala", ".c")
     val outFile = file.replace(".scala", ".out")
     test(s"stainless --genc --genc-output=$cFile $file should fail") {
-      an [inox.FatalError] should be thrownBy runMainWithArgs(Array(file) :+ "--genc" :+ s"--genc-output=$cFile")
+      an [inox.FatalError] should be thrownBy runMainWithArgs(Array(file) ++ benchmarkFlags(file) :+ "--genc" :+ s"--genc-output=$cFile")
     }
   }
 
   for (file <- validFiles) {
-    val extraOpts = Seq("--batched", "--solvers=smt-z3", "--strict-arithmetic=false", "--timeout=10")
+    val extraOpts = Seq("--batched", "--solvers=smt-z3", "--strict-arithmetic=false", "--timeout=10") ++ benchmarkFlags(file)
     test(s"stainless ${extraOpts.mkString(" ")} $file") {
       val (localCtx, optReport) = runMainWithArgs(Array(file) ++ extraOpts)
       assert(localCtx.reporter.errorCount == 0, "No errors")
@@ -48,12 +52,21 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
     }
   }
 
+  for (file <- unverifiedFiles) {
+    val extraOpts = Seq("--batched", "--solvers=smt-z3", "--strict-arithmetic=false", "--timeout=10") ++ benchmarkFlags(file)
+    test(s"stainless ${extraOpts.mkString(" ")} $file should have invalid VCs") {
+      val (_, optReport) = runMainWithArgs(Array(file) ++ extraOpts)
+      assert(optReport.nonEmpty, "Report returned by Stainless")
+      assert(!optReport.get.isSuccess, "Some VCs should be invalid")
+    }
+  }
+
   for (file <- validFiles) {
     val cFile = file.replace(".scala", ".c")
     val hFile = file.replace(".scala", ".h")
     val outFile = file.replace(".scala", ".out")
     test(s"stainless --genc --genc-output=$cFile $file") {
-      runMainWithArgs(Array(file) :+ "--genc" :+ s"--genc-output=$cFile")
+      runMainWithArgs(Array(file) ++ benchmarkFlags(file) :+ "--genc" :+ s"--genc-output=$cFile")
       assert(Files.exists(Paths.get(cFile)))
       assert(Files.exists(Paths.get(hFile)))
       // Snapshot the generated C and header against golden files so that unintended
@@ -84,6 +97,11 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
     assert(output == "8410120", s"Output '$output' should be '8410120'")
   }
 
+  test("Checking that BigIntArith outputs 55036005050") {
+    val output = runCHelper("BigIntArith.scala")
+    assert(output == "55036005050", s"Output '$output' should be '55036005050'")
+  }
+
   test("Checking that Pointer2 outputs 124443") {
     val output = runCHelper("Pointer2.scala")
     assert(output == "124443", s"Output '$output' should be '124443'")
@@ -104,6 +122,17 @@ class GenCSuite extends AnyFunSuite with inox.ResourceUtils with InputUtils with
       val output = runCHelper(file)
       assert(output == checkValue, s"Output '$output' should be $checkValue")
     }
+  }
+
+  /** Extra Stainless options for a benchmark, from an optional `<Name>.flags` sidecar file
+    * next to the `.scala` file (whitespace-separated). Used e.g. to pass
+    * `--genc-bigint-as=uint32` to both the verification and the genc runs of a benchmark.
+    */
+  def benchmarkFlags(scalaFile: String): Seq[String] = {
+    val flagsFile = Paths.get(scalaFile.replace(".scala", ".flags"))
+    if (Files.exists(flagsFile))
+      new String(Files.readAllBytes(flagsFile), StandardCharsets.UTF_8).split("\\s+").filter(_.nonEmpty).toSeq
+    else Seq()
   }
 
   /** Map a benchmark resource path to the corresponding golden file in the source tree.


### PR DESCRIPTION
Implements #1773.