### PR TITLE
Substitute the inliner's opaque proxies in inlined code

### DIFF
--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline1.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline1.scala
@@ -1,0 +1,33 @@
+import stainless.lang._
+
+// When the enclosing object of an inlined method declares an opaque type alias,
+// Dotty's inliner materializes that object as local proxies in the inlined code
+// (`val $proxy1: Lib.type{type Positive = BigInt} = Lib.$asInstanceOf[...]`,
+// `val Lib$_this = $proxy1`) and casts value arguments to `A & A[Lib := $proxy1]`.
+// This is the shape of `Try.flatMap` in the Stainless library, in a user object.
+object OpaqueTypesInline1 {
+  object Lib {
+    opaque type Positive = BigInt
+
+    sealed abstract class Try[T] {
+      inline def flatMap[U](f: T => Try[U]): Try[U] = this match {
+        case Success(t) => f(t)
+        case Failure(exc) => Failure(exc)
+      }
+    }
+    case class Success[T](t: T) extends Try[T]
+    case class Failure[T](exc: BigInt) extends Try[T]
+  }
+
+  import Lib._
+
+  def g(x: Try[BigInt]): Try[BigInt] = {
+    x.flatMap(y => Success(y + 1))
+  }.ensuring(res => res match {
+    case Success(r) => x match {
+      case Success(y) => r == y + 1
+      case _ => false
+    }
+    case Failure(_) => x.isInstanceOf[Failure[BigInt]]
+  })
+}

--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline2.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline2.scala
@@ -1,0 +1,28 @@
+import stainless.lang._
+
+// Inline methods defined directly in an object with an opaque type alias: the
+// inlined bodies call sibling members through the this-proxy (`Refined$_this.f(x)`),
+// and an argument of the opaque type gets the proxied intersection type
+// `(p : Refined.Positive) & $proxy.Positive`.
+object OpaqueTypesInline2 {
+  object Refined {
+    opaque type Positive = BigInt
+
+    def f(x: Positive): Positive = x
+    def h(x: BigInt): BigInt = x
+
+    inline def Positive(value: BigInt): Positive = f(value)
+    inline def viaThis(value: BigInt): BigInt = this.h(value)
+    inline def mk(value: BigInt): Positive = value
+    inline def unmk(p: Positive): BigInt = p
+  }
+
+  def run(x: BigInt): Unit = {
+    val nine = Refined.Positive(x)
+    val ten = Refined.viaThis(x)
+    assert(ten == x)
+    val p = Refined.mk(x)
+    val q = Refined.unmk(p)
+    assert(q == x)
+  }
+}

--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline3.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline3.scala
@@ -1,0 +1,20 @@
+import stainless.lang._
+
+// An opaque type constructor (its alias is a type lambda), and an inline method
+// taking a lambda whose type mentions a class of the object, plus a by-name argument.
+object OpaqueTypesInline3 {
+  object Lib {
+    opaque type Id[A] = A
+
+    case class Box[A](a: A)
+
+    def helper(b: BigInt): BigInt = b
+
+    inline def apply[A](b: Box[A])(f: Box[A] => BigInt)(inline g: => BigInt): BigInt =
+      f(b) + g + helper(1)
+  }
+
+  def run(b: Lib.Box[BigInt]): BigInt = {
+    Lib(b)(bb => bb.a)(2)
+  }.ensuring(_ == b.a + 3)
+}

--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline4.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline4.scala
@@ -1,0 +1,18 @@
+import stainless.lang._
+
+// A package object with an opaque type alias: members called through an explicit
+// `this` are inlined as `package$_this.helper(x)`.
+package object opaqueTypesInline4 {
+  opaque type Id[A] = A
+
+  def helper(b: BigInt): BigInt = b
+
+  inline def viaThis(value: BigInt): BigInt = this.helper(value)
+  inline def plain(value: BigInt): BigInt = helper(value)
+}
+
+object OpaqueTypesInline4 {
+  def run(x: BigInt): BigInt = {
+    opaqueTypesInline4.viaThis(x) + opaqueTypesInline4.plain(x)
+  }.ensuring(_ == x + x)
+}

--- a/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline5.scala
+++ b/frontends/benchmarks/dotty-specific/valid/OpaqueTypesInline5.scala
@@ -1,0 +1,21 @@
+import stainless.lang._
+
+// Nested inline calls across two objects with opaque type aliases: the proxies of
+// the outer inlining are referenced from inside the inner `Inlined` node.
+object OpaqueTypesInline5 {
+  object A {
+    opaque type TA = BigInt
+    def fa(x: BigInt): BigInt = x
+    inline def ia(x: BigInt): BigInt = this.fa(x) + B.ib(x)
+  }
+
+  object B {
+    opaque type TB = BigInt
+    def fb(x: BigInt): BigInt = x
+    inline def ib(x: BigInt): BigInt = this.fb(x)
+  }
+
+  def run(x: BigInt): BigInt = {
+    A.ia(x)
+  }.ensuring(_ == x + x)
+}

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/ASTExtractors.scala
@@ -651,6 +651,15 @@ trait ASTExtractors {
       }
     }
 
+    /** Strips the `Inlined(EmptyTree, Nil, _)` markers with which the inliner wraps the trees that come
+      * from the call site of an inlined method (arguments, references to `this`). Unlike
+      * `tpd.stripInlined`, this keeps inlined calls that carry bindings.
+      */
+    def stripInlineMarkers(tree: tpd.Tree): tpd.Tree = tree match {
+      case Inlined(_, Nil, expansion) => stripInlineMarkers(expansion)
+      case _ => tree
+    }
+
     object ExCall {
       def unapply(tree: tpd.Tree): Option[(Option[tpd.Tree], Symbol, Seq[tpd.Tree], Seq[tpd.Tree])] = {
         val optCall = tree match {
@@ -667,8 +676,10 @@ trait ASTExtractors {
         }
 
         optCall.map { case (rec, sym, tps, args) =>
+          // Receivers coming from the call site of an inlined method are wrapped in `Inlined` markers
           val newRec = rec.filterNot { r =>
-            (r.symbol `is` Module) && !(r.symbol `is` Case)
+            val recSym = stripInlineMarkers(r).symbol
+            (recSym `is` Module) && !(recSym `is` Case)
           }
           (newRec, sym, tps, args)
         }

--- a/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
+++ b/frontends/dotty/src/main/scala/stainless/frontends/dotc/CodeExtraction.scala
@@ -6,6 +6,8 @@ package frontends.dotc
 import dotty.tools.dotc.*
 import ast.tpd
 import ast.untpd
+import ast.TreeTypeMap
+import inlines.Inliner.OpaqueProxy
 import ast.Trees.*
 import core.Contexts
 import core.Contexts.Context as DottyContext
@@ -1164,6 +1166,58 @@ class CodeExtraction(inoxCtx: inox.Context,
       args.map(extractTree)
   }
 
+  /** Dotty's inliner keeps a reference to the enclosing object `O` of an inlined method when `O`
+   *  contains opaque type aliases (see `Inliner.canElideThis`), and exposes these aliases through
+   *  a refined "opaque proxy" (see `Inliner.addOpaqueProxies`):
+   *
+   *    val $proxy1: O.type{type T = R} = O.$asInstanceOf[O.type{type T = R}]
+   *    val O$_this: ($proxy1 : O.type{type T = R}) = $proxy1
+   *
+   *  In the inlined code, types are then expressed relative to these proxies (`O$_this.C[X]`),
+   *  members of `O` are selected on them (`O$_this.f(x)`) and value arguments whose type mentions
+   *  `O` are cast to the intersection `A & A[O := $proxy1]`.
+   *
+   *  Objects have no instances in Stainless (their members are extracted as top-level definitions),
+   *  so we substitute the proxies by `O` itself and drop their bindings, just like the inliner does
+   *  for the result type of the inlined call (see `Inliner.mapBackToOpaques`). The intersections
+   *  then become redundant and are simplified away.
+   */
+  private def substituteModuleProxies(bindings: List[tpd.Tree], expansion: tpd.Tree): (List[tpd.Tree], tpd.Tree) = {
+    // The reference `O` that an inliner proxy binding stands for, if it is one
+    def proxiedRef(vd: tpd.ValDef): Option[TermRef] = vd.symbol.termRef match {
+      // val $proxy1: O.type{type T = R} = O.$asInstanceOf[O.type{type T = R}]
+      case OpaqueProxy(ref) => Some(ref)
+      // val O$_this: ($proxy1 : O.type{type T = R}) = $proxy1
+      case _ if vd.symbol.is(InlineProxy) => vd.symbol.info match {
+        case OpaqueProxy(ref) => Some(ref)
+        case _ => None
+      }
+      case _ => None
+    }
+    val proxies: Map[Symbol, TermRef] = bindings.collect {
+      case vd: tpd.ValDef => proxiedRef(vd).map(vd.symbol -> _)
+    }.flatten.toMap
+
+    if (proxies.isEmpty) (bindings, expansion)
+    else {
+      val typeMap = new TypeMap {
+        // Also map the prefixes of static types such as `$proxy1.C`
+        override def stopAt = StopAt.Package
+        def apply(tp: Type): Type = tp match {
+          case tr: TermRef if proxies.contains(tr.symbol) => proxies(tr.symbol)
+          case _ => mapOver(tp)
+        }
+        // `A & A[O := $proxy1]` becomes `A & A`: simplify it to `A`
+        override protected def derivedAndType(tp: AndType, tp1: Type, tp2: Type): Type = tp1 & tp2
+      }
+      // Mapping a block also gives the remaining local bindings symbols with mapped types, and
+      // `TreeTypeMap` re-creates the references whose type changed (`Ident($proxy1)` becomes `O`)
+      val block = tpd.Block(bindings.filterNot(b => proxies.contains(b.symbol)), expansion)
+      val Block(bindings1, expansion1) = new TreeTypeMap(typeMap = typeMap).transform(block): @unchecked
+      (bindings1, expansion1)
+    }
+  }
+
   private def extractBlock(es: List[tpd.Tree])(using dctx: DefContext): xt.Expr = {
     val fctx = es.collect {
       case ExFunctionDef(sym, tparams, vparams, tpt, rhs) => (sym, tparams, vparams)
@@ -1715,7 +1769,8 @@ class CodeExtraction(inoxCtx: inox.Context,
         case _ => expr
       }
 
-      rec(extractBlock(members :+ body))
+      val (bindings, expansion) = substituteModuleProxies(members, body)
+      rec(extractBlock(bindings :+ expansion))
 
     case ExChooseExpression(tpt, pred) =>
       reporter.warning(tr.sourcePos, "`choose` expressions may be unsafe due to difficulty in checking their realizability automatically")
@@ -2789,7 +2844,7 @@ class CodeExtraction(inoxCtx: inox.Context,
         (extractType(p), idx) match {
           case (xt.MapType(from, ct @ xt.ClassType(id, Seq(to))), 1) =>
             xt.MapType(from, xt.ClassType(id, Seq(extractType(tpe))).copiedFrom(ct))
-          case (xt.NAryType(tps, recons), _) =>
+          case (xt.NAryType(tps, recons), _) if idx >= 0 =>
             recons(tps.updated(idx, extractType(tpe)))
           case (_, _) => throw MatchError(s"Cannot extract refined type $name in $p", pos)
         }


### PR DESCRIPTION
Another attempt at fixing the bug #1782 tries to fix.

It's not exactly simpler than #1782, but I think it's closer to being the right thing. It substitute proxies generated by Dotty in inlined code back to their definitions.


| Case | Shape | main | #1782 | this PR |
|---|---|---|---|---|
| `MonadicTry2` | library `Try.flatMap`, `opaque type` in `package object lang` | n/a (no opaque in library) | 48/48 valid | 48/48 valid |
| `V1` | same as the library, in `object Lib` | crash `IndexOutOfBoundsException: -1` | crash `IndexOutOfBoundsException: -1` | 17/17 valid |
| `V2` | `inline def`s directly in `object Refined`, `this.h(x)`, opaque param/result | crash `IndexOutOfBoundsException: -1` | crash `IndexOutOfBoundsException: -1` | 2/2 valid |
| `V3` | `opaque type Id[A] = A`, `inline def` with a lambda and a by-name argument | `Stainless does not support type [A] =>> A` | `missing dependencies: Method Lib3, Class Lib3` | 1/1 valid |
| `V4` | `package object` with `opaque type`, `inline def viaThis(v) = this.helper(v)` | `Stainless does not support type [A] =>> A` | `missing dependencies: Method package$_this` | 1/1 valid |
| `V5` | nested inline calls across two objects with opaque types | crash `IndexOutOfBoundsException: -1` | crash `IndexOutOfBoundsException: -1` | 1/1 valid |


## Detailed description

When the enclosing object `O` of an inlined method declares an opaque type alias, Dotty's inliner does not elide `O.this` (`Inliner.canElideThis`) and instead binds the object to a proxy exposing the aliases (`Inliner.addOpaqueProxies`):

    val $proxy1: O.type{type T = R} = O.$asInstanceOf[O.type{type T = R}]
    val O$_this: ($proxy1 : O.type{type T = R}) = $proxy1

Types in the inlined code are then expressed relative to these proxies, members of `O` are selected on them, and value arguments whose type mentions `O` are cast to `A & A[O := $proxy1]`. None of this can be extracted as is: the proxy bindings have refined object types, and the intersections are unsupported. This affects any object mixing `opaque type` and `inline def`, and crashed extraction with an `IndexOutOfBoundsException` in the `RefinedType` case.

Objects have no instances in Stainless, so at each `Inlined` node the proxies (recognised with `Inliner.OpaqueProxy`) are substituted by `O` itself with a `TreeTypeMap`, their bindings are dropped and the redundant intersections are simplified with `glb`, mirroring what the inliner does for the result type (`Inliner.mapBackToOpaques`).

`ExCall` now looks through the binding-less `Inlined` markers that wrap references coming from the call site when testing whether a receiver is a module, and the `RefinedType` case reports an error instead of crashing when the refined member is not a type parameter of the parent.